### PR TITLE
feat: ステッカー商品から「クリア」カラーを削除 (FEAT-0007)

### DIFF
--- a/.claude/specs/FEAT-0007.yaml
+++ b/.claude/specs/FEAT-0007.yaml
@@ -1,0 +1,122 @@
+id: FEAT-0007
+summary: |
+  ステッカー商品タイプから「クリア」カラーを削除し、
+  「ホワイト」のみの単一カラー体制にする。
+
+background:
+  why: |
+    ビジネス要件の変更により、ステッカー商品の「クリア」タイプが不要となった。
+    システム全体から「クリア」カラーを削除し、「ホワイト」のみをサポートする。
+  who: 管理者（商品マスタ管理者）
+  when: |
+    ステッカー商品の登録・受注・価格計算時に、
+    「ホワイト」カラーのみが選択肢として提供される。
+
+scope:
+  includes:
+    - バックエンド StickerColor Enum から CLEAR を削除（Python: api/app/models/order.py）
+    - バックエンド STICKER_PRICES 辞書から CLEAR の価格エントリを削除（api/app/services/external_service.py）
+    - シードデータからステッカー「クリア」の商品データを削除（api/scripts/seed.py）
+    - APIドキュメントからステッカー「クリア」の記述を削除（api/docs/order-api.md）
+    - 既存データ対応方針の明示
+  excludes:
+    - DBマイグレーション（color列はVARCHAR型のためENUM制約なし、マイグレーション不要）
+    - フロントエンドの商品フォーム変更（color はフリーテキスト入力のため、Enum に依存していない）
+    - TypeScript型定義の変更（StickerColor 型はフロントエンドに存在しない）
+  prerequisites:
+    - ステッカー商品タイプのカラーが StickerColor Enum で定義されている
+    - DBの products.color はVARCHAR(50) 型であり、DB側にENUM制約がない
+
+input_output:
+  inputs:
+    - name: ステッカーの color 属性
+      type: string
+      required: true
+      validation: "ホワイト" のみ許可（"クリア" は拒否）
+  outputs:
+    - name: ステッカー商品オプション
+      type: ProductOptionsResponse
+      description: color リストに「ホワイト」のみが含まれる
+    - name: ステッカー価格計算
+      type: PriceCalculationResponse
+      description: color="ホワイト" の場合のみ価格計算が成功する
+  state_changes:
+    - StickerColor Enum から CLEAR メンバーが削除される
+    - STICKER_PRICES 辞書から CLEAR の価格が削除される
+    - シードデータからステッカー「クリア」が削除される（ステッカーは1種類に）
+
+acceptance_criteria:
+  - id: AC-001
+    description: StickerColor Enum に「クリア」が存在しないこと
+    test_type: unit
+    given: StickerColor Enum の定義
+    when: StickerColor のメンバーを列挙する
+    then: WHITE のみが存在し、CLEAR は存在しない
+
+  - id: AC-002
+    description: ステッカーの受注バリデーションで「クリア」が拒否されること
+    test_type: unit
+    given: ステッカー商品の受注データ
+    when: color に「クリア」を指定して受注バリデーションを実行する
+    then: ValidationError が発生し、有効な色は「ホワイト」のみと示される
+
+  - id: AC-003
+    description: ステッカーの受注バリデーションで「ホワイト」が受け付けられること
+    test_type: unit
+    given: ステッカー商品の受注データ
+    when: color に「ホワイト」を指定して受注バリデーションを実行する
+    then: バリデーションが成功する
+
+  - id: AC-004
+    description: ステッカーの商品オプション取得で「ホワイト」のみ返ること
+    test_type: unit
+    given: ExternalService の get_product_options
+    when: product_type に STICKER を指定する
+    then: color リストに「ホワイト」のみが含まれ、「クリア」は含まれない
+
+  - id: AC-005
+    description: ステッカーの価格計算で「クリア」が拒否されること
+    test_type: unit
+    given: ExternalService の calculate_price
+    when: product_type=sticker, color=クリア で価格計算を実行する
+    then: ValidationError が発生する
+
+  - id: AC-006
+    description: ステッカーの価格計算で「ホワイト」が成功すること
+    test_type: unit
+    given: ExternalService の calculate_price
+    when: product_type=sticker, color=ホワイト で価格計算を実行する
+    then: 単価79円で価格計算が成功する
+
+  - id: AC-007
+    description: STICKER_PRICES に「クリア」の価格が存在しないこと
+    test_type: unit
+    given: STICKER_PRICES 辞書
+    when: 辞書のキーを確認する
+    then: 「ホワイト」のみが存在し、「クリア」は存在しない
+
+constraints:
+  performance: []
+  security:
+    - 管理者のみ商品マスタの編集が可能（既存制約、変更なし）
+  compatibility:
+    - 既存の「クリア」カラーが設定されたステッカー商品マスタ（products テーブル）は、
+      シードデータのリセット時に削除される。本番環境では手動で is_active=false に設定するか、
+      color を「ホワイト」に更新する運用対応とする。
+    - 既存の受注データ（order_items テーブル）の color="クリア" は過去データとしてそのまま保持する。
+      Enum バリデーションは新規受注時のみ適用されるため、既存データに影響しない。
+
+assumptions:
+  - 「クリア」カラーのステッカー商品が本番環境に登録されている可能性があるが、
+    シードデータの削除のみで対応し、マイグレーションでのデータ更新は行わない。
+    本番運用上の対応は運用チームに委ねる。
+  - フロントエンドの商品フォームは color をフリーテキスト入力としているため、
+    Enum の変更はフロントエンドに直接影響しない。
+  - DB の color カラムは VARCHAR 型であり、DB レベルでの制約変更は不要。
+  - ステッカーの価格体系は「ホワイト」= 79円のみとなる。
+
+success_metrics:
+  - StickerColor Enum から CLEAR が削除されている
+  - ステッカー受注時に「クリア」を指定するとバリデーションエラーになる
+  - ステッカーの商品オプション API が「ホワイト」のみを返す
+  - 全テスト（ユニット・統合）がパスする

