### PR TITLE
feat: 発注・配送ステータスの手動切り替え機能

### DIFF
--- a/.claude/specs/FEAT-0006.yaml
+++ b/.claude/specs/FEAT-0006.yaml
@@ -1,0 +1,138 @@
+id: FEAT-0006
+title: 発注・配送ステータスの手動切り替え機能
+created_at: 2026-02-23
+status: approved
+
+summary: |
+  発注ステータス（発注中・製造中・納入済）と配送ステータス（配送準備待ち・配送準備完了・発送完了）を
+  手動で自由に切り替え可能にする。
+
+requirements:
+  order_status:
+    description: 発注ステータスの手動切り替え
+    statuses:
+      - ordered: 発注中
+      - manufacturing: 製造中
+      - delivered: 納入済
+    transitions:
+      ordered: [manufacturing, delivered]
+      manufacturing: [ordered, delivered]
+      delivered: [ordered, manufacturing]
+    side_effects:
+      to_delivered: 配送レコード（Shipment）を自動作成（既存動作維持）
+      from_delivered: 関連する配送レコードを削除
+    notes:
+      - shipped は配送側で制御されるため発注ステータスとしては直接操作不可
+
+  shipment_status:
+    description: 配送ステータスの手動切り替え
+    statuses:
+      - pending: 配送準備待ち
+      - ready: 配送準備完了
+      - shipped: 発送完了
+    transitions:
+      pending: [ready, shipped]
+      ready: [pending, shipped]
+      shipped: [pending, ready]
+    side_effects:
+      to_shipped:
+        - 関連する受注ステータスを shipped に更新
+        - shipped_at を現在時刻に設定
+      from_shipped:
+        - 関連する受注ステータスを delivered に戻す
+        - shipped_at をクリア
+
+acceptance_criteria:
+  - scenario: 発注中から製造中に変更
+    given: 発注ステータスが「発注中」の受注がある
+    when: ステータスを「製造中」に変更する
+    then: ステータスが「製造中」に更新される
+
+  - scenario: 製造中から発注中に戻す
+    given: 発注ステータスが「製造中」の受注がある
+    when: ステータスを「発注中」に変更する
+    then: ステータスが「発注中」に更新される
+
+  - scenario: 発注中から納入済に変更
+    given: 発注ステータスが「発注中」の受注がある
+    when: ステータスを「納入済」に変更する
+    then:
+      - ステータスが「納入済」に更新される
+      - 配送レコードが自動作成される
+
+  - scenario: 納入済から発注中に戻す
+    given: 発注ステータスが「納入済」の受注がある
+    and: 配送レコードが存在する
+    when: ステータスを「発注中」に変更する
+    then:
+      - ステータスが「発注中」に更新される
+      - 関連する配送レコードが削除される
+
+  - scenario: 納入済から製造中に戻す
+    given: 発注ステータスが「納入済」の受注がある
+    and: 配送レコードが存在する
+    when: ステータスを「製造中」に変更する
+    then:
+      - ステータスが「製造中」に更新される
+      - 関連する配送レコードが削除される
+
+  - scenario: 配送準備待ちから準備完了に変更
+    given: 配送ステータスが「配送準備待ち」の配送がある
+    when: ステータスを「準備完了」に変更する
+    then: ステータスが「準備完了」に更新される
+
+  - scenario: 準備完了から配送準備待ちに戻す
+    given: 配送ステータスが「準備完了」の配送がある
+    when: ステータスを「配送準備待ち」に変更する
+    then: ステータスが「配送準備待ち」に更新される
+
+  - scenario: 配送準備待ちから発送完了に変更
+    given: 配送ステータスが「配送準備待ち」の配送がある
+    when: ステータスを「発送完了」に変更する
+    then:
+      - ステータスが「発送完了」に更新される
+      - shipped_at が現在時刻に設定される
+      - 関連する受注ステータスが「発送完了」に更新される
+
+  - scenario: 準備完了から発送完了に変更
+    given: 配送ステータスが「準備完了」の配送がある
+    when: ステータスを「発送完了」に変更する
+    then:
+      - ステータスが「発送完了」に更新される
+      - shipped_at が現在時刻に設定される
+      - 関連する受注ステータスが「発送完了」に更新される
+
+  - scenario: 発送完了から配送準備待ちに戻す
+    given: 配送ステータスが「発送完了」の配送がある
+    and: 関連する受注ステータスが「発送完了」である
+    when: ステータスを「配送準備待ち」に変更する
+    then:
+      - ステータスが「配送準備待ち」に更新される
+      - shipped_at がクリアされる
+      - 関連する受注ステータスが「納入済」に戻る
+
+  - scenario: 発送完了から準備完了に戻す
+    given: 配送ステータスが「発送完了」の配送がある
+    and: 関連する受注ステータスが「発送完了」である
+    when: ステータスを「準備完了」に変更する
+    then:
+      - ステータスが「準備完了」に更新される
+      - shipped_at がクリアされる
+      - 関連する受注ステータスが「納入済」に戻る
+
+scope:
+  includes:
+    - バックエンド: ステータス遷移バリデーションの変更
+    - バックエンド: 配送削除ロジックの追加
+    - バックエンド: shipped からの戻し時の受注ステータス連動
+    - フロントエンド: 受注詳細画面にステータス変更UIを追加
+  excludes:
+    - 一括ステータス更新の変更（既存のまま）
+    - ステータス変更履歴の記録（別機能として要検討）
+
+assumptions:
+  - 配送削除時、配送に含まれる ShipmentItem もカスケード削除される
+  - 受注詳細画面のステータス変更UIは、配送詳細画面と同様のダイアログ形式
+
+test_priority:
+  - 通常のステータス切り替えの正常動作テストを入念に行う

--- a/api/app/repositories/shipment_repository.py
+++ b/api/app/repositories/shipment_repository.py
@@ -212,3 +212,43 @@ class ShipmentRepository:
         result = await self._db.execute(query)
         count = result.scalar() or 0
         return count > 0
+
+    async def delete_by_order_id(self, order_id: str) -> None:
+        """Delete shipment and shipment items for a given order.
+
+        This removes the ShipmentItem for the order, and if the Shipment
+        has no more items, deletes the Shipment as well.
+
+        Args:
+            order_id: The order ID whose shipment should be deleted.
+        """
+        # Find the shipment item for this order
+        query = select(ShipmentItem).where(ShipmentItem.order_id == order_id)
+        result = await self._db.execute(query)
+        shipment_item = result.scalar_one_or_none()
+
+        if not shipment_item:
+            return
+
+        shipment_id = shipment_item.shipment_id
+
+        # Delete the shipment item
+        await self._db.delete(shipment_item)
+        await self._db.flush()
+
+        # Check if shipment has any remaining items
+        remaining_query = (
+            select(func.count(ShipmentItem.id))
+            .where(ShipmentItem.shipment_id == shipment_id)
+        )
+        remaining_result = await self._db.execute(remaining_query)
+        remaining_count = remaining_result.scalar() or 0
+
+        # If no items remain, delete the shipment
+        if remaining_count == 0:
+            shipment_query = select(Shipment).where(Shipment.id == shipment_id)
+            shipment_result = await self._db.execute(shipment_query)
+            shipment = shipment_result.scalar_one_or_none()
+            if shipment:
+                await self._db.delete(shipment)
+                await self._db.flush()

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -31,8 +31,10 @@ from app.schemas.order import (
     OrderResponse,
     OrderShipmentInfo,
 )
+from app.models.shipment import ShipmentStatus
 from app.utils.exceptions import (
     DuplicateError,
+    InvalidStatusTransitionError,
     OrderNotFoundError,
     ProductNotFoundError,
     ValidationError,
@@ -176,10 +178,46 @@ class OrderService:
         )
 
     async def update_status(self, order_id: str, status: OrderStatus) -> OrderResponse:
-        """Update order status."""
+        """Update order status.
+
+        Implements manual status switching with the following rules:
+        - shipped への直接遷移は拒否（Shipment経由でのみshippedになる）
+        - shipped ステータスからの遷移は拒否（Shipment経由で戻す必要がある）
+        - delivered -> ordered/manufacturing: 関連Shipmentがshippedなら拒否、そうでなければShipment削除
+        - ordered/manufacturing -> delivered: Shipment自動作成
+        """
         order = await self._order_repo.find_by_id(order_id)
         if not order:
             raise OrderNotFoundError(order_id)
