### PR TITLE
feat: 商品種別を5種類に限定（マグカップ削除）

### DIFF
--- a/.claude/specs/FEAT-0002.yaml
+++ b/.claude/specs/FEAT-0002.yaml
@@ -1,0 +1,50 @@
+id: FEAT-0002
+title: 商品種別を5種類に限定（マグカップ削除）
+created_at: 2026-02-23
+status: confirmed
+
+summary: |
+  システムで扱う商品種別を5種類（キーホルダー・ステッカー・トートバッグ・Tシャツ・スタンド）に限定し、
+  マグカップ（MUG）を完全に削除する。
+
+scope:
+  include:
+    - ProductType Enum から MUG を削除（Python）
+    - ProductType 型から "mug" を削除（TypeScript）
+    - フロントエンドの商品種別ラベルマッピングから「マグカップ」を削除（3箇所）
+    - Zodバリデーションスキーマから "mug" を削除
+  exclude:
+    - DBマイグレーション（データなし、VARCHAR型のため不要）
+    - 既存データの移行処理
+
+acceptance_criteria:
+  - given: 商品登録フォームを開いたとき
+    when: 商品種別のセレクトボックスを確認する
+    then: 5種類（キーホルダー・ステッカー・トートバッグ・Tシャツ・スタンド）のみ表示される
+
+  - given: APIに商品を登録するとき
+    when: product_type に "mug" を指定する
+    then: バリデーションエラーが返される
+
+  - given: 商品種別の型定義を確認するとき
+    when: ProductType の値を列挙する
+    then: 5種類のみ定義されている
+
+affected_files:
+  - path: api/app/models/product.py
+    change: MUG = "mug" を削除
+  - path: web/src/types/api/index.ts
+    change: '"mug" を削除'
+  - path: web/src/features/products/components/product-form.tsx
+    change: ラベルマッピング・Zodスキーマから削除
+  - path: web/src/features/products/components/product-list.tsx
+    change: ラベルマッピングから削除
+  - path: web/src/app/(dashboard)/products/[id]/page.tsx
+    change: ラベルマッピングから削除
+
+assumptions:
+  - マグカップの商品データは未登録のため、データ移行は不要
+  - DBスキーマはVARCHAR型のため、マイグレーション不要
+
+constraints:
+  - 許可された5種類以外の商品種別はAPI・フロントエンド両方で拒否する

--- a/api/app/models/product.py
+++ b/api/app/models/product.py
@@ -15,7 +15,6 @@ class ProductType(str, Enum):
     ACRYLIC_STAND = "acrylic_stand"  # アクリルスタンド
     STICKER = "sticker"  # ステッカー
     TOTE_BAG = "tote_bag"  # トートバッグ
-    MUG = "mug"  # マグカップ
     TSHIRT = "tshirt"  # Tシャツ
 
 

--- a/web/src/app/(dashboard)/products/[id]/page.tsx
+++ b/web/src/app/(dashboard)/products/[id]/page.tsx
@@ -15,7 +15,6 @@ const productTypeLabels: Record<ProductType, string> = {
   acrylic_stand: "アクリルスタンド",
   sticker: "ステッカー",
   tote_bag: "トートバッグ",
-  mug: "マグカップ",
   tshirt: "Tシャツ",
 };
 

--- a/web/src/features/products/components/product-form.tsx
+++ b/web/src/features/products/components/product-form.tsx
@@ -33,7 +33,6 @@ const productTypes: { value: ProductType; label: string }[] = [
   { value: "acrylic_stand", label: "アクリルスタンド" },
   { value: "sticker", label: "ステッカー" },
   { value: "tote_bag", label: "トートバッグ" },
-  { value: "mug", label: "マグカップ" },
   { value: "tshirt", label: "Tシャツ" },
 ];
 
@@ -43,7 +42,6 @@ const productSchema = z.object({
     "acrylic_stand",
     "sticker",
     "tote_bag",
-    "mug",
     "tshirt",
   ]),
   size: z.string().optional(),

--- a/web/src/features/products/components/product-list.tsx
+++ b/web/src/features/products/components/product-list.tsx
@@ -21,7 +21,6 @@ const productTypeLabels: Record<ProductType, string> = {
   acrylic_stand: "アクリルスタンド",
   sticker: "ステッカー",
   tote_bag: "トートバッグ",
-  mug: "マグカップ",
   tshirt: "Tシャツ",
 };
 

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -190,7 +190,6 @@ export type ProductType =
   | "acrylic_stand"
   | "sticker"
   | "tote_bag"