--- a/api/app/models/order.py
+++ b/api/app/models/order.py
@@ -84,7 +84,6 @@ class StickerSize(str, Enum):
 class StickerColor(str, Enum):
     """ステッカーカラー."""
 
-    CLEAR = "クリア"
     WHITE = "ホワイト"
 
 

--- a/api/app/services/external_service.py
+++ b/api/app/services/external_service.py
@@ -40,7 +40,6 @@ ACRYLIC_STAND_PRICES = {
 }
 
 STICKER_PRICES = {
-    StickerColor.CLEAR.value: 105,
     StickerColor.WHITE.value: 79,
 }
 

--- a/api/docs/order-api.md
+++ b/api/docs/order-api.md
@@ -192,7 +192,7 @@ POST /api/v1/orders
 
 - **ステッカー** (`product_type: sticker`)
   - `size`: `100x100mm`
-  - `color`: `クリア`, `ホワイト`
+  - `color`: `ホワイト`
 
 - **トートバッグ** (`product_type: tote_bag`)
   - `size`: `M`
@@ -540,7 +540,6 @@ Tシャツ（`product_type: tshirt`）の場合、以下の値のみ許可され
 
 | 値 | 説明 | 原価 |
 |----|------|------|
-| クリア | 透明 | 105円 |
 | ホワイト | 白 | 79円 |
 
 ### トートバッグ属性値
@@ -629,7 +628,7 @@ GET /api/v1/external/product-options/{product_type}
 {
   "product_type": "sticker",
   "size": ["100x100mm"],
-  "color": ["クリア", "ホワイト"],
+  "color": ["ホワイト"],
   "position": []
 }
 ```
@@ -735,7 +734,7 @@ POST /api/v1/external/price-calculation
 - `tshirt`: size=S/M/L/XL, color=白, position=正面
 - `acrylic_keychain`: size=50x50mm/70x70mm/100x100mm
 - `acrylic_stand`: size=50x50mm/70x70mm/100x100mm
-- `sticker`: size=100x100mm, color=クリア/ホワイト
+- `sticker`: size=100x100mm, color=ホワイト
 - `tote_bag`: size=M, color=ナチュラル, position=正面
 
 ### レスポンス例
@@ -820,7 +819,7 @@ curl -X POST "https://api.example.com/api/v1/external/price-calculation" \
   -d '{
     "product_type": "sticker",
     "size": "100x100mm",
-    "color": "クリア",
+    "color": "ホワイト",
     "quantity": 10
   }'
 ```