+
+        current_status = OrderStatus(order.status)
+
+        # shipped への直接遷移は拒否
+        if status == OrderStatus.SHIPPED:
+            raise InvalidStatusTransitionError(current_status.value, status.value)
+
+        # shipped ステータスからの遷移は拒否
+        if current_status == OrderStatus.SHIPPED:
+            raise InvalidStatusTransitionError(current_status.value, status.value)
+
+        # delivered -> ordered/manufacturing の遷移時の処理
+        if current_status == OrderStatus.DELIVERED and status in (
+            OrderStatus.ORDERED,
+            OrderStatus.MANUFACTURING,
+        ):
+            # 関連Shipmentを確認
+            shipment_map = await self._shipment_repo.find_by_order_ids([order_id])
+            shipment = shipment_map.get(order_id)
+
+            if shipment:
+                # Shipmentがshippedなら拒否
+                if shipment.status == ShipmentStatus.SHIPPED.value:
+                    raise ValidationError(
+                        "Cannot revert order status: related shipment is already shipped. "
+                        "Please revert the shipment status first."
+                    )
+                # そうでなければShipment削除
+                await self._shipment_repo.delete_by_order_id(order_id)
 
         order.status = status.value
         order = await self._order_repo.update(order)

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -124,13 +124,19 @@ class ShipmentService:
         if not self._is_valid_transition(current_status, data.status):
             raise InvalidStatusTransitionError(current_status.value, data.status.value)
 
+        # Handle reverting from shipped to pending/ready
+        is_reverting_from_shipped = (
+            current_status == ShipmentStatus.SHIPPED and
+            data.status in (ShipmentStatus.PENDING, ShipmentStatus.READY)
+        )
+
         shipment.status = data.status.value
 
-        if data.tracking_number:
+        if data.tracking_number is not None:
             shipment.tracking_number = data.tracking_number
-        if data.carrier:
+        if data.carrier is not None:
             shipment.carrier = data.carrier
-        if data.note:
+        if data.note is not None:
             shipment.note = data.note
 
         # Set timestamps
@@ -143,8 +149,17 @@ class ShipmentService:
             for item in shipment.items:
                 await self._order_repo.update_status(item.order_id, OrderStatus.SHIPPED)
 
+        # When reverting from shipped, clear shipped_at and revert orders to delivered
+        if is_reverting_from_shipped:
+            shipment.shipped_at = None
+            for item in shipment.items:
+                await self._order_repo.update_status(item.order_id, OrderStatus.DELIVERED)
+
         await self._shipment_repo.update(shipment)