-  | "mug"
   | "tshirt";
 
 export interface Product {

--- a/web/tests/unit/product-form.test.tsx
+++ b/web/tests/unit/product-form.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * ProductForm のテスト
+ *
+ * FEAT-0002: 商品種別を5種類に限定（マグカップ削除）
+ *
+ * このテストは、商品フォームに許可された5種類のみが表示され、
+ * マグカップが削除されていることを検証します。
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { ProductForm } from '@/features/products/components/product-form'
+
+// SWR をモック
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({
+    data: { items: [] },
+    error: null,
+    isLoading: false,
+  })),
+}))
+
+// API クライアントをモック
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(() => Promise.resolve({})),
+}))
+
+describe('ProductForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('商品種別オプションの検証', () => {
+    it('商品種別セレクトボックスに5種類のみ表示される', () => {
+      render(<ProductForm />)
+
+      // Radix UIのSelect は hidden の native select を持つ
+      // その中のオプションを取得して検証
+      const hiddenSelects = document.querySelectorAll('select[aria-hidden="true"]')
+      // 最初の hidden select が商品種別
+      const productTypeSelect = hiddenSelects[0]
+
+      expect(productTypeSelect).toBeDefined()
+
+      const options = productTypeSelect.querySelectorAll('option')
+      const optionTexts = Array.from(options).map((opt) => opt.textContent)
+
+      // 許可された5種類が表示されることを確認
+      expect(optionTexts).toContain('アクリルキーホルダー')
+      expect(optionTexts).toContain('アクリルスタンド')
+      expect(optionTexts).toContain('ステッカー')
+      expect(optionTexts).toContain('トートバッグ')
+      expect(optionTexts).toContain('Tシャツ')
+    })
+
+    it('商品種別セレクトボックスにマグカップが表示されない', () => {
+      render(<ProductForm />)
+
+      // Radix UIのSelect は hidden の native select を持つ
+      const hiddenSelects = document.querySelectorAll('select[aria-hidden="true"]')
+      const productTypeSelect = hiddenSelects[0]
+
+      expect(productTypeSelect).toBeDefined()
+
+      const options = productTypeSelect.querySelectorAll('option')
+      const optionTexts = Array.from(options).map((opt) => opt.textContent)
+
+      // マグカップが表示されないことを確認
+      expect(optionTexts).not.toContain('マグカップ')
+    })
+
+    it('商品種別の選択肢が正確に5つである', () => {
+      render(<ProductForm />)
+
+      // Radix UIのSelect は hidden の native select を持つ
+      const hiddenSelects = document.querySelectorAll('select[aria-hidden="true"]')
+      const productTypeSelect = hiddenSelects[0]
+
+      expect(productTypeSelect).toBeDefined()
+
+      const options = productTypeSelect.querySelectorAll('option')
+
+      // 選択肢が正確に5つであることを確認
+      expect(options).toHaveLength(5)
+    })
+  })
+
+  describe('productTypes配列の検証', () => {
+    it('productTypes配列にマグカップが含まれていない', async () => {
+      // product-form.tsx から productTypes をインポートできないため
+      // レンダリング結果から間接的に検証
+      render(<ProductForm />)
+
+      // 「マグカップ」というテキストがドキュメント内に存在しないことを確認
+      expect(screen.queryByText('マグカップ')).not.toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 商品種別を5種類（キーホルダー・ステッカー・トートバッグ・Tシャツ・スタンド）に限定
- マグカップ（MUG）をシステムから完全に削除
- バックエンドEnumとフロントエンド型定義・UIを同時に更新

## 変更内容
- `api/app/models/product.py`: ProductType Enumからマグカップを削除
- `web/src/types/api/index.ts`: TypeScript型定義を更新
- `web/src/features/products/components/product-form.tsx`: フォームの選択肢とZodスキーマを更新
- `web/src/features/products/components/product-list.tsx`: 商品種別ラベルを更新
- `web/src/app/(dashboard)/products/[id]/page.tsx`: 商品種別ラベルを更新

## Test plan
- [x] バックエンドユニットテスト（ProductType Enumの検証）
- [x] バックエンド統合テスト（API バリデーション検証）
- [x] フロントエンドユニットテスト（商品フォームの選択肢検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)