@@ -1042,6 +1041,7 @@ if ($statusCode === 201) {
 
 | バージョン | 日付 | 内容 |
 |-----------|------|------|
+| 3.2.0 | 2026-02-23 | ステッカーのカラーから「クリア」を削除。「ホワイト」のみの単一カラー体制に変更。(FEAT-0007) |
 | 3.1.0 | 2026-02-14 | レスポンスに `source` および `order_source_id` フィールド追加。受注元管理がDB管理に完全移行。 |
 | 3.0.0 | 2026-02-14 | **破壊的変更**: 住所フィールド正規化。`address` を削除し、`address_prefecture` + `address_city` を必須に。レスポンスの `customer_address` を `customer_full_address` に変更（自動生成）。 |
 | 2.3.0 | 2026-02-14 | 住所分割フィールド追加（address_prefecture, address_city, address_building）。配送CSVエクスポート対応。 |

--- a/api/scripts/seed.py
+++ b/api/scripts/seed.py
@@ -272,19 +272,7 @@ async def seed_products(session: AsyncSession, manufacturers: dict[str, Manufact
             "order_limit": None,
             "is_active": True,
         },
-        # ステッカー (2種類)
-        {
-            "id": generate_uuid(),
-            "product_type": ProductType.STICKER.value,
-            "size": "100x100mm",
-            "position": None,
-            "color": "クリア",
-            "manufacturer_id": seedot_id,
-            "cost": 105,
-            "lead_time_days": 10,
-            "order_limit": None,
-            "is_active": True,
-        },
+        # ステッカー (1種類)
         {
             "id": generate_uuid(),
             "product_type": ProductType.STICKER.value,

--- a/api/tests/integration/test_sticker_color_removal.py
+++ b/api/tests/integration/test_sticker_color_removal.py
@@ -1,0 +1,204 @@
+"""ステッカー「クリア」カラー削除の統合テスト
+
+FEAT-0007: ステッカー商品タイプから「クリア」カラーを削除し、
+「ホワイト」のみの単一カラー体制にする。
+
+このテストは、外部API経由でステッカーのカラーバリデーションが
+正しく動作することを検証します。
+
+テスト対象エンドポイント:
+- GET  /api/v1/external/product-options/sticker
+- POST /api/v1/external/price-calculation
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid import uuid4
+
+
+class TestStickerColorRemovalAPI:
+    """ステッカーカラー削除の統合テスト（API経由）"""
+
+    @pytest.fixture
+    async def api_key_headers(self, db_session: AsyncSession):
+        """テスト用のAPIキーを作成し、ヘッダーとして返す"""
+        source_id = str(uuid4())
+        source_code = f"STICKER{source_id[:6].upper()}"
+        api_key = f"test-sticker-api-key-{source_id}"
+
+        await db_session.execute(
+            text("""
+                INSERT INTO order_sources (id, code, name, api_key, phone, postal_code, address_prefecture, address_city, is_active, created_at, updated_at)
+                VALUES (:id, :code, :name, :api_key, :phone, :postal_code, :address_prefecture, :address_city, :is_active, NOW(), NOW())
+            """),
+            {
+                "id": source_id,
+                "code": source_code,
+                "name": "Sticker Test Source",
+                "api_key": api_key,
+                "phone": "090-0000-0000",
+                "postal_code": "100-0001",
+                "address_prefecture": "東京都",
+                "address_city": "千代田区",
+                "is_active": True,
+            }
+        )
+        await db_session.commit()
+
+        yield {"X-API-Key": api_key}
+
+    @pytest.mark.asyncio
+    async def test_product_options_sticker_returns_only_white(
+        self,
+        client: AsyncClient,
+        api_key_headers: dict,
+    ):
+        """AC-004 統合: ステッカーの商品オプションAPIが「ホワイト」のみ返すこと
+
+        given: 外部API認証済み
+        when: GET /api/v1/external/product-options/sticker を呼び出す
+        then: color リストに「ホワイト」のみが含まれ、「クリア」は含まれない
+        """
+        response = await client.get(
+            "/api/v1/external/product-options/sticker",
+            headers=api_key_headers,
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200 OK, but got {response.status_code}: {response.text}"
+        )
+
+        data = response.json()
+        assert data["product_type"] == "sticker"
+        assert data["color"] == ["ホワイト"], (
+            f"ステッカーのカラーは ['ホワイト'] のみであるべきですが、{data['color']} が返されました。"
+        )
+        assert "クリア" not in data["color"], (
+            "ステッカーのカラーに「クリア」が含まれています。"
+        )
+
+    @pytest.mark.asyncio
+    async def test_price_calculation_sticker_rejects_clear(
+        self,
+        client: AsyncClient,
+        api_key_headers: dict,
+    ):
+        """AC-005 統合: ステッカーの価格計算APIで「クリア」が拒否されること
+
+        given: 外部API認証済み
+        when: POST /api/v1/external/price-calculation で color=クリア を指定
+        then: 400エラーが返される
+        """
+        response = await client.post(
+            "/api/v1/external/price-calculation",
+            headers={**api_key_headers, "Content-Type": "application/json"},
+            json={
+                "product_type": "sticker",
+                "size": "100x100mm",
+                "color": "クリア",
+                "quantity": 1,
+            },
+        )
+
+        assert response.status_code == 400, (
+            f"Expected 400 Bad Request, but got {response.status_code}: {response.text}"
+        )
+
+        data = response.json()
+        assert "error" in data, "Expected error response"
+        assert data["error"]["code"] == "VALIDATION_ERROR", (
+            f"Expected error code 'VALIDATION_ERROR', but got '{data['error']['code']}'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_price_calculation_sticker_accepts_white(
+        self,
+        client: AsyncClient,
+        api_key_headers: dict,
+    ):
+        """AC-006 統合: ステッカーの価格計算APIで「ホワイト」が成功すること
+
+        given: 外部API認証済み
+        when: POST /api/v1/external/price-calculation で color=ホワイト を指定
+        then: 単価79円で価格計算が成功する
+        """
+        response = await client.post(
+            "/api/v1/external/price-calculation",
+            headers={**api_key_headers, "Content-Type": "application/json"},
+            json={
+                "product_type": "sticker",
+                "size": "100x100mm",
+                "color": "ホワイト",
+                "quantity": 5,
+            },
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200 OK, but got {response.status_code}: {response.text}"
+        )
+
+        data = response.json()
+        assert data["product_type"] == "sticker"
+        assert data["color"] == "ホワイト"
+        assert data["unit_price"] == 79, (
+            f"ステッカー「ホワイト」の単価は79円であるべきですが、{data['unit_price']}円です。"
+        )
+        assert data["total_price"] == 79 * 5, (
+            f"合計金額は {79 * 5}円であるべきですが、{data['total_price']}円です。"
+        )
+        assert data["quantity"] == 5
+
+    @pytest.mark.asyncio
+    async def test_price_calculation_sticker_white_single(
+        self,
+        client: AsyncClient,
+        api_key_headers: dict,
+    ):
+        """AC-006 統合: ステッカー「ホワイト」の単品価格計算
+
+        given: 外部API認証済み
+        when: POST /api/v1/external/price-calculation で color=ホワイト, quantity=1
+        then: 単価79円、合計79円で成功する
+        """
+        response = await client.post(
+            "/api/v1/external/price-calculation",
+            headers={**api_key_headers, "Content-Type": "application/json"},
+            json={
+                "product_type": "sticker",
+                "size": "100x100mm",
+                "color": "ホワイト",
+                "quantity": 1,
+            },
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200 OK, but got {response.status_code}: {response.text}"
+        )
+
+        data = response.json()
+        assert data["unit_price"] == 79
+        assert data["total_price"] == 79
+
+    @pytest.mark.asyncio
+    async def test_product_options_sticker_returns_correct_size(
+        self,
+        client: AsyncClient,
+        api_key_headers: dict,
+    ):
+        """統合: ステッカーの商品オプションAPIがサイズも正しく返すこと
+
+        given: 外部API認証済み
+        when: GET /api/v1/external/product-options/sticker を呼び出す
+        then: size リストに「100x100mm」のみが含まれる
+        """
+        response = await client.get(
+            "/api/v1/external/product-options/sticker",
+            headers=api_key_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["size"] == ["100x100mm"]
+        assert data["position"] == []

--- a/api/tests/unit/test_sticker_color_removal.py
+++ b/api/tests/unit/test_sticker_color_removal.py
@@ -1,0 +1,265 @@
+"""ステッカー「クリア」カラー削除のユニットテスト
+
+FEAT-0007: ステッカー商品タイプから「クリア」カラーを削除し、
+「ホワイト」のみの単一カラー体制にする。
+
+テスト対象:
+- StickerColor Enum
+- ExternalService.get_product_options (STICKER)
+- ExternalService.calculate_price (STICKER)
+- STICKER_PRICES 辞書
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from app.models.order import StickerColor
+from app.models.product import ProductType
+from app.schemas.external import PriceCalculationRequest
+from app.services.external_service import ExternalService, STICKER_PRICES
+from app.utils.exceptions import ValidationError
+
+
+class TestStickerColorEnum:
+    """StickerColor Enum のテスト"""
+
+    def test_ac001_sticker_color_has_no_clear(self):
+        """AC-001: StickerColor Enum に「クリア」が存在しないこと
+
+        given: StickerColor Enum の定義
+        when: StickerColor のメンバーを列挙する
+        then: WHITE のみが存在し、CLEAR は存在しない
+        """
+        member_names = [member.name for member in StickerColor]
+        assert "CLEAR" not in member_names, (
+            "StickerColor に CLEAR メンバーが存在します。削除が必要です。"
+        )
+
+    def test_ac001_sticker_color_has_only_white(self):
+        """AC-001: StickerColor Enum に WHITE のみが存在すること
+
+        given: StickerColor Enum の定義
+        when: StickerColor のメンバーを列挙する
+        then: WHITE のみが存在する
+        """
+        member_names = [member.name for member in StickerColor]
+        assert member_names == ["WHITE"], (
+            f"StickerColor のメンバーは WHITE のみであるべきですが、{member_names} が存在します。"
+        )
+
+    def test_ac001_sticker_color_clear_value_is_not_valid(self):
+        """AC-001: StickerColor Enum に「クリア」値が存在しないこと
+
+        given: StickerColor Enum の定義
+        when: 「クリア」値でEnumを生成しようとする
+        then: ValueError が発生する
+        """
+        with pytest.raises(ValueError):
+            StickerColor("クリア")
+
+    def test_ac001_sticker_color_white_value_is_valid(self):
+        """AC-001: StickerColor Enum に「ホワイト」値が有効であること
+
+        given: StickerColor Enum の定義
+        when: 「ホワイト」値でEnumを生成する
+        then: 正常に生成される
+        """
+        color = StickerColor("ホワイト")
+        assert color == StickerColor.WHITE
+        assert color.value == "ホワイト"
+
+
+class TestStickerOrderValidation:
+    """ステッカー受注バリデーションのテスト"""
+
+    @pytest.fixture
+    def service(self):
+        """ExternalService のインスタンス（モック依存）"""
+        mock_product_repo = AsyncMock()
+        mock_order_repo = AsyncMock()
+        return ExternalService(mock_product_repo, mock_order_repo)
+
+    def test_ac002_sticker_validation_rejects_clear_color(self, service: ExternalService):
+        """AC-002: ステッカーの受注バリデーションで「クリア」が拒否されること
+
+        given: ステッカー商品の受注データ
+        when: color に「クリア」を指定して受注バリデーションを実行する
+        then: ValidationError が発生し、有効な色は「ホワイト」のみと示される
+        """
+        request = PriceCalculationRequest(
+            product_type=ProductType.STICKER,
+            size="100x100mm",
+            color="クリア",
+            quantity=1,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            # calculate_price は同期的にバリデーションを行い、
+            # _calculate_sticker_price を呼ぶ（同期メソッド）
+            service._calculate_sticker_price(request)
+
+        # エラーメッセージに「ホワイト」が含まれ、有効な色として示されること
+        assert "ホワイト" in exc_info.value.message, (
+            f"エラーメッセージに「ホワイト」が含まれるべきですが: {exc_info.value.message}"
+        )
+        # 「クリア」が有効な色として含まれないこと
+        assert "クリア" not in exc_info.value.message or "Invalid color 'クリア'" in exc_info.value.message, (
+            f"エラーメッセージが不適切です: {exc_info.value.message}"
+        )
+
+    def test_ac003_sticker_validation_accepts_white_color(self, service: ExternalService):
+        """AC-003: ステッカーの受注バリデーションで「ホワイト」が受け付けられること
+
+        given: ステッカー商品の受注データ
+        when: color に「ホワイト」を指定して受注バリデーションを実行する
+        then: バリデーションが成功する
+        """
+        request = PriceCalculationRequest(
+            product_type=ProductType.STICKER,
+            size="100x100mm",
+            color="ホワイト",
+            quantity=1,
+        )
+
+        # ValidationError が発生しないこと
+        result = service._calculate_sticker_price(request)
+        assert result.color == "ホワイト"
+        assert result.product_type == ProductType.STICKER
+
+
+class TestStickerProductOptions:
+    """ステッカー商品オプション取得のテスト"""
+
+    @pytest.fixture
+    def service(self):
+        """ExternalService のインスタンス（モック依存）"""
+        mock_product_repo = AsyncMock()
+        mock_order_repo = AsyncMock()
+        return ExternalService(mock_product_repo, mock_order_repo)
+
+    def test_ac004_sticker_options_returns_only_white(self, service: ExternalService):
+        """AC-004: ステッカーの商品オプション取得で「ホワイト」のみ返ること
+
+        given: ExternalService の get_product_options
+        when: product_type に STICKER を指定する
+        then: color リストに「ホワイト」のみが含まれ、「クリア」は含まれない
+        """
+        result = service.get_product_options(ProductType.STICKER)
+
+        assert result.product_type == ProductType.STICKER
+        assert result.color == ["ホワイト"], (
+            f"ステッカーのカラーは ['ホワイト'] のみであるべきですが、{result.color} が返されました。"
+        )
+        assert "クリア" not in result.color, (
+            "ステッカーのカラーに「クリア」が含まれています。削除が必要です。"
+        )
+
+
+class TestStickerPriceCalculation:
+    """ステッカー価格計算のテスト"""
+
+    @pytest.fixture
+    def service(self):
+        """ExternalService のインスタンス（モック依存）"""
+        mock_product_repo = AsyncMock()
+        mock_order_repo = AsyncMock()
+        return ExternalService(mock_product_repo, mock_order_repo)
+
+    def test_ac005_sticker_price_rejects_clear_color(self, service: ExternalService):
+        """AC-005: ステッカーの価格計算で「クリア」が拒否されること
+
+        given: ExternalService の calculate_price
+        when: product_type=sticker, color=クリア で価格計算を実行する
+        then: ValidationError が発生する
+        """
+        request = PriceCalculationRequest(
+            product_type=ProductType.STICKER,
+            size="100x100mm",
+            color="クリア",
+            quantity=1,
+        )
+
+        with pytest.raises(ValidationError):
+            service._calculate_sticker_price(request)
+
+    def test_ac006_sticker_price_succeeds_with_white_at_79_yen(self, service: ExternalService):
+        """AC-006: ステッカーの価格計算で「ホワイト」が成功すること
+
+        given: ExternalService の calculate_price
+        when: product_type=sticker, color=ホワイト で価格計算を実行する
+        then: 単価79円で価格計算が成功する
+        """
+        request = PriceCalculationRequest(
+            product_type=ProductType.STICKER,
+            size="100x100mm",
+            color="ホワイト",
+            quantity=3,
+        )
+
+        result = service._calculate_sticker_price(request)
+
+        assert result.unit_price == 79, (
+            f"ステッカー「ホワイト」の単価は79円であるべきですが、{result.unit_price}円です。"
+        )
+        assert result.total_price == 79 * 3, (
+            f"合計金額は {79 * 3}円であるべきですが、{result.total_price}円です。"
+        )
+        assert result.quantity == 3
+
+    def test_ac006_sticker_price_white_single_quantity(self, service: ExternalService):
+        """AC-006: ステッカー「ホワイト」の単品価格が79円であること
+
+        given: ExternalService の calculate_price
+        when: product_type=sticker, color=ホワイト, quantity=1 で価格計算を実行する
+        then: 単価79円、合計79円で成功する
+        """
+        request = PriceCalculationRequest(
+            product_type=ProductType.STICKER,
+            size="100x100mm",
+            color="ホワイト",
+            quantity=1,
+        )
+
+        result = service._calculate_sticker_price(request)
+
+        assert result.unit_price == 79
+        assert result.total_price == 79
+
+
+class TestStickerPricesDictionary:
+    """STICKER_PRICES 辞書のテスト"""
+
+    def test_ac007_sticker_prices_has_no_clear(self):
+        """AC-007: STICKER_PRICES に「クリア」の価格が存在しないこと
+
+        given: STICKER_PRICES 辞書
+        when: 辞書のキーを確認する
+        then: 「ホワイト」のみが存在し、「クリア」は存在しない
+        """
+        assert "クリア" not in STICKER_PRICES, (
+            "STICKER_PRICES に「クリア」のエントリが存在します。削除が必要です。"
+        )
+
+    def test_ac007_sticker_prices_has_only_white(self):
+        """AC-007: STICKER_PRICES に「ホワイト」のみが存在すること
+
+        given: STICKER_PRICES 辞書
+        when: 辞書のキーを確認する
+        then: 「ホワイト」のキーのみが存在する
+        """
+        assert list(STICKER_PRICES.keys()) == ["ホワイト"], (
+            f"STICKER_PRICES のキーは ['ホワイト'] のみであるべきですが、"
+            f"{list(STICKER_PRICES.keys())} です。"
+        )
+
+    def test_ac007_sticker_prices_white_is_79(self):
+        """AC-007: STICKER_PRICES の「ホワイト」の価格が79円であること
+
+        given: STICKER_PRICES 辞書
+        when: 「ホワイト」の価格を確認する
+        then: 79円である
+        """
+        assert STICKER_PRICES.get("ホワイト") == 79, (
+            f"STICKER_PRICES の「ホワイト」の価格は79円であるべきですが、"
+            f"{STICKER_PRICES.get('ホワイト')}円です。"
+        )


### PR DESCRIPTION
## Summary
- ステッカー商品タイプから「クリア」カラーを削除し、「ホワイト」のみの単一カラー体制に変更
- StickerColor Enum から CLEAR メンバーを削除
- STICKER_PRICES 辞書から CLEAR の価格エントリ（105円）を削除
- シードデータからステッカー「クリア」の商品データを削除
- APIドキュメント（order-api.md）の6箇所を更新

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `api/app/models/order.py` | StickerColor Enum から `CLEAR = "クリア"` を削除 |
| `api/app/services/external_service.py` | STICKER_PRICES から CLEAR の価格エントリを削除 |
| `api/scripts/seed.py` | ステッカー「クリア」の商品シードデータを削除 |
| `api/docs/order-api.md` | ドキュメント6箇所を更新、変更履歴追記 |

## 変更不要の確認済み
- `order_service.py`: StickerColor Enum バリデーションが自動追随するため変更不要
- フロントエンド: color はフリーテキスト入力のため影響なし
- DBマイグレーション: color カラムは VARCHAR 型のため不要

## Test plan
- [x] ユニットテスト 13件 PASS（AC-001〜AC-007 カバー）
- [x] 統合テスト 5件 PASS（API経由の検証）
- [x] 品質ゲート 6層検証 PASS

## 既存データへの影響
- 既存の受注データ（order_items.color="クリア"）は過去データとして保持
- 本番環境の商品マスタに「クリア」がある場合は運用対応（is_active=false or color更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)