-        return self._to_response(shipment)
+
+        # Refresh shipment to get updated relationships
+        refreshed_shipment = await self._shipment_repo.find_by_id(shipment_id)
+        return self._to_response(refreshed_shipment)
 
     async def upload_packing_photo(
         self, shipment_id: str, photo: UploadFile
@@ -251,11 +266,18 @@ class ShipmentService:
     def _is_valid_transition(
         self, current: ShipmentStatus, target: ShipmentStatus
     ) -> bool:
-        """Check if status transition is valid."""
+        """Check if status transition is valid.
+
+        Supports bidirectional transitions for manual status switching.
+        """
+        # Allow same status (idempotent)
+        if current == target:
+            return True
+
         valid_transitions = {
-            ShipmentStatus.PENDING: [ShipmentStatus.READY],
-            ShipmentStatus.READY: [ShipmentStatus.SHIPPED],
-            ShipmentStatus.SHIPPED: [],  # 最終ステータス
+            ShipmentStatus.PENDING: [ShipmentStatus.READY, ShipmentStatus.SHIPPED],
+            ShipmentStatus.READY: [ShipmentStatus.PENDING, ShipmentStatus.SHIPPED],
+            ShipmentStatus.SHIPPED: [ShipmentStatus.PENDING, ShipmentStatus.READY],
         }
         return target in valid_transitions.get(current, [])
 

--- a/api/tests/integration/test_order_status_flow.py
+++ b/api/tests/integration/test_order_status_flow.py
@@ -1,0 +1,502 @@
+"""Integration tests for order status flow.
+
+FEAT-0006: Order status manual switching functionality.
+Tests the full flow through API -> Service -> Repository -> Database.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid import uuid4
+
+
+@pytest.fixture
+async def test_order_ordered(db_session: AsyncSession, test_order_source: dict):
+    """Create a test order in 'ordered' status."""
+    order_id = str(uuid4())
+
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id, product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at, created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id, :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(), NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": f"ORD-{order_id[:8]}",
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product",
+            "quantity": 1,
+            "customer_name": "Test Customer",
+            "customer_email": "customer@example.com",
+            "customer_phone": "090-0000-0000",
+            "customer_postal_code": "100-0001",
+            "customer_address_prefecture": "Tokyo",
+            "customer_address_city": "Chiyoda",
+            "status": "ordered",
+        },
+    )
+    await db_session.commit()
+
+    yield {"id": order_id, "order_source_id": test_order_source["id"]}
+
+
+@pytest.fixture
+async def test_order_manufacturing(db_session: AsyncSession, test_order_source: dict):
+    """Create a test order in 'manufacturing' status."""
+    order_id = str(uuid4())
+
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id, product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at, created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id, :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(), NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": f"MFG-{order_id[:8]}",
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product",
+            "quantity": 1,
+            "customer_name": "Test Customer",
+            "customer_email": "customer@example.com",
+            "customer_phone": "090-0000-0000",
+            "customer_postal_code": "100-0001",
+            "customer_address_prefecture": "Tokyo",
+            "customer_address_city": "Chiyoda",
+            "status": "manufacturing",
+        },
+    )
+    await db_session.commit()
+
+    yield {"id": order_id, "order_source_id": test_order_source["id"]}
+
+
+@pytest.fixture
+async def test_order_delivered_with_shipment(
+    db_session: AsyncSession, test_order_source: dict
+):
+    """Create a test order in 'delivered' status with a pending shipment."""
+    order_id = str(uuid4())
+    shipment_id = str(uuid4())
+    shipment_item_id = str(uuid4())
+
+    # Create order
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id, product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at, created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id, :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(), NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": f"DLV-{order_id[:8]}",
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product",
+            "quantity": 1,
+            "customer_name": "Test Customer",
+            "customer_email": "customer@example.com",
+            "customer_phone": "090-0000-0000",
+            "customer_postal_code": "100-0001",
+            "customer_address_prefecture": "Tokyo",
+            "customer_address_city": "Chiyoda",
+            "status": "delivered",
+        },
+    )
+
+    # Create shipment
+    await db_session.execute(
+        text("""
+            INSERT INTO shipments (id, status, created_at, updated_at)
+            VALUES (:id, :status, NOW(), NOW())
+        """),
+        {"id": shipment_id, "status": "pending"},
+    )
+
+    # Create shipment item
+    await db_session.execute(
+        text("""
+            INSERT INTO shipment_items (id, shipment_id, order_id, created_at, updated_at)
+            VALUES (:id, :shipment_id, :order_id, NOW(), NOW())
+        """),
+        {"id": shipment_item_id, "shipment_id": shipment_id, "order_id": order_id},
+    )
+
+    await db_session.commit()
+
+    yield {
+        "id": order_id,
+        "shipment_id": shipment_id,
+        "order_source_id": test_order_source["id"],
+    }
+
+
+@pytest.fixture
+async def test_order_delivered_with_shipped_shipment(
+    db_session: AsyncSession, test_order_source: dict
+):
+    """Create a test order in 'delivered' status with a shipped shipment."""
+    order_id = str(uuid4())
+    shipment_id = str(uuid4())
+    shipment_item_id = str(uuid4())
+
+    # Create order (status is still delivered, but shipment is shipped)
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id, product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at, created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id, :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(), NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": f"SHP-{order_id[:8]}",
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product",
+            "quantity": 1,
+            "customer_name": "Test Customer",
+            "customer_email": "customer@example.com",
+            "customer_phone": "090-0000-0000",
+            "customer_postal_code": "100-0001",
+            "customer_address_prefecture": "Tokyo",
+            "customer_address_city": "Chiyoda",
+            "status": "shipped",  # Already shipped
+        },
+    )
+
+    # Create shipped shipment
+    await db_session.execute(
+        text("""
+            INSERT INTO shipments (id, status, shipped_at, created_at, updated_at)
+            VALUES (:id, :status, NOW(), NOW(), NOW())
+        """),
+        {"id": shipment_id, "status": "shipped"},
+    )
+
+    # Create shipment item
+    await db_session.execute(
+        text("""
+            INSERT INTO shipment_items (id, shipment_id, order_id, created_at, updated_at)
+            VALUES (:id, :shipment_id, :order_id, NOW(), NOW())
+        """),
+        {"id": shipment_item_id, "shipment_id": shipment_id, "order_id": order_id},
+    )
+
+    await db_session.commit()
+
+    yield {
+        "id": order_id,
+        "shipment_id": shipment_id,
+        "order_source_id": test_order_source["id"],
+    }
+
+
+class TestOrderStatusTransitionAPI:
+    """Integration tests for order status transition via API."""
+
+    # ===========================================
+    # Forward transitions
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ordered_to_manufacturing(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_ordered: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: ordered -> manufacturing via API."""
+        order_id = test_order_ordered["id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "manufacturing"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "manufacturing"
+
+        # Verify in database
+        result = await db_session.execute(
+            text("SELECT status FROM orders WHERE id = :id"),
+            {"id": order_id},
+        )
+        row = result.fetchone()
+        assert row[0] == "manufacturing"
+
+    @pytest.mark.asyncio
+    async def test_manufacturing_to_ordered(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_manufacturing: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: manufacturing -> ordered via API (reverse transition)."""
+        order_id = test_order_manufacturing["id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "ordered"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ordered"
+
+    @pytest.mark.asyncio
+    async def test_ordered_to_delivered_creates_shipment(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_ordered: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: ordered -> delivered creates shipment automatically."""
+        order_id = test_order_ordered["id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "delivered"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "delivered"
+
+        # Verify shipment was created
+        result = await db_session.execute(
+            text("""
+                SELECT s.id FROM shipments s
+                JOIN shipment_items si ON si.shipment_id = s.id
+                WHERE si.order_id = :order_id
+            """),
+            {"order_id": order_id},
+        )
+        shipment = result.fetchone()
+        assert shipment is not None
+
+    @pytest.mark.asyncio
+    async def test_manufacturing_to_delivered_creates_shipment(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_manufacturing: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: manufacturing -> delivered creates shipment automatically."""
+        order_id = test_order_manufacturing["id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "delivered"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "delivered"
+
+        # Verify shipment was created
+        result = await db_session.execute(
+            text("""
+                SELECT s.id FROM shipments s
+                JOIN shipment_items si ON si.shipment_id = s.id
+                WHERE si.order_id = :order_id
+            """),
+            {"order_id": order_id},
+        )
+        shipment = result.fetchone()
+        assert shipment is not None
+
+    # ===========================================
+    # Reverse transitions (from delivered)
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_delivered_to_ordered_deletes_shipment(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_delivered_with_shipment: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: delivered -> ordered deletes related shipment."""
+        order_id = test_order_delivered_with_shipment["id"]
+        shipment_id = test_order_delivered_with_shipment["shipment_id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "ordered"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ordered"
+
+        # Verify shipment was deleted (or shipment_item was deleted)
+        result = await db_session.execute(
+            text("""
+                SELECT si.id FROM shipment_items si
+                WHERE si.order_id = :order_id
+            """),
+            {"order_id": order_id},
+        )
+        shipment_item = result.fetchone()
+        assert shipment_item is None
+
+    @pytest.mark.asyncio
+    async def test_delivered_to_manufacturing_deletes_shipment(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_delivered_with_shipment: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: delivered -> manufacturing deletes related shipment."""
+        order_id = test_order_delivered_with_shipment["id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "manufacturing"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "manufacturing"
+
+        # Verify shipment was deleted
+        result = await db_session.execute(
+            text("""
+                SELECT si.id FROM shipment_items si
+                WHERE si.order_id = :order_id
+            """),
+            {"order_id": order_id},
+        )
+        shipment_item = result.fetchone()
+        assert shipment_item is None
+
+    # ===========================================
+    # Invalid transitions
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_cannot_transition_to_shipped_directly(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_ordered: dict,
+    ):
+        """Test: Direct transition to shipped is rejected."""
+        order_id = test_order_ordered["id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "shipped"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "INVALID_STATUS_TRANSITION" in data.get("error", {}).get("code", "")
+
+    @pytest.mark.asyncio
+    async def test_cannot_revert_from_delivered_when_shipment_shipped(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_delivered_with_shipped_shipment: dict,
+    ):
+        """Test: Cannot go back from delivered when shipment is already shipped."""
+        order_id = test_order_delivered_with_shipped_shipment["id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "ordered"},
+            headers=auth_headers,
+        )
+
+        # Should be rejected because shipment is already shipped
+        assert response.status_code == 400
+
+    # ===========================================
+    # Edge cases
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_order_not_found(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """Test: Returns 404 when order not found."""
+        non_existent_id = str(uuid4())
+
+        response = await client.patch(
+            f"/api/v1/orders/{non_existent_id}/status",
+            json={"status": "manufacturing"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_value(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_ordered: dict,
+    ):
+        """Test: Returns 422 when invalid status value provided."""
+        order_id = test_order_ordered["id"]
+
+        response = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "invalid_status"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 422

--- a/api/tests/integration/test_shipment_status_flow.py
+++ b/api/tests/integration/test_shipment_status_flow.py
@@ -1,0 +1,623 @@
+"""Integration tests for shipment status flow.
+
+FEAT-0006: Shipment status manual switching functionality.
+Tests the full flow through API -> Service -> Repository -> Database.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid import uuid4
+
+
+@pytest.fixture
+async def test_shipment_pending(
+    db_session: AsyncSession, test_order_source: dict
+):
+    """Create a test shipment in 'pending' status with one order."""
+    order_id = str(uuid4())
+    shipment_id = str(uuid4())
+    shipment_item_id = str(uuid4())
+
+    # Create order in delivered status
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id, product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at, created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id, :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(), NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": f"PND-{order_id[:8]}",
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product",
+            "quantity": 1,
+            "customer_name": "Test Customer",
+            "customer_email": "customer@example.com",
+            "customer_phone": "090-0000-0000",
+            "customer_postal_code": "100-0001",
+            "customer_address_prefecture": "Tokyo",
+            "customer_address_city": "Chiyoda",
+            "status": "delivered",
+        },
+    )
+
+    # Create pending shipment
+    await db_session.execute(
+        text("""
+            INSERT INTO shipments (id, status, created_at, updated_at)
+            VALUES (:id, :status, NOW(), NOW())
+        """),
+        {"id": shipment_id, "status": "pending"},
+    )
+
+    # Create shipment item
+    await db_session.execute(
+        text("""
+            INSERT INTO shipment_items (id, shipment_id, order_id, created_at, updated_at)
+            VALUES (:id, :shipment_id, :order_id, NOW(), NOW())
+        """),
+        {"id": shipment_item_id, "shipment_id": shipment_id, "order_id": order_id},
+    )
+
+    await db_session.commit()
+
+    yield {
+        "id": shipment_id,
+        "order_id": order_id,
+        "order_source_id": test_order_source["id"],
+    }
+
+
+@pytest.fixture
+async def test_shipment_ready(
+    db_session: AsyncSession, test_order_source: dict
+):
+    """Create a test shipment in 'ready' status with one order."""
+    order_id = str(uuid4())
+    shipment_id = str(uuid4())
+    shipment_item_id = str(uuid4())
+
+    # Create order in delivered status
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id, product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at, created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id, :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(), NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": f"RDY-{order_id[:8]}",
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product",
+            "quantity": 1,
+            "customer_name": "Test Customer",
+            "customer_email": "customer@example.com",
+            "customer_phone": "090-0000-0000",
+            "customer_postal_code": "100-0001",
+            "customer_address_prefecture": "Tokyo",
+            "customer_address_city": "Chiyoda",
+            "status": "delivered",
+        },
+    )
+
+    # Create ready shipment
+    await db_session.execute(
+        text("""
+            INSERT INTO shipments (id, status, created_at, updated_at)
+            VALUES (:id, :status, NOW(), NOW())
+        """),
+        {"id": shipment_id, "status": "ready"},
+    )
+
+    # Create shipment item
+    await db_session.execute(
+        text("""
+            INSERT INTO shipment_items (id, shipment_id, order_id, created_at, updated_at)
+            VALUES (:id, :shipment_id, :order_id, NOW(), NOW())
+        """),
+        {"id": shipment_item_id, "shipment_id": shipment_id, "order_id": order_id},
+    )
+
+    await db_session.commit()
+
+    yield {
+        "id": shipment_id,
+        "order_id": order_id,
+        "order_source_id": test_order_source["id"],
+    }
+
+
+@pytest.fixture
+async def test_shipment_shipped(
+    db_session: AsyncSession, test_order_source: dict
+):
+    """Create a test shipment in 'shipped' status with one order."""
+    order_id = str(uuid4())
+    shipment_id = str(uuid4())
+    shipment_item_id = str(uuid4())
+
+    # Create order in shipped status
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id, product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at, created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id, :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(), NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": f"SHP-{order_id[:8]}",
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product",
+            "quantity": 1,
+            "customer_name": "Test Customer",
+            "customer_email": "customer@example.com",
+            "customer_phone": "090-0000-0000",
+            "customer_postal_code": "100-0001",
+            "customer_address_prefecture": "Tokyo",
+            "customer_address_city": "Chiyoda",
+            "status": "shipped",
+        },
+    )
+
+    # Create shipped shipment
+    await db_session.execute(
+        text("""
+            INSERT INTO shipments (id, status, shipped_at, created_at, updated_at)
+            VALUES (:id, :status, NOW(), NOW(), NOW())
+        """),
+        {"id": shipment_id, "status": "shipped"},
+    )
+
+    # Create shipment item
+    await db_session.execute(
+        text("""
+            INSERT INTO shipment_items (id, shipment_id, order_id, created_at, updated_at)
+            VALUES (:id, :shipment_id, :order_id, NOW(), NOW())
+        """),
+        {"id": shipment_item_id, "shipment_id": shipment_id, "order_id": order_id},
+    )
+
+    await db_session.commit()
+
+    yield {
+        "id": shipment_id,
+        "order_id": order_id,
+        "order_source_id": test_order_source["id"],
+    }
+
+
+@pytest.fixture
+async def test_shipment_with_multiple_orders(
+    db_session: AsyncSession, test_order_source: dict
+):
+    """Create a test shipment with multiple orders."""
+    order_ids = [str(uuid4()) for _ in range(3)]
+    shipment_id = str(uuid4())
+
+    # Create multiple orders in delivered status
+    for i, order_id in enumerate(order_ids):
+        await db_session.execute(
+            text("""
+                INSERT INTO orders (
+                    id, order_number, order_source_id, product_name, quantity,
+                    customer_name, customer_email, customer_phone,
+                    customer_postal_code, customer_address_prefecture,
+                    customer_address_city, status, ordered_at, created_at, updated_at
+                )
+                VALUES (
+                    :id, :order_number, :order_source_id, :product_name, :quantity,
+                    :customer_name, :customer_email, :customer_phone,
+                    :customer_postal_code, :customer_address_prefecture,
+                    :customer_address_city, :status, NOW(), NOW(), NOW()
+                )
+            """),
+            {
+                "id": order_id,
+                "order_number": f"MLT-{i}-{order_id[:8]}",
+                "order_source_id": test_order_source["id"],
+                "product_name": f"Test Product {i}",
+                "quantity": 1,
+                "customer_name": "Test Customer",
+                "customer_email": "customer@example.com",
+                "customer_phone": "090-0000-0000",
+                "customer_postal_code": "100-0001",
+                "customer_address_prefecture": "Tokyo",
+                "customer_address_city": "Chiyoda",
+                "status": "delivered",
+            },
+        )
+
+    # Create pending shipment
+    await db_session.execute(
+        text("""
+            INSERT INTO shipments (id, status, created_at, updated_at)
+            VALUES (:id, :status, NOW(), NOW())
+        """),
+        {"id": shipment_id, "status": "pending"},
+    )
+
+    # Create shipment items for all orders
+    for order_id in order_ids:
+        shipment_item_id = str(uuid4())
+        await db_session.execute(
+            text("""
+                INSERT INTO shipment_items (id, shipment_id, order_id, created_at, updated_at)
+                VALUES (:id, :shipment_id, :order_id, NOW(), NOW())
+            """),
+            {"id": shipment_item_id, "shipment_id": shipment_id, "order_id": order_id},
+        )
+
+    await db_session.commit()
+
+    yield {
+        "id": shipment_id,
+        "order_ids": order_ids,
+        "order_source_id": test_order_source["id"],
+    }
+
+
+class TestShipmentStatusTransitionAPI:
+    """Integration tests for shipment status transition via API."""
+
+    # ===========================================
+    # Forward transitions
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_pending_to_ready(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_pending: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: pending -> ready via API."""
+        shipment_id = test_shipment_pending["id"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "ready"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+
+        # Verify in database
+        result = await db_session.execute(
+            text("SELECT status FROM shipments WHERE id = :id"),
+            {"id": shipment_id},
+        )
+        row = result.fetchone()
+        assert row[0] == "ready"
+
+    @pytest.mark.asyncio
+    async def test_ready_to_pending(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_ready: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: ready -> pending via API (reverse transition)."""
+        shipment_id = test_shipment_ready["id"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "pending"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_pending_to_shipped_updates_order(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_pending: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: pending -> shipped sets shipped_at and updates order to shipped."""
+        shipment_id = test_shipment_pending["id"]
+        order_id = test_shipment_pending["order_id"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "shipped"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "shipped"
+        assert data["shipped_at"] is not None
+
+        # Verify order status was updated
+        result = await db_session.execute(
+            text("SELECT status FROM orders WHERE id = :id"),
+            {"id": order_id},
+        )
+        row = result.fetchone()
+        assert row[0] == "shipped"
+
+    @pytest.mark.asyncio
+    async def test_ready_to_shipped_updates_order(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_ready: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: ready -> shipped sets shipped_at and updates order to shipped."""
+        shipment_id = test_shipment_ready["id"]
+        order_id = test_shipment_ready["order_id"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "shipped"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "shipped"
+        assert data["shipped_at"] is not None
+
+        # Verify order status was updated
+        result = await db_session.execute(
+            text("SELECT status FROM orders WHERE id = :id"),
+            {"id": order_id},
+        )
+        row = result.fetchone()
+        assert row[0] == "shipped"
+
+    # ===========================================
+    # Reverse transitions (from shipped)
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_shipped_to_pending_reverts_order(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_shipped: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: shipped -> pending clears shipped_at and reverts order to delivered."""
+        shipment_id = test_shipment_shipped["id"]
+        order_id = test_shipment_shipped["order_id"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "pending"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "pending"
+        assert data["shipped_at"] is None
+
+        # Verify order status was reverted
+        result = await db_session.execute(
+            text("SELECT status FROM orders WHERE id = :id"),
+            {"id": order_id},
+        )
+        row = result.fetchone()
+        assert row[0] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_shipped_to_ready_reverts_order(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_shipped: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: shipped -> ready clears shipped_at and reverts order to delivered."""
+        shipment_id = test_shipment_shipped["id"]
+        order_id = test_shipment_shipped["order_id"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "ready"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+        assert data["shipped_at"] is None
+
+        # Verify order status was reverted
+        result = await db_session.execute(
+            text("SELECT status FROM orders WHERE id = :id"),
+            {"id": order_id},
+        )
+        row = result.fetchone()
+        assert row[0] == "delivered"
+
+    # ===========================================
+    # Multiple orders in shipment
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_shipped_updates_all_orders(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_with_multiple_orders: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: shipping a shipment with multiple orders updates all orders."""
+        shipment_id = test_shipment_with_multiple_orders["id"]
+        order_ids = test_shipment_with_multiple_orders["order_ids"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "shipped"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "shipped"
+
+        # Verify all orders were updated
+        for order_id in order_ids:
+            result = await db_session.execute(
+                text("SELECT status FROM orders WHERE id = :id"),
+                {"id": order_id},
+            )
+            row = result.fetchone()
+            assert row[0] == "shipped"
+
+    @pytest.mark.asyncio
+    async def test_revert_from_shipped_reverts_all_orders(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_with_multiple_orders: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: reverting from shipped reverts all orders to delivered."""
+        shipment_id = test_shipment_with_multiple_orders["id"]
+        order_ids = test_shipment_with_multiple_orders["order_ids"]
+
+        # First, ship it
+        await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "shipped"},
+            headers=auth_headers,
+        )
+
+        # Then revert
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "pending"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "pending"
+
+        # Verify all orders were reverted
+        for order_id in order_ids:
+            result = await db_session.execute(
+                text("SELECT status FROM orders WHERE id = :id"),
+                {"id": order_id},
+            )
+            row = result.fetchone()
+            assert row[0] == "delivered"
+
+    # ===========================================
+    # Additional fields
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_tracking_number_set_on_ship(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_ready: dict,
+        db_session: AsyncSession,
+    ):
+        """Test: tracking number can be set when shipping."""
+        shipment_id = test_shipment_ready["id"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={
+                "status": "shipped",
+                "tracking_number": "1234567890",
+                "carrier": "Yamato",
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["tracking_number"] == "1234567890"
+        assert data["carrier"] == "Yamato"
+
+        # Verify in database
+        result = await db_session.execute(
+            text("SELECT tracking_number, carrier FROM shipments WHERE id = :id"),
+            {"id": shipment_id},
+        )
+        row = result.fetchone()
+        assert row[0] == "1234567890"
+        assert row[1] == "Yamato"
+
+    # ===========================================
+    # Edge cases
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_shipment_not_found(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """Test: Returns 404 when shipment not found."""
+        non_existent_id = str(uuid4())
+
+        response = await client.patch(
+            f"/api/v1/shipments/{non_existent_id}/status",
+            json={"status": "ready"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_value(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_shipment_pending: dict,
+    ):
+        """Test: Returns 422 when invalid status value provided."""
+        shipment_id = test_shipment_pending["id"]
+
+        response = await client.patch(
+            f"/api/v1/shipments/{shipment_id}/status",
+            json={"status": "invalid_status"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 422

--- a/api/tests/unit/test_order_service_status.py
+++ b/api/tests/unit/test_order_service_status.py
@@ -1,0 +1,371 @@
+"""Unit tests for OrderService status transitions.
+
+FEAT-0006: Order status manual switching functionality.
+Tests cover all order status transition scenarios.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+import pytest
+
+from app.models.order import Order, OrderStatus
+from app.models.shipment import Shipment, ShipmentItem, ShipmentStatus
+from app.services.order_service import OrderService
+from app.utils.exceptions import InvalidStatusTransitionError, ValidationError
+
+
+@pytest.fixture
+def mock_order_repo():
+    """Mock order repository."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_product_repo():
+    """Mock product repository."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_shipment_repo():
+    """Mock shipment repository."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def order_service(mock_order_repo, mock_product_repo, mock_shipment_repo):
+    """Create OrderService with mocked dependencies."""
+    return OrderService(
+        order_repo=mock_order_repo,
+        product_repo=mock_product_repo,
+        shipment_repo=mock_shipment_repo,
+    )
+
+
+def create_mock_order(
+    order_id: str = "order-123",
+    status: str = OrderStatus.ORDERED.value,
+) -> MagicMock:
+    """Create a mock order object."""
+    order = MagicMock(spec=Order)
+    order.id = order_id
+    order.status = status
+    order.order_number = "TEST-001"
+    order.customer_name = "Test Customer"
+    order.customer_postal_code = "100-0001"
+    order.customer_address_prefecture = "Tokyo"
+    order.customer_address_city = "Chiyoda"
+    order.customer_address_building = None
+    order.customer_phone = "090-1234-5678"
+    order.customer_email = "test@example.com"
+    order.ordered_at = datetime.now(timezone.utc)
+    order.total_price = 1000
+    order.items = []
+    order.order_source = None
+    order.order_source_id = None
+    order.product_id = None
+    order.product_name = None
+    order.price = None
+    order.quantity = None
+    order.manufacturing_data_path = None
+    order.manufacturing_data_filename = None
+    order.manufacturing_data_size = None
+    order.created_at = datetime.now(timezone.utc)
+    order.updated_at = datetime.now(timezone.utc)
+    return order
+
+
+def create_mock_shipment(
+    shipment_id: str = "shipment-123",
+    status: str = ShipmentStatus.PENDING.value,
+    order_ids: list[str] | None = None,
+) -> MagicMock:
+    """Create a mock shipment object."""
+    shipment = MagicMock(spec=Shipment)
+    shipment.id = shipment_id
+    shipment.status = status
+    shipment.tracking_number = None
+    shipment.carrier = None
+    shipment.shipped_at = None
+    shipment.items = []
+
+    if order_ids:
+        for order_id in order_ids:
+            item = MagicMock(spec=ShipmentItem)
+            item.order_id = order_id
+            shipment.items.append(item)
+
+    return shipment
+
+
+class TestOrderStatusTransition:
+    """Test order status transition functionality."""
+
+    # ===========================================
+    # Normal transitions (forward)
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ordered_to_manufacturing_success(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: ordered -> manufacturing is allowed."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.ORDERED.value)
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.find_by_order_ids.return_value = {}
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.MANUFACTURING,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.MANUFACTURING.value
+        mock_order_repo.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manufacturing_to_ordered_success(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: manufacturing -> ordered is allowed (reverse transition)."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.MANUFACTURING.value)
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.find_by_order_ids.return_value = {}
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.ORDERED,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.ORDERED.value
+        mock_order_repo.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ordered_to_delivered_creates_shipment(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: ordered -> delivered creates shipment automatically."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.ORDERED.value)
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.exists_for_order.return_value = False
+        mock_shipment_repo.find_by_order_ids.return_value = {}
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.DELIVERED,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.DELIVERED.value
+        mock_shipment_repo.create.assert_called_once_with(order_ids=["order-123"])
+
+    @pytest.mark.asyncio
+    async def test_manufacturing_to_delivered_creates_shipment(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: manufacturing -> delivered creates shipment automatically."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.MANUFACTURING.value)
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.exists_for_order.return_value = False
+        mock_shipment_repo.find_by_order_ids.return_value = {}
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.DELIVERED,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.DELIVERED.value
+        mock_shipment_repo.create.assert_called_once()
+
+    # ===========================================
+    # Reverse transitions (from delivered)
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_delivered_to_ordered_deletes_shipment(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: delivered -> ordered deletes related shipment."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.DELIVERED.value)
+        shipment = create_mock_shipment(status=ShipmentStatus.PENDING.value)
+
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.find_by_order_ids.return_value = {"order-123": shipment}
+        mock_shipment_repo.delete_by_order_id.return_value = None
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.ORDERED,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.ORDERED.value
+        mock_shipment_repo.delete_by_order_id.assert_called_once_with("order-123")
+
+    @pytest.mark.asyncio
+    async def test_delivered_to_manufacturing_deletes_shipment(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: delivered -> manufacturing deletes related shipment."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.DELIVERED.value)
+        shipment = create_mock_shipment(status=ShipmentStatus.PENDING.value)
+
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.find_by_order_ids.return_value = {"order-123": shipment}
+        mock_shipment_repo.delete_by_order_id.return_value = None
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.MANUFACTURING,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.MANUFACTURING.value
+        mock_shipment_repo.delete_by_order_id.assert_called_once_with("order-123")
+
+    # ===========================================
+    # Invalid transitions
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_cannot_transition_to_shipped_directly(
+        self, order_service, mock_order_repo
+    ):
+        """Test: Direct transition to shipped is not allowed."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.ORDERED.value)
+        mock_order_repo.find_by_id.return_value = order
+
+        # Act & Assert
+        with pytest.raises(InvalidStatusTransitionError):
+            await order_service.update_status(
+                order_id="order-123",
+                status=OrderStatus.SHIPPED,
+            )
+
+    @pytest.mark.asyncio
+    async def test_cannot_transition_from_delivered_when_shipment_is_shipped(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: Cannot go back from delivered when shipment is already shipped."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.DELIVERED.value)
+        shipment = create_mock_shipment(status=ShipmentStatus.SHIPPED.value)
+
+        mock_order_repo.find_by_id.return_value = order
+        mock_shipment_repo.find_by_order_ids.return_value = {"order-123": shipment}
+
+        # Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            await order_service.update_status(
+                order_id="order-123",
+                status=OrderStatus.ORDERED,
+            )
+
+        assert "shipped" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_cannot_transition_from_shipped(
+        self, order_service, mock_order_repo
+    ):
+        """Test: Cannot transition from shipped status."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.SHIPPED.value)
+        mock_order_repo.find_by_id.return_value = order
+
+        # Act & Assert
+        with pytest.raises(InvalidStatusTransitionError):
+            await order_service.update_status(
+                order_id="order-123",
+                status=OrderStatus.DELIVERED,
+            )
+
+    # ===========================================
+    # Edge cases
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_delivered_to_ordered_when_no_shipment_exists(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: delivered -> ordered when no shipment exists (no error)."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.DELIVERED.value)
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.find_by_order_ids.return_value = {}  # No shipment
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.ORDERED,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.ORDERED.value
+        mock_shipment_repo.delete_by_order_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_same_status_transition_is_idempotent(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: Transitioning to the same status is allowed (idempotent)."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.MANUFACTURING.value)
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.find_by_order_ids.return_value = {}
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.MANUFACTURING,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.MANUFACTURING.value
+
+    @pytest.mark.asyncio
+    async def test_to_delivered_does_not_duplicate_shipment(
+        self, order_service, mock_order_repo, mock_shipment_repo
+    ):
+        """Test: Going to delivered when shipment already exists does not create duplicate."""
+        # Arrange
+        order = create_mock_order(status=OrderStatus.MANUFACTURING.value)
+        mock_order_repo.find_by_id.return_value = order
+        mock_order_repo.update.return_value = order
+        mock_shipment_repo.exists_for_order.return_value = True  # Shipment already exists
+        mock_shipment_repo.find_by_order_ids.return_value = {}
+
+        # Act
+        result = await order_service.update_status(
+            order_id="order-123",
+            status=OrderStatus.DELIVERED,
+        )
+
+        # Assert
+        assert order.status == OrderStatus.DELIVERED.value
+        mock_shipment_repo.create.assert_not_called()

--- a/api/tests/unit/test_shipment_service_status.py
+++ b/api/tests/unit/test_shipment_service_status.py
@@ -1,0 +1,432 @@
+"""Unit tests for ShipmentService status transitions.
+
+FEAT-0006: Shipment status manual switching functionality.
+Tests cover all shipment status transition scenarios including
+bidirectional transitions and order status synchronization.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+import pytest
+
+from app.models.order import Order, OrderStatus
+from app.models.shipment import Shipment, ShipmentItem, ShipmentStatus
+from app.schemas.shipment import ShipmentStatusUpdate
+from app.services.shipment_service import ShipmentService
+from app.utils.exceptions import InvalidStatusTransitionError
+
+
+@pytest.fixture
+def mock_shipment_repo():
+    """Mock shipment repository."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_order_repo():
+    """Mock order repository."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_file_storage():
+    """Mock file storage."""
+    storage = AsyncMock()
+    return storage
+
+
+@pytest.fixture
+def shipment_service(mock_shipment_repo, mock_order_repo, mock_file_storage):
+    """Create ShipmentService with mocked dependencies."""
+    return ShipmentService(
+        shipment_repo=mock_shipment_repo,
+        order_repo=mock_order_repo,
+        file_storage=mock_file_storage,
+    )
+
+
+def create_mock_order(
+    order_id: str = "order-123",
+    status: str = OrderStatus.DELIVERED.value,
+) -> MagicMock:
+    """Create a mock order object."""
+    order = MagicMock(spec=Order)
+    order.id = order_id
+    order.status = status
+    order.order_number = "TEST-001"
+    order.product_name = "Test Product"
+    order.customer_name = "Test Customer"
+    order.customer_postal_code = "100-0001"
+    order.customer_address_prefecture = "Tokyo"
+    order.customer_address_city = "Chiyoda"
+    order.customer_address_building = None
+    order.customer_phone = "090-1234-5678"
+    return order
+
+
+def create_mock_shipment(
+    shipment_id: str = "shipment-123",
+    status: str = ShipmentStatus.PENDING.value,
+    order_ids: list[str] | None = None,
+    shipped_at: datetime | None = None,
+) -> MagicMock:
+    """Create a mock shipment object."""
+    shipment = MagicMock(spec=Shipment)
+    shipment.id = shipment_id
+    shipment.status = status
+    shipment.tracking_number = None
+    shipment.carrier = None
+    shipment.packing_photo_path = None
+    shipment.shipped_at = shipped_at
+    shipment.delivered_at = None
+    shipment.note = None
+    shipment.created_at = datetime.now(timezone.utc)
+    shipment.updated_at = datetime.now(timezone.utc)
+    shipment.items = []
+
+    if order_ids:
+        for order_id in order_ids:
+            item = MagicMock(spec=ShipmentItem)
+            item.id = f"item-{order_id}"
+            item.order_id = order_id
+            item.order = create_mock_order(order_id)
+            shipment.items.append(item)
+
+    # Set first_order property
+    if shipment.items:
+        shipment.first_order = shipment.items[0].order
+    else:
+        shipment.first_order = None
+
+    return shipment
+
+
+class TestShipmentStatusTransition:
+    """Test shipment status transition functionality."""
+
+    # ===========================================
+    # Normal forward transitions
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_pending_to_ready_success(
+        self, shipment_service, mock_shipment_repo
+    ):
+        """Test: pending -> ready is allowed."""
+        # Arrange
+        shipment = create_mock_shipment(status=ShipmentStatus.PENDING.value)
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(status=ShipmentStatus.READY)
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.status == ShipmentStatus.READY.value
+        mock_shipment_repo.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ready_to_pending_success(
+        self, shipment_service, mock_shipment_repo
+    ):
+        """Test: ready -> pending is allowed (reverse transition)."""
+        # Arrange
+        shipment = create_mock_shipment(status=ShipmentStatus.READY.value)
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(status=ShipmentStatus.PENDING)
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.status == ShipmentStatus.PENDING.value
+        mock_shipment_repo.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pending_to_shipped_success(
+        self, shipment_service, mock_shipment_repo, mock_order_repo
+    ):
+        """Test: pending -> shipped is allowed, sets shipped_at and updates orders."""
+        # Arrange
+        order_ids = ["order-123", "order-456"]
+        shipment = create_mock_shipment(
+            status=ShipmentStatus.PENDING.value,
+            order_ids=order_ids,
+        )
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(status=ShipmentStatus.SHIPPED)
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.status == ShipmentStatus.SHIPPED.value
+        assert shipment.shipped_at is not None
+        # All related orders should be updated to SHIPPED
+        assert mock_order_repo.update_status.call_count == len(order_ids)
+
+    @pytest.mark.asyncio
+    async def test_ready_to_shipped_success(
+        self, shipment_service, mock_shipment_repo, mock_order_repo
+    ):
+        """Test: ready -> shipped is allowed, sets shipped_at and updates orders."""
+        # Arrange
+        order_ids = ["order-123"]
+        shipment = create_mock_shipment(
+            status=ShipmentStatus.READY.value,
+            order_ids=order_ids,
+        )
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(status=ShipmentStatus.SHIPPED)
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.status == ShipmentStatus.SHIPPED.value
+        assert shipment.shipped_at is not None
+        mock_order_repo.update_status.assert_called_once_with(
+            "order-123", OrderStatus.SHIPPED
+        )
+
+    # ===========================================
+    # Reverse transitions (from shipped)
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_shipped_to_pending_success(
+        self, shipment_service, mock_shipment_repo, mock_order_repo
+    ):
+        """Test: shipped -> pending clears shipped_at and reverts order status to delivered."""
+        # Arrange
+        order_ids = ["order-123"]
+        shipment = create_mock_shipment(
+            status=ShipmentStatus.SHIPPED.value,
+            order_ids=order_ids,
+            shipped_at=datetime.now(timezone.utc),
+        )
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(status=ShipmentStatus.PENDING)
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.status == ShipmentStatus.PENDING.value
+        assert shipment.shipped_at is None
+        mock_order_repo.update_status.assert_called_once_with(
+            "order-123", OrderStatus.DELIVERED
+        )
+
+    @pytest.mark.asyncio
+    async def test_shipped_to_ready_success(
+        self, shipment_service, mock_shipment_repo, mock_order_repo
+    ):
+        """Test: shipped -> ready clears shipped_at and reverts order status to delivered."""
+        # Arrange
+        order_ids = ["order-123", "order-456"]
+        shipment = create_mock_shipment(
+            status=ShipmentStatus.SHIPPED.value,
+            order_ids=order_ids,
+            shipped_at=datetime.now(timezone.utc),
+        )
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(status=ShipmentStatus.READY)
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.status == ShipmentStatus.READY.value
+        assert shipment.shipped_at is None
+        # All related orders should be reverted to DELIVERED
+        assert mock_order_repo.update_status.call_count == len(order_ids)
+        for call_args in mock_order_repo.update_status.call_args_list:
+            assert call_args[0][1] == OrderStatus.DELIVERED
+
+    # ===========================================
+    # Multiple orders in one shipment
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_shipped_to_pending_updates_all_orders(
+        self, shipment_service, mock_shipment_repo, mock_order_repo
+    ):
+        """Test: When multiple orders in shipment, all are updated on status change."""
+        # Arrange
+        order_ids = ["order-1", "order-2", "order-3"]
+        shipment = create_mock_shipment(
+            status=ShipmentStatus.SHIPPED.value,
+            order_ids=order_ids,
+            shipped_at=datetime.now(timezone.utc),
+        )
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(status=ShipmentStatus.PENDING)
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert mock_order_repo.update_status.call_count == 3
+        called_order_ids = [call[0][0] for call in mock_order_repo.update_status.call_args_list]
+        assert set(called_order_ids) == set(order_ids)
+
+    # ===========================================
+    # Additional fields on status update
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_tracking_number_updated_on_transition(
+        self, shipment_service, mock_shipment_repo, mock_order_repo
+    ):
+        """Test: Tracking number can be set during status update."""
+        # Arrange
+        shipment = create_mock_shipment(
+            status=ShipmentStatus.READY.value,
+            order_ids=["order-123"],
+        )
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(
+            status=ShipmentStatus.SHIPPED,
+            tracking_number="1234567890",
+            carrier="Yamato",
+        )
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.tracking_number == "1234567890"
+        assert shipment.carrier == "Yamato"
+
+    @pytest.mark.asyncio
+    async def test_note_updated_on_transition(
+        self, shipment_service, mock_shipment_repo
+    ):
+        """Test: Note can be set during status update."""
+        # Arrange
+        shipment = create_mock_shipment(status=ShipmentStatus.PENDING.value)
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(
+            status=ShipmentStatus.READY,
+            note="Ready for pickup",
+        )
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.note == "Ready for pickup"
+
+    # ===========================================
+    # Validation of bidirectional transitions
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_all_transitions_allowed(
+        self, shipment_service, mock_shipment_repo, mock_order_repo
+    ):
+        """Test: All status transitions are allowed in the new bidirectional model."""
+        transitions = [
+            (ShipmentStatus.PENDING, ShipmentStatus.READY),
+            (ShipmentStatus.READY, ShipmentStatus.PENDING),
+            (ShipmentStatus.PENDING, ShipmentStatus.SHIPPED),
+            (ShipmentStatus.READY, ShipmentStatus.SHIPPED),
+            (ShipmentStatus.SHIPPED, ShipmentStatus.PENDING),
+            (ShipmentStatus.SHIPPED, ShipmentStatus.READY),
+        ]
+
+        for from_status, to_status in transitions:
+            # Arrange
+            shipment = create_mock_shipment(
+                shipment_id=f"shipment-{from_status.value}-{to_status.value}",
+                status=from_status.value,
+                order_ids=["order-123"],
+                shipped_at=datetime.now(timezone.utc) if from_status == ShipmentStatus.SHIPPED else None,
+            )
+            mock_shipment_repo.find_by_id.return_value = shipment
+            mock_shipment_repo.update.return_value = shipment
+
+            update_data = ShipmentStatusUpdate(status=to_status)
+
+            # Act - should not raise
+            result = await shipment_service.update_status(
+                shipment_id=shipment.id,
+                data=update_data,
+            )
+
+            # Assert
+            assert shipment.status == to_status.value
+
+    # ===========================================
+    # Edge cases
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_same_status_transition_is_idempotent(
+        self, shipment_service, mock_shipment_repo
+    ):
+        """Test: Transitioning to the same status is allowed (idempotent)."""
+        # Arrange
+        shipment = create_mock_shipment(status=ShipmentStatus.READY.value)
+        mock_shipment_repo.find_by_id.return_value = shipment
+        mock_shipment_repo.update.return_value = shipment
+
+        update_data = ShipmentStatusUpdate(status=ShipmentStatus.READY)
+
+        # Act
+        result = await shipment_service.update_status(
+            shipment_id="shipment-123",
+            data=update_data,
+        )
+
+        # Assert
+        assert shipment.status == ShipmentStatus.READY.value
+        mock_shipment_repo.update.assert_called_once()

--- a/web/src/features/orders/components/order-detail.tsx
+++ b/web/src/features/orders/components/order-detail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/common/status-badge";
@@ -13,10 +14,12 @@ import {
 } from "@/components/ui/table";
 import { Download, Package, User, FileText, ShoppingBag, ExternalLink } from "lucide-react";
 import { apiClient } from "@/lib/api/client";
+import { OrderStatusUpdateDialog } from "./order-status-update-dialog";
 import type { Order, OrderItem } from "@/types/api";
 
 interface OrderDetailProps {
   order: Order;
+  onUpdate?: () => void;
 }
 
 function formatDate(dateString: string): string {
@@ -45,7 +48,9 @@ function formatProductType(type: string): string {
   return typeMap[type] || type;
 }
 
-export function OrderDetail({ order }: OrderDetailProps) {
+export function OrderDetail({ order, onUpdate }: OrderDetailProps) {
+  const [isStatusDialogOpen, setIsStatusDialogOpen] = useState(false);
+
   const handleDownloadManufacturingData = async () => {
     try {
       const data = await apiClient<Blob>(`/orders/${order.id}/manufacturing-data`);
@@ -77,7 +82,16 @@ export function OrderDetail({ order }: OrderDetailProps) {
               <Package className="h-5 w-5" />
               受注情報
             </CardTitle>
-            <StatusBadge status={order.status} />
+            <div className="flex items-center gap-3">
+              <StatusBadge status={order.status} />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsStatusDialogOpen(true)}
+              >
+                ステータス変更
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -280,6 +294,17 @@ export function OrderDetail({ order }: OrderDetailProps) {
           </dl>
         </CardContent>
       </Card>
+
+      {/* ステータス変更ダイアログ */}
+      <OrderStatusUpdateDialog
+        order={order}
+        open={isStatusDialogOpen}
+        onClose={() => setIsStatusDialogOpen(false)}
+        onSuccess={() => {
+          setIsStatusDialogOpen(false);
+          onUpdate?.();
+        }}
+      />
     </div>
   );
 }

--- a/web/src/features/orders/components/order-status-update-dialog.tsx
+++ b/web/src/features/orders/components/order-status-update-dialog.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { apiClient } from "@/lib/api/client";
+import type { Order, OrderStatus } from "@/types/api";
+
+interface OrderStatusUpdateDialogProps {
+  order: Order;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+// Statuses that can be selected manually (shipped is controlled by shipment)
+const statusOptions: { value: OrderStatus; label: string }[] = [
+  { value: "ordered", label: "受注済み" },
+  { value: "manufacturing", label: "製造中" },
+  { value: "delivered", label: "配送準備完了" },
+];
+
+export function OrderStatusUpdateDialog({
+  order,
+  open,
+  onClose,
+  onSuccess,
+}: OrderStatusUpdateDialogProps) {
+  const [newStatus, setNewStatus] = useState<OrderStatus>(order.status);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Check if shipment is already shipped
+  const isShipmentShipped = order.shipment?.status === "shipped";
+
+  const handleStatusUpdate = async () => {
+    if (newStatus === order.status) {
+      onClose();
+      return;
+    }
+
+    setIsUpdating(true);
+    setError(null);
+
+    try {
+      await apiClient(`/orders/${order.id}/status`, {
+        method: "PATCH",
+        body: { status: newStatus },
+      });
+      onSuccess();
+      onClose();
+    } catch (err: unknown) {
+      if (err && typeof err === "object" && "message" in err) {
+        setError(String(err.message));
+      } else if (err && typeof err === "object" && "code" in err) {
+        if (err.code === "INVALID_STATUS_TRANSITION") {
+          setError("このステータス変更は許可されていません。");
+        } else {
+          setError("ステータスの更新に失敗しました。");
+        }
+      } else {
+        setError("ステータスの更新に失敗しました。");
+      }
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const currentStatusLabel =
+    statusOptions.find((opt) => opt.value === order.status)?.label ||
+    order.status;
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>ステータス変更</DialogTitle>
+          <DialogDescription>
+            発注のステータスを変更します。現在のステータス: {currentStatusLabel}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isShipmentShipped && (
+          <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+            この発注の配送は既に発送済みです。ステータスを変更するには、先に配送のステータスを戻してください。
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">新しいステータス</label>
+            <Select
+              value={newStatus}
+              onValueChange={(value) => setNewStatus(value as OrderStatus)}
+              disabled={isShipmentShipped}
+            >
+              <SelectTrigger aria-disabled={isShipmentShipped}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {statusOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleStatusUpdate}
+            disabled={isUpdating || isShipmentShipped}
+          >
+            {isUpdating ? "更新中..." : "更新"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -14,6 +14,22 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }))
 
+// Mock pointer capture methods for Radix UI Select
+if (typeof Element.prototype.hasPointerCapture === 'undefined') {
+  Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false)
+}
+if (typeof Element.prototype.setPointerCapture === 'undefined') {
+  Element.prototype.setPointerCapture = vi.fn()
+}
+if (typeof Element.prototype.releasePointerCapture === 'undefined') {
+  Element.prototype.releasePointerCapture = vi.fn()
+}
+
+// Mock scrollIntoView for Radix UI components
+if (typeof Element.prototype.scrollIntoView === 'undefined') {
+  Element.prototype.scrollIntoView = vi.fn()
+}
+
 // Mock Next.js router
 vi.mock('next/navigation', () => ({
   useRouter: () => ({

--- a/web/tests/unit/order-status-update-dialog.test.tsx
+++ b/web/tests/unit/order-status-update-dialog.test.tsx
@@ -1,0 +1,570 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OrderStatusUpdateDialog } from '@/features/orders/components/order-status-update-dialog'
+import type { Order, OrderStatus } from '@/types/api'
+
+// Mock the API client
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+}))
+
+import { apiClient } from '@/lib/api/client'
+
+const mockApiClient = vi.mocked(apiClient)
+
+const createMockOrder = (overrides: Partial<Order> = {}): Order => ({
+  id: 'order-123',
+  order_number: 'TEST-001',
+  status: 'ordered' as OrderStatus,
+  source: 'test-source',
+  order_source_id: 'source-123',
+  customer_name: 'Test Customer',
+  customer_postal_code: '100-0001',
+  customer_address_prefecture: 'Tokyo',
+  customer_address_city: 'Chiyoda',
+  customer_address_building: null,
+  customer_full_address: 'Tokyo Chiyoda',
+  customer_phone: '090-1234-5678',
+  customer_email: 'test@example.com',
+  ordered_at: '2024-01-01T00:00:00Z',
+  total_price: 1000,
+  items: [],
+  shipment: null,
+  product_id: null,
+  product_name: null,
+  price: null,
+  quantity: null,
+  manufacturing_data: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('OrderStatusUpdateDialog', () => {
+  const mockOnSuccess = vi.fn()
+  const mockOnClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Dialog rendering', () => {
+    it('renders dialog when open is true', () => {
+      const order = createMockOrder()
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(screen.getByText(/ステータス変更/)).toBeInTheDocument()
+    })
+
+    it('does not render dialog when open is false', () => {
+      const order = createMockOrder()
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={false}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('displays current order status', () => {
+      const order = createMockOrder({ status: 'manufacturing' as OrderStatus })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // Multiple elements may contain the status label (description and select)
+      expect(screen.getAllByText(/製造中/).length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('Status options', () => {
+    it('shows ordered, manufacturing, and delivered as selectable options', () => {
+      const order = createMockOrder({ status: 'ordered' as OrderStatus })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // Open the select dropdown
+      const selectTrigger = screen.getByRole('combobox')
+      fireEvent.click(selectTrigger)
+
+      // Check that all valid statuses are available (may have duplicates due to description)
+      expect(screen.getAllByText(/受注済み/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/製造中/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/配送準備完了/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('does not show shipped as a direct option (controlled by shipment)', () => {
+      const order = createMockOrder({ status: 'ordered' as OrderStatus })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      fireEvent.click(selectTrigger)
+
+      // shipped should not be available as a direct transition
+      const options = screen.getAllByRole('option')
+      const shippedOption = options.find(opt => opt.textContent?.toLowerCase().includes('shipped'))
+      expect(shippedOption).toBeUndefined()
+    })
+  })
+
+  describe('Status transitions: ordered -> manufacturing', () => {
+    it('allows transition from ordered to manufacturing', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({ status: 'ordered' as OrderStatus })
+
+      mockApiClient.mockResolvedValueOnce({
+        ...order,
+        status: 'manufacturing',
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // Select manufacturing status
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      const manufacturingOption = screen.getByRole('option', { name: /製造中/ })
+      await user.click(manufacturingOption)
+
+      // Submit the form
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/orders/order-123/status'),
+          expect.objectContaining({
+            method: 'PATCH',
+            body: expect.objectContaining({ status: 'manufacturing' }),
+          })
+        )
+        expect(mockOnSuccess).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Status transitions: manufacturing -> ordered', () => {
+    it('allows reverse transition from manufacturing to ordered', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({ status: 'manufacturing' as OrderStatus })
+
+      mockApiClient.mockResolvedValueOnce({
+        ...order,
+        status: 'ordered',
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      const orderedOption = screen.getByRole('option', { name: /受注済み/ })
+      await user.click(orderedOption)
+
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/orders/order-123/status'),
+          expect.objectContaining({
+            method: 'PATCH',
+            body: expect.objectContaining({ status: 'ordered' }),
+          })
+        )
+        expect(mockOnSuccess).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Status transitions: to delivered (creates shipment)', () => {
+    it('allows transition from ordered to delivered', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({ status: 'ordered' as OrderStatus })
+
+      mockApiClient.mockResolvedValueOnce({
+        ...order,
+        status: 'delivered',
+        shipment: { id: 'shipment-123', status: 'pending' },
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      const deliveredOption = screen.getByRole('option', { name: /配送準備完了/ })
+      await user.click(deliveredOption)
+
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/orders/order-123/status'),
+          expect.objectContaining({
+            method: 'PATCH',
+            body: expect.objectContaining({ status: 'delivered' }),
+          })
+        )
+        expect(mockOnSuccess).toHaveBeenCalled()
+      })
+    })
+
+    it('allows transition from manufacturing to delivered', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({ status: 'manufacturing' as OrderStatus })
+
+      mockApiClient.mockResolvedValueOnce({
+        ...order,
+        status: 'delivered',
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      const deliveredOption = screen.getByRole('option', { name: /配送準備完了/ })
+      await user.click(deliveredOption)
+
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/orders/order-123/status'),
+          expect.objectContaining({
+            method: 'PATCH',
+            body: expect.objectContaining({ status: 'delivered' }),
+          })
+        )
+      })
+    })
+  })
+
+  describe('Status transitions: from delivered (deletes shipment)', () => {
+    it('allows transition from delivered to ordered', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({
+        status: 'delivered' as OrderStatus,
+        shipment: { id: 'shipment-123', status: 'pending', tracking_number: null, carrier: null },
+      })
+
+      mockApiClient.mockResolvedValueOnce({
+        ...order,
+        status: 'ordered',
+        shipment: null,
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      const orderedOption = screen.getByRole('option', { name: /受注済み/ })
+      await user.click(orderedOption)
+
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/orders/order-123/status'),
+          expect.objectContaining({
+            method: 'PATCH',
+            body: expect.objectContaining({ status: 'ordered' }),
+          })
+        )
+      })
+    })
+
+    it('allows transition from delivered to manufacturing', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({
+        status: 'delivered' as OrderStatus,
+        shipment: { id: 'shipment-123', status: 'pending', tracking_number: null, carrier: null },
+      })
+
+      mockApiClient.mockResolvedValueOnce({
+        ...order,
+        status: 'manufacturing',
+        shipment: null,
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      const manufacturingOption = screen.getByRole('option', { name: /製造中/ })
+      await user.click(manufacturingOption)
+
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/orders/order-123/status'),
+          expect.objectContaining({
+            method: 'PATCH',
+            body: expect.objectContaining({ status: 'manufacturing' }),
+          })
+        )
+      })
+    })
+  })
+
+  describe('Warning for shipped shipment', () => {
+    it('shows warning when trying to revert from delivered with shipped shipment', () => {
+      const order = createMockOrder({
+        status: 'delivered' as OrderStatus,
+        shipment: { id: 'shipment-123', status: 'shipped', tracking_number: '12345', carrier: 'Yamato' },
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // Should show a warning that shipment is already shipped
+      expect(screen.getByText(/発送済み/)).toBeInTheDocument()
+    })
+
+    it('disables status change when shipment is shipped', () => {
+      const order = createMockOrder({
+        status: 'delivered' as OrderStatus,
+        shipment: { id: 'shipment-123', status: 'shipped', tracking_number: '12345', carrier: 'Yamato' },
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // The select or submit should be disabled
+      const selectTrigger = screen.getByRole('combobox')
+      expect(selectTrigger).toHaveAttribute('aria-disabled', 'true')
+    })
+  })
+
+  describe('Error handling', () => {
+    it('shows error message when API call fails', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({ status: 'ordered' as OrderStatus })
+
+      mockApiClient.mockRejectedValueOnce(new Error('Network error'))
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      const manufacturingOption = screen.getByRole('option', { name: /製造中/ })
+      await user.click(manufacturingOption)
+
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(screen.getByText(/Network error/)).toBeInTheDocument()
+      })
+    })
+
+    it('shows validation error for invalid transition', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({ status: 'ordered' as OrderStatus })
+
+      // Throw error without message to test code-based error handling
+      mockApiClient.mockRejectedValueOnce({
+        status: 400,
+        code: 'INVALID_STATUS_TRANSITION',
+      })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // Simulate trying an invalid transition (shouldn't happen with proper UI, but test the error handling)
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      // Select a different status to trigger API call
+      const manufacturingOption = screen.getByRole('option', { name: /製造中/ })
+      await user.click(manufacturingOption)
+
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(screen.getByText(/許可されていません/)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Dialog interactions', () => {
+    it('calls onClose when cancel button is clicked', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder()
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const cancelButton = screen.getByRole('button', { name: /キャンセル/ })
+      await user.click(cancelButton)
+
+      expect(mockOnClose).toHaveBeenCalled()
+    })
+
+    it('shows loading state while submitting', async () => {
+      const user = userEvent.setup()
+      const order = createMockOrder({ status: 'ordered' as OrderStatus })
+
+      // Make the API call hang
+      mockApiClient.mockImplementationOnce(() => new Promise(() => {}))
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      await user.click(selectTrigger)
+      const manufacturingOption = screen.getByRole('option', { name: /製造中/ })
+      await user.click(manufacturingOption)
+
+      const submitButton = screen.getByRole('button', { name: /更新/ })
+      await user.click(submitButton)
+
+      // Should show loading state
+      await waitFor(() => {
+        expect(screen.getByText(/更新中/)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Japanese labels', () => {
+    it('displays Japanese status labels', () => {
+      const order = createMockOrder({ status: 'ordered' as OrderStatus })
+
+      render(
+        <OrderStatusUpdateDialog
+          order={order}
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const selectTrigger = screen.getByRole('combobox')
+      fireEvent.click(selectTrigger)
+
+      // Should have Japanese labels
+      // (Actual labels depend on implementation, testing the pattern)
+      expect(
+        screen.queryByText(/ordered|manufacturing|配送準備完了/) ||
+        screen.queryByText(/ordered|manufacturing|配送準備完了/)
+      ).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- 発注ステータス（発注中・製造中・納入済）間の双方向遷移を許可
- 配送ステータス（配送準備待ち・配送準備完了・発送完了）間の双方向遷移を許可
- 納入済から戻す場合は関連配送レコードを削除
- 発送完了から戻す場合は関連受注ステータスを納入済に戻し、shipped_atをクリア
- 受注詳細画面にステータス変更ダイアログを追加

## 変更ファイル

**バックエンド:**
- `api/app/repositories/shipment_repository.py` - `delete_by_order_id` メソッド追加
- `api/app/services/order_service.py` - delivered からの戻し時の配送削除ロジック
- `api/app/services/shipment_service.py` - 双方向遷移許可 + shipped 戻し時の受注連動

**フロントエンド:**
- `web/src/features/orders/components/order-status-update-dialog.tsx` - 新規ダイアログ
- `web/src/features/orders/components/order-detail.tsx` - ステータス変更ボタン追加

## Test plan

- [x] バックエンドユニットテスト（23件パス）
- [x] バックエンド統合テスト（21件パス）
- [x] フロントエンドテスト（18件パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)