### PR TITLE
feat: 受注元（OrderSource）CRUD管理ページを実装 (FEAT-0014)

### DIFF
--- a/.claude/specs/FEAT-0015-order-sources.yaml
+++ b/.claude/specs/FEAT-0015-order-sources.yaml
@@ -1,0 +1,257 @@
+id: FEAT-0015
+summary: 管理者が受注元（外部販売サイト）を一覧表示・登録・編集・削除できる管理ページを使える
+
+background:
+  why: |
+    現在、OrderSourceモデル・リポジトリは存在するが、管理用のAPIエンドポイントとフロントエンドUIが存在しない。
+    /order-sources および /settings/order-sources にアクセスすると404になる。
+    受注元の登録・変更・削除が画面からできず、データベース直接操作に依存している状態。
+    管理画面から受注元をCRUD操作できるようにすることで、運用効率を大幅に改善する。
+  who: 管理者（admin）
+  when: |
+    - 新しい外部販売サイト（受注元）を登録するとき
+    - 既存の受注元情報（名前、住所、電話番号、APIキー等）を変更するとき
+    - 受注元を無効化・削除するとき
+    - 登録済みの受注元一覧を確認するとき
+
+scope:
+  includes:
+    - バックエンドAPI: 受注元CRUD エンドポイント（GET一覧, GET詳細, POST作成, PATCH更新, DELETE削除）
+    - バックエンドAPI: 受注元スキーマ（OrderSourceCreate, OrderSourceUpdate, OrderSourceResponse, OrderSourceListResponse）
+    - バックエンドAPI: 受注元サービス（OrderSourceService）
+    - フロントエンド: /order-sources ページ（受注元一覧表示、登録ダイアログ、編集ダイアログ、削除確認ダイアログ）
+    - フロントエンド: /settings/order-sources ページ（設定ページ内の受注元管理へのナビゲーションまたは同等UI）
+    - フロントエンド: サイドバーに「受注元」メニューを追加
+    - ユニットテスト・統合テストの追加
+  excludes:
+    - 受注元とオーダーの紐づけUI（既存のAPIキー認証で自動紐づけ済み）
+    - APIキーの自動生成機能（管理者が手動入力する想定）
+    - 受注元の権限管理（管理者のみアクセス可能、既存の認可機構を利用）
+  prerequisites:
+    - OrderSourceモデル（api/app/models/order_source.py）が存在すること
+    - OrderSourceRepository（api/app/repositories/order_source_repository.py）が存在すること
+    - 依存性注入（get_order_source_repository）が設定済みであること
+
+input_output:
+  inputs:
+    - name: name
+      type: string
+      required: true
+      validation: 1〜100文字、受注元の表示名
+    - name: code
+      type: string
+      required: true
+      validation: 1〜50文字、ユニーク、受注元コード（例: "RKSYO"）
+    - name: api_key
+      type: string
+      required: true
+      validation: 1〜100文字、ユニーク、外部APIキー
+    - name: phone
+      type: string
+      required: true
+      validation: 1〜20文字、電話番号
+    - name: postal_code
+      type: string
+      required: true
+      validation: 1〜10文字、郵便番号
+    - name: address_prefecture
+      type: string
+      required: true
+      validation: 1〜50文字、都道府県
+    - name: address_city
+      type: string
+      required: true
+      validation: 1文字以上、市区町村以降
+    - name: address_building
+      type: string
+      required: false
+      validation: 最大200文字、建物名等
+    - name: is_active
+      type: boolean
+      required: false
+      validation: 有効/無効フラグ（更新時のみ）
+  outputs:
+    - name: 受注元一覧
+      type: OrderSourceListResponse
+      description: ページネーション付きの受注元一覧（items, total, page, limit）
+    - name: 受注元詳細
+      type: OrderSourceResponse
+      description: 単一の受注元情報（id, code, name, api_key, phone, postal_code, address_*, is_active, created_at, updated_at）
+  state_changes:
+    - 受注元レコードの作成（order_sourcesテーブルへのINSERT）
+    - 受注元レコードの更新（order_sourcesテーブルへのUPDATE）
+    - 受注元レコードの削除（order_sourcesテーブルからのDELETE）
+
+acceptance_criteria:
+  # --- バックエンドAPI ---
+  - id: AC-001
+    description: GET /order-sources で受注元一覧を取得できる
+    test_type: integration
+    given: 受注元が複数登録されている
+    when: GET /api/v1/order-sources を管理者トークンで呼び出す
+    then: items配列に受注元一覧、total、page、limitが返される
+
+  - id: AC-002
+    description: GET /order-sources でis_activeフィルターが動作する
+    test_type: integration
+    given: 有効・無効の受注元が混在している
+    when: GET /api/v1/order-sources?is_active=true を呼び出す
+    then: is_active=trueの受注元のみが返される
+
+  - id: AC-003
+    description: GET /order-sources/{id} で受注元詳細を取得できる
+    test_type: integration
+    given: 受注元が登録されている
+    when: GET /api/v1/order-sources/{id} を管理者トークンで呼び出す
+    then: 指定IDの受注元情報が返される
+
+  - id: AC-004
+    description: GET /order-sources/{id} で存在しないIDを指定すると404が返る
+    test_type: integration
+    given: 指定IDの受注元が存在しない
+    when: GET /api/v1/order-sources/{存在しないID} を呼び出す
+    then: 404エラーが返される
+
+  - id: AC-005
+    description: POST /order-sources で受注元を作成できる
+    test_type: integration
+    given: 管理者としてログインしている
+    when: POST /api/v1/order-sources に必要フィールドを含むJSONを送信する
+    then: 201ステータスで作成された受注元情報が返される
+
+  - id: AC-006
+    description: POST /order-sources で重複するcodeを指定すると409エラーが返る
+    test_type: integration
+    given: code="RKSYO"の受注元が既に存在する
+    when: POST /api/v1/order-sources で同じcode="RKSYO"を送信する
+    then: 409 Conflictエラーが返される
+
+  - id: AC-007
+    description: POST /order-sources で重複するapi_keyを指定すると409エラーが返る
+    test_type: integration
+    given: あるapi_keyの受注元が既に存在する
+    when: POST /api/v1/order-sources で同じapi_keyを送信する
+    then: 409 Conflictエラーが返される
+
+  - id: AC-008
+    description: PATCH /order-sources/{id} で受注元を更新できる
+    test_type: integration
+    given: 受注元が登録されている
+    when: PATCH /api/v1/order-sources/{id} に変更フィールドを含むJSONを送信する
+    then: 200ステータスで更新された受注元情報が返される
+
+  - id: AC-009
+    description: DELETE /order-sources/{id} で受注元を削除できる
+    test_type: integration
+    given: 受注元が登録されている
+    when: DELETE /api/v1/order-sources/{id} を管理者トークンで呼び出す
+    then: 204ステータスが返され、受注元が削除される
+
+  - id: AC-010
+    description: 認証なしでAPIにアクセスすると401が返る
+    test_type: integration
+    given: 認証トークンなし
+    when: GET /api/v1/order-sources を呼び出す
+    then: 401 Unauthorizedエラーが返される
+
+  # --- バックエンドサービスロジック ---
+  - id: AC-011
+    description: OrderSourceServiceがリポジトリを通じてCRUD操作を行う
+    test_type: unit
+    given: OrderSourceServiceがインスタンス化されている
+    when: create/get_by_id/list/update/deleteメソッドを呼び出す
+    then: 対応するリポジトリメソッドが呼ばれ、正しいレスポンスが返される
+
+  - id: AC-012
+    description: OrderSourceServiceが重複code/api_keyを検知しエラーを返す
+    test_type: unit
+    given: 同じcode/api_keyの受注元が存在する
+    when: createメソッドで重複するcode/api_keyを渡す
+    then: ConflictErrorがraiseされる
+
+  # --- フロントエンド ---
+  - id: AC-013
+    description: /order-sources ページで受注元一覧が表示される
+    test_type: unit
+    given: 受注元一覧ページにアクセスする
+    when: ページが読み込まれる
+    then: 受注元のコード、名前、電話番号、有効/無効状態が一覧表示される
+
+  - id: AC-014
+    description: 受注元一覧ページから新規登録ダイアログを開いて受注元を登録できる
+    test_type: unit
+    given: 受注元一覧ページを表示している
+    when: 「新規登録」ボタンをクリックし、必要情報を入力して保存する
+    then: 受注元が登録され、一覧に反映される
+
+  - id: AC-015
+    description: 受注元一覧ページから編集ダイアログを開いて受注元を編集できる
+    test_type: unit
+    given: 受注元一覧ページに受注元が表示されている
+    when: 受注元の「編集」ボタンをクリックし、情報を変更して保存する
+    then: 受注元が更新され、一覧に反映される
+
+  - id: AC-016
+    description: 受注元一覧ページから削除確認ダイアログを開いて受注元を削除できる
+    test_type: unit
+    given: 受注元一覧ページに受注元が表示されている
+    when: 受注元の「削除」ボタンをクリックし、確認ダイアログで「削除」を選択する
+    then: 受注元が削除され、一覧から消える
+
+  - id: AC-017
+    description: サイドバーに「受注元」メニューが表示される
+    test_type: unit
+    given: ダッシュボード画面にアクセスする
+    when: サイドバーを確認する
+    then: 「受注元」メニューが表示され、クリックすると /order-sources に遷移する
+
+  - id: AC-018
+    description: /settings/order-sources にアクセスすると受注元管理ページに遷移する
+    test_type: unit
+    given: ユーザーがログイン済み
+    when: /settings/order-sources にアクセスする
+    then: 受注元管理ページが表示される（/order-sources と同等のUIまたはリダイレクト）
+
+  - id: AC-019
+    description: 受注元フォームのバリデーションが動作する
+    test_type: unit
+    given: 新規登録ダイアログが開いている
+    when: 必須項目を空のまま保存しようとする
+    then: バリデーションエラーメッセージが表示され、送信されない
+
+  - id: AC-020
+    description: APIキーがマスク表示される
+    test_type: unit
+    given: 受注元一覧が表示されている
+    when: APIキー列を確認する
+    then: APIキーがマスク表示（先頭数文字 + ****）される
+
+constraints:
+  performance:
+    - 受注元一覧取得のレスポンスは500ms以内
+    - ページネーション対応（デフォルト20件）
+  security:
+    - 管理者（admin）のみアクセス可能（get_current_admin依存性を使用）
+    - APIキーは一覧画面でマスク表示する（セキュリティ上の配慮）
+    - APIキーの全文は詳細取得/編集時のみ表示
+  compatibility:
+    - 既存のAPIキー認証（verify_api_key）との互換性を維持
+    - 既存のOrder → OrderSource紐づけに影響を与えない
+    - SenderAddresseMixin（name, phone, postal_code, address_*）のフィールドをそのまま活用
+
+assumptions:
+  - 受注元コード（code）は英数字とハイフンで構成される想定（例: "RKSYO", "BASE-01"）
+  - APIキーは管理者が手動で入力する（自動生成機能は今回スコープ外）
+  - /settings/order-sources は /order-sources と同じ一覧UIを表示する（設定ページ内サブページとして実装）
+  - 受注元削除時に紐づくOrderのorder_source_idはNULLに設定される（既存のForeignKey ondelete="SET NULL" に準拠）
+  - 一覧テーブルの列: コード、名前、電話番号、住所（都道府県+市区町村）、APIキー（マスク表示）、状態（有効/無効）、操作ボタン
+  - サイドバーのアイコンにはlucide-reactの「Store」アイコンを使用する
+  - フロントエンドの受注元フック（useOrderSources）はSWRパターンで実装する（既存のuseManufacturers等と同等）
+
+success_metrics:
+  - /order-sources ページが正常に表示され、CRUD操作が全て動作する
+  - /settings/order-sources ページが正常に表示される
+  - サイドバーから受注元ページにナビゲートできる
+  - バックエンドAPIのユニット・統合テストが全てパスする
+  - フロントエンドのユニットテストが全てパスする
+  - 既存のAPIキー認証・受注紐づけ機能に影響がない

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -28,6 +28,7 @@ from app.services.manufacturer_order_service import ManufacturerOrderService
 from app.services.manufacturer_portal_service import ManufacturerPortalService
 from app.services.order_list_service import OrderListService
 from app.services.order_service import OrderService
+from app.services.order_source_service import OrderSourceService
 from app.services.order_status_history_service import OrderStatusHistoryService
 from app.services.product_service import ProductService
 from app.services.shipment_service import ShipmentService
@@ -121,6 +122,13 @@ def get_manufacturer_service(
 ) -> ManufacturerService:
     """Get manufacturer service."""
     return ManufacturerService(manufacturer_repo)
+
+
+def get_order_source_service(
+    order_source_repo: Annotated[OrderSourceRepository, Depends(get_order_source_repository)],
+) -> OrderSourceService:
+    """Get order source service."""
+    return OrderSourceService(order_source_repo)
 
 
 def get_order_service(

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -12,6 +12,7 @@ from app.routers import (
     external,
     manufacturer_portal,
     manufacturers,
+    order_sources,
     orders,
     products,
     shipments,
@@ -75,6 +76,7 @@ app.include_router(orders.router, prefix=settings.API_V1_PREFIX)
 app.include_router(shipments.router, prefix=settings.API_V1_PREFIX)
 app.include_router(chat.router, prefix=settings.API_V1_PREFIX)
 app.include_router(dashboard.router, prefix=settings.API_V1_PREFIX)
+app.include_router(order_sources.router, prefix=settings.API_V1_PREFIX)
 app.include_router(external.router, prefix=settings.API_V1_PREFIX)
 
 

--- a/api/app/routers/order_sources.py
+++ b/api/app/routers/order_sources.py
@@ -1,0 +1,74 @@
+"""Order sources router."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+
+from app.dependencies import get_current_admin, get_order_source_service
+from app.models.user import User
+from app.schemas.order_source import (
+    OrderSourceCreate,
+    OrderSourceListResponse,
+    OrderSourceResponse,
+    OrderSourceUpdate,
+)
+from app.services.order_source_service import OrderSourceService
+
+router = APIRouter(prefix="/order-sources", tags=["order-sources"])
+
+
+@router.get("", response_model=OrderSourceListResponse)
+async def list_order_sources(
+    service: Annotated[OrderSourceService, Depends(get_order_source_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    is_active: bool | None = None,
+) -> OrderSourceListResponse:
+    """List order sources with pagination and filters."""
+    return await service.list(
+        page=page,
+        limit=limit,
+        is_active=is_active,
+    )
+
+
+@router.get("/{order_source_id}", response_model=OrderSourceResponse)
+async def get_order_source(
+    order_source_id: str,
+    service: Annotated[OrderSourceService, Depends(get_order_source_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> OrderSourceResponse:
+    """Get an order source by ID."""
+    return await service.get_by_id(order_source_id)
+
+
+@router.post("", response_model=OrderSourceResponse, status_code=201)
+async def create_order_source(
+    data: OrderSourceCreate,
+    service: Annotated[OrderSourceService, Depends(get_order_source_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> OrderSourceResponse:
+    """Create a new order source."""
+    return await service.create(data)
+
+
+@router.patch("/{order_source_id}", response_model=OrderSourceResponse)
+async def update_order_source(
+    order_source_id: str,
+    data: OrderSourceUpdate,
+    service: Annotated[OrderSourceService, Depends(get_order_source_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> OrderSourceResponse:
+    """Update an order source."""
+    return await service.update(order_source_id, data)
+
+
+@router.delete("/{order_source_id}", status_code=204)
+async def delete_order_source(
+    order_source_id: str,
+    service: Annotated[OrderSourceService, Depends(get_order_source_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> None:
+    """Delete an order source."""
+    await service.delete(order_source_id)

--- a/api/app/schemas/order_source.py
+++ b/api/app/schemas/order_source.py
@@ -1,0 +1,60 @@
+"""OrderSource schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OrderSourceCreate(BaseModel):
+    """OrderSource creation schema."""
+
+    code: str = Field(..., min_length=1, max_length=50)
+    name: str = Field(..., min_length=1, max_length=100)
+    api_key: str = Field(..., min_length=1, max_length=100)
+    phone: str = Field(..., min_length=1, max_length=20)
+    postal_code: str = Field(..., min_length=1, max_length=10)
+    address_prefecture: str = Field(..., min_length=1, max_length=50)
+    address_city: str = Field(..., min_length=1)
+    address_building: str | None = Field(None, max_length=200)
+
+
+class OrderSourceUpdate(BaseModel):
+    """OrderSource update schema."""
+
+    code: str | None = Field(None, min_length=1, max_length=50)
+    name: str | None = Field(None, min_length=1, max_length=100)
+    api_key: str | None = Field(None, min_length=1, max_length=100)
+    phone: str | None = Field(None, min_length=1, max_length=20)
+    postal_code: str | None = Field(None, min_length=1, max_length=10)
+    address_prefecture: str | None = Field(None, min_length=1, max_length=50)
+    address_city: str | None = Field(None, min_length=1)
+    address_building: str | None = Field(None, max_length=200)
+    is_active: bool | None = None
+
+
+class OrderSourceResponse(BaseModel):
+    """OrderSource response schema."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    code: str
+    name: str
+    api_key: str
+    phone: str
+    postal_code: str
+    address_prefecture: str
+    address_city: str
+    address_building: str | None = None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class OrderSourceListResponse(BaseModel):
+    """OrderSource list response schema."""
+
+    items: list[OrderSourceResponse]
+    total: int
+    page: int
+    limit: int

--- a/api/app/services/order_source_service.py
+++ b/api/app/services/order_source_service.py
@@ -1,0 +1,123 @@
+"""OrderSource service."""
+
+from app.models.order_source import OrderSource
+from app.repositories.order_source_repository import OrderSourceRepository
+from app.schemas.order_source import (
+    OrderSourceCreate,
+    OrderSourceListResponse,
+    OrderSourceResponse,
+    OrderSourceUpdate,
+)
+from app.utils.exceptions import DuplicateError, OrderSourceNotFoundError
+
+
+class OrderSourceService:
+    """Service for order source operations."""
+
+    def __init__(self, order_source_repo: OrderSourceRepository):
+        self._order_source_repo = order_source_repo
+
+    async def create(self, data: OrderSourceCreate) -> OrderSourceResponse:
+        """Create a new order source."""
+        # Check for duplicate code
+        existing_by_code = await self._order_source_repo.find_by_code(data.code)
+        if existing_by_code:
+            raise DuplicateError("OrderSource", "code", data.code)
+
+        # Check for duplicate api_key
+        existing_by_api_key = await self._order_source_repo.find_by_api_key(data.api_key)
+        if existing_by_api_key:
+            raise DuplicateError("OrderSource", "api_key", data.api_key)
+
+        order_source = OrderSource(
+            code=data.code,
+            name=data.name,
+            api_key=data.api_key,
+            phone=data.phone,
+            postal_code=data.postal_code,
+            address_prefecture=data.address_prefecture,
+            address_city=data.address_city,
+            address_building=data.address_building,
+        )
+
+        order_source = await self._order_source_repo.create(order_source)
+        return self._to_response(order_source)
+
+    async def get_by_id(self, order_source_id: str) -> OrderSourceResponse:
+        """Get an order source by ID."""
+        order_source = await self._order_source_repo.find_by_id(order_source_id)
+        if not order_source:
+            raise OrderSourceNotFoundError(order_source_id)
+        return self._to_response(order_source)
+
+    async def list(
+        self,
+        page: int = 1,
+        limit: int = 20,
+        is_active: bool | None = None,
+    ) -> OrderSourceListResponse:
+        """List order sources with pagination and filters."""
+        order_sources, total = await self._order_source_repo.find_all(
+            page=page,
+            limit=limit,
+            is_active=is_active,
+        )
+
+        return OrderSourceListResponse(
+            items=[self._to_response(s) for s in order_sources],
+            total=total,
+            page=page,
+            limit=limit,
+        )
+
+    async def update(
+        self, order_source_id: str, data: OrderSourceUpdate
+    ) -> OrderSourceResponse:
+        """Update an order source."""
+        order_source = await self._order_source_repo.find_by_id(order_source_id)
+        if not order_source:
+            raise OrderSourceNotFoundError(order_source_id)
+
+        # Check for duplicate code if being changed
+        if data.code and data.code != order_source.code:
+            existing = await self._order_source_repo.find_by_code(data.code)
+            if existing:
+                raise DuplicateError("OrderSource", "code", data.code)
+
+        # Check for duplicate api_key if being changed
+        if data.api_key and data.api_key != order_source.api_key:
+            existing = await self._order_source_repo.find_by_api_key(data.api_key)
+            if existing:
+                raise DuplicateError("OrderSource", "api_key", data.api_key)
+
+        # Update fields
+        update_data = data.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(order_source, field, value)
+
+        order_source = await self._order_source_repo.update(order_source)
+        return self._to_response(order_source)
+
+    async def delete(self, order_source_id: str) -> None:
+        """Delete an order source."""
+        order_source = await self._order_source_repo.find_by_id(order_source_id)
+        if not order_source:
+            raise OrderSourceNotFoundError(order_source_id)
+        await self._order_source_repo.delete(order_source)
+
+    def _to_response(self, order_source: OrderSource) -> OrderSourceResponse:
+        """Convert order source model to response schema."""
+        return OrderSourceResponse(
+            id=order_source.id,
+            code=order_source.code,
+            name=order_source.name,
+            api_key=order_source.api_key,
+            phone=order_source.phone,
+            postal_code=order_source.postal_code,
+            address_prefecture=order_source.address_prefecture,
+            address_city=order_source.address_city,
+            address_building=order_source.address_building,
+            is_active=order_source.is_active,
+            created_at=order_source.created_at,
+            updated_at=order_source.updated_at,
+        )

--- a/api/app/utils/exceptions.py
+++ b/api/app/utils/exceptions.py
@@ -52,6 +52,13 @@ class OrderNotFoundError(NotFoundError):
         super().__init__("Order", order_id)
 
 
+class OrderSourceNotFoundError(NotFoundError):
+    """OrderSource not found error."""
+
+    def __init__(self, order_source_id: UUID | str):
+        super().__init__("OrderSource", order_source_id)
+
+
 class ValidationError(AppException):
     """Validation error."""
 

--- a/api/tests/integration/test_order_source_crud.py
+++ b/api/tests/integration/test_order_source_crud.py
@@ -1,0 +1,590 @@
+"""受注元（OrderSource）CRUD APIの統合テスト
+
+FEAT-0014: 受注元管理CRUD
+
+テスト対象: /api/v1/order-sources エンドポイント
+- AC-001: GET /order-sources で受注元一覧を取得できる
+- AC-002: GET /order-sources でis_activeフィルターが動作する
+- AC-003: GET /order-sources/{id} で受注元詳細を取得できる
+- AC-004: GET /order-sources/{id} で存在しないIDを指定すると404が返る
+- AC-005: POST /order-sources で受注元を作成できる
+- AC-006: POST /order-sources で重複するcodeを指定すると409エラーが返る
+- AC-007: POST /order-sources で重複するapi_keyを指定すると409エラーが返る
+- AC-008: PATCH /order-sources/{id} で受注元を更新できる
+- AC-009: DELETE /order-sources/{id} で受注元を削除できる
+- AC-010: 認証なしでAPIにアクセスすると401が返る
+"""
+
+import pytest
+from uuid import uuid4
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+
+
+# APIプレフィックス
+API_PREFIX = settings.API_V1_PREFIX
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def test_order_source_for_crud(db_session: AsyncSession):
+    """CRUD テスト用の受注元を作成"""
+    source_id = str(uuid4())
+    source_code = f"CRUD{source_id[:6].upper()}"
+    api_key = f"crud-api-key-{source_id}"
+
+    await db_session.execute(
+        text("""
+            INSERT INTO order_sources (id, code, name, api_key, phone, postal_code, address_prefecture, address_city, is_active, created_at, updated_at)
+            VALUES (:id, :code, :name, :api_key, :phone, :postal_code, :address_prefecture, :address_city, :is_active, NOW(), NOW())
+        """),
+        {
+            "id": source_id,
+            "code": source_code,
+            "name": "CRUD Test Source",
+            "api_key": api_key,
+            "phone": "03-1234-5678",
+            "postal_code": "100-0001",
+            "address_prefecture": "東京都",
+            "address_city": "千代田区1-1-1",
+            "is_active": True,
+        }
+    )
+    await db_session.commit()
+
+    yield {
+        "id": source_id,
+        "code": source_code,
+        "api_key": api_key,
+        "name": "CRUD Test Source",
+    }
+
+
+@pytest.fixture
+async def test_inactive_order_source(db_session: AsyncSession):
+    """無効な受注元を作成"""
+    source_id = str(uuid4())
+    source_code = f"INACT{source_id[:5].upper()}"
+
+    await db_session.execute(
+        text("""
+            INSERT INTO order_sources (id, code, name, api_key, phone, postal_code, address_prefecture, address_city, is_active, created_at, updated_at)
+            VALUES (:id, :code, :name, :api_key, :phone, :postal_code, :address_prefecture, :address_city, :is_active, NOW(), NOW())
+        """),
+        {
+            "id": source_id,
+            "code": source_code,
+            "name": "Inactive Source",
+            "api_key": f"inactive-api-key-{source_id}",
+            "phone": "03-9999-8888",
+            "postal_code": "150-0001",
+            "address_prefecture": "東京都",
+            "address_city": "渋谷区",
+            "is_active": False,
+        }
+    )
+    await db_session.commit()
+
+    yield {
+        "id": source_id,
+        "code": source_code,
+        "name": "Inactive Source",
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC-001: GET /order-sources で受注元一覧を取得できる
+# ---------------------------------------------------------------------------
+
+class TestListOrderSources:
+    """GET /order-sources 一覧取得テスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac001_list_order_sources(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_source_for_crud: dict,
+    ):
+        """AC-001: GET /order-sources で受注元一覧を取得できる
+
+        given: 受注元が登録されている
+        when: GET /api/v1/order-sources を管理者トークンで呼び出す
+        then: items配列に受注元一覧、total、page、limitが返される
+        """
+        response = await client.get(
+            f"{API_PREFIX}/order-sources",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert "total" in data
+        assert "page" in data
+        assert "limit" in data
+        assert isinstance(data["items"], list)
+        assert data["total"] >= 1
+
+    # ---------------------------------------------------------------------------
+    # AC-002: GET /order-sources でis_activeフィルターが動作する
+    # ---------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_ac002_list_order_sources_is_active_filter(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_source_for_crud: dict,
+        test_inactive_order_source: dict,
+    ):
+        """AC-002: GET /order-sources でis_activeフィルターが動作する
+
+        given: 有効・無効の受注元が混在している
+        when: GET /api/v1/order-sources?is_active=true を呼び出す
+        then: is_active=trueの受注元のみが返される
+        """
+        response = await client.get(
+            f"{API_PREFIX}/order-sources?is_active=true",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # 全てのアイテムがis_active=trueであること
+        for item in data["items"]:
+            assert item["is_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_ac002_list_order_sources_is_active_false_filter(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_source_for_crud: dict,
+        test_inactive_order_source: dict,
+    ):
+        """is_active=falseフィルターで無効な受注元のみが返される
+
+        given: 有効・無効の受注元が混在している
+        when: GET /api/v1/order-sources?is_active=false を呼び出す
+        then: is_active=falseの受注元のみが返される
+        """
+        response = await client.get(
+            f"{API_PREFIX}/order-sources?is_active=false",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        for item in data["items"]:
+            assert item["is_active"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC-003/004: GET /order-sources/{id} 詳細取得テスト
+# ---------------------------------------------------------------------------
+
+class TestGetOrderSource:
+    """GET /order-sources/{id} 詳細取得テスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac003_get_order_source_by_id(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_source_for_crud: dict,
+    ):
+        """AC-003: GET /order-sources/{id} で受注元詳細を取得できる
+
+        given: 受注元が登録されている
+        when: GET /api/v1/order-sources/{id} を管理者トークンで呼び出す
+        then: 指定IDの受注元情報が返される
+        """
+        source_id = test_order_source_for_crud["id"]
+        response = await client.get(
+            f"{API_PREFIX}/order-sources/{source_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == source_id
+        assert data["code"] == test_order_source_for_crud["code"]
+        assert data["name"] == "CRUD Test Source"
+        assert "phone" in data
+        assert "postal_code" in data
+        assert "address_prefecture" in data
+        assert "address_city" in data
+        assert "is_active" in data
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    @pytest.mark.asyncio
+    async def test_ac004_get_order_source_not_found(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """AC-004: GET /order-sources/{id} で存在しないIDを指定すると404が返る
+
+        given: 指定IDの受注元が存在しない
+        when: GET /api/v1/order-sources/{存在しないID} を呼び出す
+        then: 404エラーが返される
+        """
+        non_existent_id = str(uuid4())
+        response = await client.get(
+            f"{API_PREFIX}/order-sources/{non_existent_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# AC-005: POST /order-sources で受注元を作成できる
+# ---------------------------------------------------------------------------
+
+class TestCreateOrderSource:
+    """POST /order-sources 作成テスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac005_create_order_source(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """AC-005: POST /order-sources で受注元を作成できる
+
+        given: 管理者としてログインしている
+        when: POST /api/v1/order-sources に必要フィールドを含むJSONを送信する
+        then: 201ステータスで作成された受注元情報が返される
+        """
+        unique_suffix = str(uuid4())[:8]
+        create_data = {
+            "code": f"NEW{unique_suffix}",
+            "name": "新規受注元",
+            "api_key": f"new-key-{unique_suffix}",
+            "phone": "03-5555-6666",
+            "postal_code": "100-0001",
+            "address_prefecture": "東京都",
+            "address_city": "千代田区丸の内1-1-1",
+            "address_building": "テストビル3F",
+        }
+
+        response = await client.post(
+            f"{API_PREFIX}/order-sources",
+            json=create_data,
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 201, (
+            f"Expected 201, got {response.status_code}: {response.json()}"
+        )
+
+        data = response.json()
+        assert data["code"] == create_data["code"]
+        assert data["name"] == "新規受注元"
+        assert data["phone"] == "03-5555-6666"
+        assert data["postal_code"] == "100-0001"
+        assert data["address_prefecture"] == "東京都"
+        assert data["address_city"] == "千代田区丸の内1-1-1"
+        assert data["address_building"] == "テストビル3F"
+        assert data["is_active"] is True
+        assert "id" in data
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    # ---------------------------------------------------------------------------
+    # AC-006: POST /order-sources で重複するcodeを指定すると409エラーが返る
+    # ---------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_ac006_create_duplicate_code_returns_409(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_source_for_crud: dict,
+    ):
+        """AC-006: POST /order-sources で重複するcodeを指定すると409エラーが返る
+
+        given: code="RKSYO"の受注元が既に存在する
+        when: POST /api/v1/order-sources で同じcodeを送信する
+        then: 409 Conflictエラーが返される
+        """
+        create_data = {
+            "code": test_order_source_for_crud["code"],  # 既存のcodeと重複
+            "name": "重複コードテスト",
+            "api_key": f"unique-key-{uuid4()}",
+            "phone": "03-0000-0000",
+            "postal_code": "100-0001",
+            "address_prefecture": "東京都",
+            "address_city": "千代田区",
+        }
+
+        response = await client.post(
+            f"{API_PREFIX}/order-sources",
+            json=create_data,
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 409, (
+            f"Expected 409 for duplicate code, got {response.status_code}: {response.json()}"
+        )
+
+    # ---------------------------------------------------------------------------
+    # AC-007: POST /order-sources で重複するapi_keyを指定すると409エラーが返る
+    # ---------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_ac007_create_duplicate_api_key_returns_409(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_source_for_crud: dict,
+    ):
+        """AC-007: POST /order-sources で重複するapi_keyを指定すると409エラーが返る
+
+        given: あるapi_keyの受注元が既に存在する
+        when: POST /api/v1/order-sources で同じapi_keyを送信する
+        then: 409 Conflictエラーが返される
+        """
+        create_data = {
+            "code": f"UNIQ{str(uuid4())[:6]}",
+            "name": "重複APIキーテスト",
+            "api_key": test_order_source_for_crud["api_key"],  # 既存のapi_keyと重複
+            "phone": "03-0000-0000",
+            "postal_code": "100-0001",
+            "address_prefecture": "東京都",
+            "address_city": "千代田区",
+        }
+
+        response = await client.post(
+            f"{API_PREFIX}/order-sources",
+            json=create_data,
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 409, (
+            f"Expected 409 for duplicate api_key, got {response.status_code}: {response.json()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-008: PATCH /order-sources/{id} で受注元を更新できる
+# ---------------------------------------------------------------------------
+
+class TestUpdateOrderSource:
+    """PATCH /order-sources/{id} 更新テスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac008_update_order_source(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_order_source_for_crud: dict,
+    ):
+        """AC-008: PATCH /order-sources/{id} で受注元を更新できる
+
+        given: 受注元が登録されている
+        when: PATCH /api/v1/order-sources/{id} に変更フィールドを含むJSONを送信する
+        then: 200ステータスで更新された受注元情報が返される
+        """
+        source_id = test_order_source_for_crud["id"]
+        update_data = {
+            "name": "更新後の受注元名",
+            "phone": "03-9999-0000",
+        }
+
+        response = await client.patch(
+            f"{API_PREFIX}/order-sources/{source_id}",
+            json=update_data,
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.json()}"
+        )
+
+        data = response.json()
+        assert data["id"] == source_id
+        assert data["name"] == "更新後の受注元名"
+        assert data["phone"] == "03-9999-0000"
+
+    @pytest.mark.asyncio
+    async def test_update_order_source_not_found(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """存在しないIDを更新しようとすると404が返る"""
+        non_existent_id = str(uuid4())
+        update_data = {"name": "更新テスト"}
+
+        response = await client.patch(
+            f"{API_PREFIX}/order-sources/{non_existent_id}",
+            json=update_data,
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# AC-009: DELETE /order-sources/{id} で受注元を削除できる
+# ---------------------------------------------------------------------------
+
+class TestDeleteOrderSource:
+    """DELETE /order-sources/{id} 削除テスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac009_delete_order_source(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        db_session: AsyncSession,
+    ):
+        """AC-009: DELETE /order-sources/{id} で受注元を削除できる
+
+        given: 受注元が登録されている
+        when: DELETE /api/v1/order-sources/{id} を管理者トークンで呼び出す
+        then: 204ステータスが返され、受注元が削除される
+        """
+        # テスト用の受注元を作成（削除テスト専用）
+        source_id = str(uuid4())
+        source_code = f"DEL{source_id[:7].upper()}"
+        await db_session.execute(
+            text("""
+                INSERT INTO order_sources (id, code, name, api_key, phone, postal_code, address_prefecture, address_city, is_active, created_at, updated_at)
+                VALUES (:id, :code, :name, :api_key, :phone, :postal_code, :address_prefecture, :address_city, :is_active, NOW(), NOW())
+            """),
+            {
+                "id": source_id,
+                "code": source_code,
+                "name": "Delete Test Source",
+                "api_key": f"delete-key-{source_id}",
+                "phone": "03-0000-0000",
+                "postal_code": "100-0001",
+                "address_prefecture": "東京都",
+                "address_city": "千代田区",
+                "is_active": True,
+            }
+        )
+        await db_session.commit()
+
+        response = await client.delete(
+            f"{API_PREFIX}/order-sources/{source_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 204
+
+        # 削除後にGETすると404が返ることを確認
+        get_response = await client.get(
+            f"{API_PREFIX}/order-sources/{source_id}",
+            headers=auth_headers,
+        )
+        assert get_response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_order_source_not_found(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """存在しないIDを削除しようとすると404が返る"""
+        non_existent_id = str(uuid4())
+        response = await client.delete(
+            f"{API_PREFIX}/order-sources/{non_existent_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# AC-010: 認証なしでAPIにアクセスすると401が返る
+# ---------------------------------------------------------------------------
+
+class TestOrderSourceAuthentication:
+    """認証テスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac010_unauthenticated_list_returns_401(
+        self,
+        client: AsyncClient,
+    ):
+        """AC-010: 認証なしでGET /order-sourcesにアクセスすると401が返る
+
+        given: 認証トークンなし
+        when: GET /api/v1/order-sources を呼び出す
+        then: 401 Unauthorizedエラーが返される
+        """
+        response = await client.get(f"{API_PREFIX}/order-sources")
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_ac010_unauthenticated_create_returns_401(
+        self,
+        client: AsyncClient,
+    ):
+        """認証なしでPOST /order-sourcesにアクセスすると401が返る"""
+        create_data = {
+            "code": "NOAUTH",
+            "name": "認証なしテスト",
+            "api_key": "no-auth-key",
+            "phone": "03-0000-0000",
+            "postal_code": "100-0001",
+            "address_prefecture": "東京都",
+            "address_city": "千代田区",
+        }
+
+        response = await client.post(
+            f"{API_PREFIX}/order-sources",
+            json=create_data,
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_ac010_unauthenticated_get_returns_401(
+        self,
+        client: AsyncClient,
+    ):
+        """認証なしでGET /order-sources/{id}にアクセスすると401が返る"""
+        response = await client.get(
+            f"{API_PREFIX}/order-sources/{uuid4()}",
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_ac010_unauthenticated_update_returns_401(
+        self,
+        client: AsyncClient,
+    ):
+        """認証なしでPATCH /order-sources/{id}にアクセスすると401が返る"""
+        response = await client.patch(
+            f"{API_PREFIX}/order-sources/{uuid4()}",
+            json={"name": "更新テスト"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_ac010_unauthenticated_delete_returns_401(
+        self,
+        client: AsyncClient,
+    ):
+        """認証なしでDELETE /order-sources/{id}にアクセスすると401が返る"""
+        response = await client.delete(
+            f"{API_PREFIX}/order-sources/{uuid4()}",
+        )
+
+        assert response.status_code == 401

--- a/api/tests/unit/test_order_source_service.py
+++ b/api/tests/unit/test_order_source_service.py
@@ -1,0 +1,449 @@
+"""OrderSourceService のユニットテスト
+
+FEAT-0014: 受注元（OrderSource）CRUD管理
+
+テスト対象: OrderSourceService
+- AC-011: create/get_by_id/list/update/deleteメソッドがリポジトリを通じてCRUD操作を行う
+- AC-012: 重複code/api_keyを検知しConflictError（DuplicateError）をraiseする
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from app.services.order_source_service import OrderSourceService
+from app.schemas.order_source import (
+    OrderSourceCreate,
+    OrderSourceUpdate,
+    OrderSourceResponse,
+    OrderSourceListResponse,
+)
+from app.utils.exceptions import DuplicateError, NotFoundError
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock OrderSource model factory
+# ---------------------------------------------------------------------------
+
+def _make_order_source(
+    *,
+    id: str | None = None,
+    code: str = "RKSYO",
+    name: str = "楽商",
+    api_key: str = "test-api-key-001",
+    phone: str = "03-1234-5678",
+    postal_code: str = "100-0001",
+    address_prefecture: str = "東京都",
+    address_city: str = "千代田区1-1-1",
+    address_building: str | None = None,
+    is_active: bool = True,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> MagicMock:
+    """Create a mock OrderSource model instance."""
+    order_source = MagicMock()
+    order_source.id = id or str(uuid4())
+    order_source.code = code
+    order_source.name = name
+    order_source.api_key = api_key
+    order_source.phone = phone
+    order_source.postal_code = postal_code
+    order_source.address_prefecture = address_prefecture
+    order_source.address_city = address_city
+    order_source.address_building = address_building
+    order_source.is_active = is_active
+    order_source.created_at = created_at or datetime(2026, 1, 1, 0, 0, 0)
+    order_source.updated_at = updated_at or datetime(2026, 1, 1, 0, 0, 0)
+    return order_source
+
+
+# ---------------------------------------------------------------------------
+# AC-011: OrderSourceServiceがリポジトリを通じてCRUD操作を行う
+# ---------------------------------------------------------------------------
+
+class TestOrderSourceServiceCRUD:
+    """AC-011: OrderSourceServiceのCRUD操作テスト"""
+
+    @pytest.fixture
+    def mock_order_source_repo(self):
+        """モック OrderSourceRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_order_source_repo):
+        """テスト対象のサービスインスタンス"""
+        return OrderSourceService(order_source_repo=mock_order_source_repo)
+
+    # --- create ---
+
+    @pytest.mark.asyncio
+    async def test_create_order_source_success(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """受注元を正常に作成できる
+
+        given: 重複するcode/api_keyが存在しない
+        when: createメソッドを呼び出す
+        then: リポジトリのcreateが呼ばれ、OrderSourceResponseが返される
+        """
+        mock_order_source_repo.find_by_code.return_value = None
+        mock_order_source_repo.find_by_api_key.return_value = None
+
+        created_source = _make_order_source(
+            code="NEWCODE",
+            name="新しい受注元",
+            api_key="new-api-key-001",
+            phone="090-1111-2222",
+            postal_code="150-0001",
+            address_prefecture="東京都",
+            address_city="渋谷区1-1-1",
+        )
+        mock_order_source_repo.create.return_value = created_source
+
+        data = OrderSourceCreate(
+            code="NEWCODE",
+            name="新しい受注元",
+            api_key="new-api-key-001",
+            phone="090-1111-2222",
+            postal_code="150-0001",
+            address_prefecture="東京都",
+            address_city="渋谷区1-1-1",
+        )
+
+        result = await service.create(data)
+
+        # リポジトリの重複チェックが呼ばれたことを確認
+        mock_order_source_repo.find_by_code.assert_called_once_with("NEWCODE")
+        mock_order_source_repo.find_by_api_key.assert_called_once_with("new-api-key-001")
+        # リポジトリのcreateが呼ばれたことを確認
+        mock_order_source_repo.create.assert_called_once()
+        # 正しいレスポンスが返されることを確認
+        assert isinstance(result, OrderSourceResponse)
+        assert result.code == "NEWCODE"
+        assert result.name == "新しい受注元"
+
+    # --- get_by_id ---
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_success(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """IDで受注元を取得できる
+
+        given: 指定IDの受注元が存在する
+        when: get_by_idメソッドを呼び出す
+        then: OrderSourceResponseが返される
+        """
+        source_id = str(uuid4())
+        mock_source = _make_order_source(id=source_id, code="RKSYO")
+        mock_order_source_repo.find_by_id.return_value = mock_source
+
+        result = await service.get_by_id(source_id)
+
+        mock_order_source_repo.find_by_id.assert_called_once_with(source_id)
+        assert isinstance(result, OrderSourceResponse)
+        assert result.id == source_id
+        assert result.code == "RKSYO"
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_not_found(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """存在しないIDの場合NotFoundErrorがraiseされる
+
+        given: 指定IDの受注元が存在しない
+        when: get_by_idメソッドを呼び出す
+        then: NotFoundErrorがraiseされる
+        """
+        mock_order_source_repo.find_by_id.return_value = None
+
+        with pytest.raises(NotFoundError) as exc_info:
+            await service.get_by_id("non-existent-id")
+
+        assert exc_info.value.status_code == 404
+
+    # --- list ---
+
+    @pytest.mark.asyncio
+    async def test_list_order_sources_success(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """受注元一覧を取得できる
+
+        given: 受注元が複数登録されている
+        when: listメソッドを呼び出す
+        then: OrderSourceListResponseが返される
+        """
+        sources = [
+            _make_order_source(code="SRC-001", name="受注元1"),
+            _make_order_source(code="SRC-002", name="受注元2"),
+        ]
+        mock_order_source_repo.find_all.return_value = (sources, 2)
+
+        result = await service.list(page=1, limit=20)
+
+        mock_order_source_repo.find_all.assert_called_once_with(
+            page=1, limit=20, is_active=None
+        )
+        assert isinstance(result, OrderSourceListResponse)
+        assert len(result.items) == 2
+        assert result.total == 2
+        assert result.page == 1
+        assert result.limit == 20
+
+    @pytest.mark.asyncio
+    async def test_list_order_sources_with_is_active_filter(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """is_activeフィルター付きで受注元一覧を取得できる
+
+        given: 有効・無効の受注元が混在している
+        when: is_active=Trueでlistメソッドを呼び出す
+        then: find_allにis_active=Trueが渡される
+        """
+        active_source = _make_order_source(code="ACTIVE", is_active=True)
+        mock_order_source_repo.find_all.return_value = ([active_source], 1)
+
+        result = await service.list(page=1, limit=20, is_active=True)
+
+        mock_order_source_repo.find_all.assert_called_once_with(
+            page=1, limit=20, is_active=True
+        )
+        assert len(result.items) == 1
+
+    # --- update ---
+
+    @pytest.mark.asyncio
+    async def test_update_order_source_success(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """受注元を正常に更新できる
+
+        given: 受注元が登録されている
+        when: updateメソッドを呼び出す
+        then: リポジトリのupdateが呼ばれ、OrderSourceResponseが返される
+        """
+        source_id = str(uuid4())
+        existing_source = _make_order_source(id=source_id, code="OLD", name="旧名前")
+        mock_order_source_repo.find_by_id.return_value = existing_source
+
+        # 更新後のモックを設定
+        updated_source = _make_order_source(id=source_id, code="OLD", name="新名前")
+        mock_order_source_repo.update.return_value = updated_source
+
+        data = OrderSourceUpdate(name="新名前")
+        result = await service.update(source_id, data)
+
+        mock_order_source_repo.find_by_id.assert_called_once_with(source_id)
+        mock_order_source_repo.update.assert_called_once()
+        assert isinstance(result, OrderSourceResponse)
+
+    @pytest.mark.asyncio
+    async def test_update_order_source_not_found(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """存在しないIDを更新しようとするとNotFoundErrorがraiseされる
+
+        given: 指定IDの受注元が存在しない
+        when: updateメソッドを呼び出す
+        then: NotFoundErrorがraiseされる
+        """
+        mock_order_source_repo.find_by_id.return_value = None
+
+        data = OrderSourceUpdate(name="新名前")
+        with pytest.raises(NotFoundError) as exc_info:
+            await service.update("non-existent-id", data)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_update_order_source_duplicate_code(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """更新時に重複するcodeを指定するとDuplicateErrorがraiseされる
+
+        given: 別の受注元が同じcodeを持っている
+        when: updateメソッドでそのcodeに変更する
+        then: DuplicateErrorがraiseされる
+        """
+        source_id = str(uuid4())
+        existing_source = _make_order_source(id=source_id, code="ORIGINAL")
+        mock_order_source_repo.find_by_id.return_value = existing_source
+
+        # 別の受注元が既に同じcodeを使用中
+        another_source = _make_order_source(id=str(uuid4()), code="DUPLICATE")
+        mock_order_source_repo.find_by_code.return_value = another_source
+
+        data = OrderSourceUpdate(code="DUPLICATE")
+        with pytest.raises(DuplicateError) as exc_info:
+            await service.update(source_id, data)
+
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_update_order_source_duplicate_api_key(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """更新時に重複するapi_keyを指定するとDuplicateErrorがraiseされる
+
+        given: 別の受注元が同じapi_keyを持っている
+        when: updateメソッドでそのapi_keyに変更する
+        then: DuplicateErrorがraiseされる
+        """
+        source_id = str(uuid4())
+        existing_source = _make_order_source(id=source_id, api_key="original-key")
+        mock_order_source_repo.find_by_id.return_value = existing_source
+
+        # codeの重複はなし
+        mock_order_source_repo.find_by_code.return_value = None
+        # 別の受注元が既に同じapi_keyを使用中
+        another_source = _make_order_source(id=str(uuid4()), api_key="duplicate-key")
+        mock_order_source_repo.find_by_api_key.return_value = another_source
+
+        data = OrderSourceUpdate(api_key="duplicate-key")
+        with pytest.raises(DuplicateError) as exc_info:
+            await service.update(source_id, data)
+
+        assert exc_info.value.status_code == 409
+
+    # --- delete ---
+
+    @pytest.mark.asyncio
+    async def test_delete_order_source_success(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """受注元を正常に削除できる
+
+        given: 受注元が登録されている
+        when: deleteメソッドを呼び出す
+        then: リポジトリのdeleteが呼ばれる
+        """
+        source_id = str(uuid4())
+        existing_source = _make_order_source(id=source_id)
+        mock_order_source_repo.find_by_id.return_value = existing_source
+
+        await service.delete(source_id)
+
+        mock_order_source_repo.find_by_id.assert_called_once_with(source_id)
+        mock_order_source_repo.delete.assert_called_once_with(existing_source)
+
+    @pytest.mark.asyncio
+    async def test_delete_order_source_not_found(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """存在しないIDを削除しようとするとNotFoundErrorがraiseされる
+
+        given: 指定IDの受注元が存在しない
+        when: deleteメソッドを呼び出す
+        then: NotFoundErrorがraiseされる
+        """
+        mock_order_source_repo.find_by_id.return_value = None
+
+        with pytest.raises(NotFoundError) as exc_info:
+            await service.delete("non-existent-id")
+
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# AC-012: OrderSourceServiceが重複code/api_keyを検知しエラーを返す
+# ---------------------------------------------------------------------------
+
+class TestOrderSourceServiceDuplicateDetection:
+    """AC-012: 重複code/api_key検知テスト"""
+
+    @pytest.fixture
+    def mock_order_source_repo(self):
+        """モック OrderSourceRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_order_source_repo):
+        """テスト対象のサービスインスタンス"""
+        return OrderSourceService(order_source_repo=mock_order_source_repo)
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate_code_raises_conflict(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """AC-012: 重複するcodeでcreateするとDuplicateErrorがraiseされる
+
+        given: code="RKSYO"の受注元が既に存在する
+        when: 同じcode="RKSYO"でcreateメソッドを呼び出す
+        then: DuplicateErrorがraiseされる
+        """
+        existing_source = _make_order_source(code="RKSYO")
+        mock_order_source_repo.find_by_code.return_value = existing_source
+
+        data = OrderSourceCreate(
+            code="RKSYO",
+            name="重複テスト",
+            api_key="different-api-key",
+            phone="03-0000-0000",
+            postal_code="100-0001",
+            address_prefecture="東京都",
+            address_city="千代田区",
+        )
+
+        with pytest.raises(DuplicateError) as exc_info:
+            await service.create(data)
+
+        assert exc_info.value.status_code == 409
+        assert "code" in exc_info.value.message.lower() or "RKSYO" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate_api_key_raises_conflict(
+        self,
+        service: OrderSourceService,
+        mock_order_source_repo: AsyncMock,
+    ):
+        """AC-012: 重複するapi_keyでcreateするとDuplicateErrorがraiseされる
+
+        given: あるapi_keyの受注元が既に存在する
+        when: 同じapi_keyでcreateメソッドを呼び出す
+        then: DuplicateErrorがraiseされる
+        """
+        mock_order_source_repo.find_by_code.return_value = None
+        existing_source = _make_order_source(api_key="duplicate-api-key")
+        mock_order_source_repo.find_by_api_key.return_value = existing_source
+
+        data = OrderSourceCreate(
+            code="UNIQUE-CODE",
+            name="重複APIキーテスト",
+            api_key="duplicate-api-key",
+            phone="03-0000-0000",
+            postal_code="100-0001",
+            address_prefecture="東京都",
+            address_city="千代田区",
+        )
+
+        with pytest.raises(DuplicateError) as exc_info:
+            await service.create(data)
+
+        assert exc_info.value.status_code == 409
+        assert "api_key" in exc_info.value.message.lower() or "duplicate-api-key" in exc_info.value.message

--- a/web/src/app/(dashboard)/order-sources/page.tsx
+++ b/web/src/app/(dashboard)/order-sources/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { OrderSourceList } from "@/features/order-sources/components/order-source-list";
+
+export default function OrderSourcesPage() {
+  return (
+    <div className="container mx-auto py-6">
+      <OrderSourceList />
+    </div>
+  );
+}

--- a/web/src/app/(dashboard)/settings/order-sources/page.tsx
+++ b/web/src/app/(dashboard)/settings/order-sources/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { OrderSourceList } from "@/features/order-sources/components/order-source-list";
+
+export default function SettingsOrderSourcesPage() {
+  return (
+    <div className="container mx-auto py-6">
+      <OrderSourceList />
+    </div>
+  );
+}

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Factory,
   Package,
   MessageSquare,
+  Store,
   Settings,
   LogOut,
 } from "lucide-react";
@@ -20,6 +21,7 @@ const navigation = [
   { name: "発注", href: "/purchase-orders", icon: FileText },
   { name: "配送", href: "/shipments", icon: Truck },
   { name: "メーカー", href: "/manufacturers", icon: Factory },
+  { name: "受注元", href: "/order-sources", icon: Store },
   { name: "商品マスタ", href: "/products", icon: Package },
   { name: "チャット", href: "/chat", icon: MessageSquare },
 ];

--- a/web/src/features/order-sources/components/order-source-delete-dialog.tsx
+++ b/web/src/features/order-sources/components/order-source-delete-dialog.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api/client";
+import type { OrderSource } from "@/types/api";
+
+interface OrderSourceDeleteDialogProps {
+  open: boolean;
+  orderSource: OrderSource;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function OrderSourceDeleteDialog({
+  open,
+  orderSource,
+  onClose,
+  onSuccess,
+}: OrderSourceDeleteDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await apiClient(`/order-sources/${orderSource.id}`, {
+        method: "DELETE",
+      });
+      onSuccess();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "削除に失敗しました";
+      setError(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>確認</DialogTitle>
+          <DialogDescription>
+            「{orderSource.name}」を本当に取り除きますか？この操作は元に戻せません。
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-600">
+            エラー: {error}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={isDeleting}
+          >
+            {isDeleting ? "削除中..." : "削除"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/order-sources/components/order-source-form-dialog.tsx
+++ b/web/src/features/order-sources/components/order-source-form-dialog.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { apiClient } from "@/lib/api/client";
+import type { OrderSource } from "@/types/api";
+
+interface OrderSourceFormDialogProps {
+  open: boolean;
+  orderSource?: OrderSource;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+interface FormData {
+  code: string;
+  name: string;
+  api_key: string;
+  phone: string;
+  postal_code: string;
+  address_prefecture: string;
+  address_city: string;
+  address_building: string;
+}
+
+interface FormErrors {
+  code?: string;
+  name?: string;
+  api_key?: string;
+  phone?: string;
+  postal_code?: string;
+  address_prefecture?: string;
+  address_city?: string;
+}
+
+const initialFormData: FormData = {
+  code: "",
+  name: "",
+  api_key: "",
+  phone: "",
+  postal_code: "",
+  address_prefecture: "",
+  address_city: "",
+  address_building: "",
+};
+
+export function OrderSourceFormDialog({
+  open,
+  orderSource,
+  onClose,
+  onSuccess,
+}: OrderSourceFormDialogProps) {
+  const isEdit = !!orderSource;
+  const [formData, setFormData] = useState<FormData>(initialFormData);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      if (orderSource) {
+        setFormData({
+          code: orderSource.code,
+          name: orderSource.name,
+          api_key: orderSource.api_key,
+          phone: orderSource.phone,
+          postal_code: orderSource.postal_code,
+          address_prefecture: orderSource.address_prefecture,
+          address_city: orderSource.address_city,
+          address_building: orderSource.address_building ?? "",
+        });
+      } else {
+        setFormData(initialFormData);
+      }
+      setErrors({});
+    }
+  }, [open, orderSource]);
+
+  const validate = (): boolean => {
+    const newErrors: FormErrors = {};
+
+    if (!formData.code.trim()) newErrors.code = "必須項目です";
+    if (!formData.name.trim()) newErrors.name = "必須項目です";
+    if (!formData.api_key.trim()) newErrors.api_key = "必須項目です";
+    if (!formData.phone.trim()) newErrors.phone = "必須項目です";
+    if (!formData.postal_code.trim()) newErrors.postal_code = "必須項目です";
+    if (!formData.address_prefecture.trim())
+      newErrors.address_prefecture = "必須項目です";
+    if (!formData.address_city.trim()) newErrors.address_city = "必須項目です";
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validate()) return;
+
+    setIsSubmitting(true);
+    try {
+      if (isEdit) {
+        await apiClient(`/order-sources/${orderSource!.id}`, {
+          method: "PATCH",
+          body: {
+            code: formData.code,
+            name: formData.name,
+            api_key: formData.api_key,
+            phone: formData.phone,
+            postal_code: formData.postal_code,
+            address_prefecture: formData.address_prefecture,
+            address_city: formData.address_city,
+            address_building: formData.address_building || null,
+          },
+        });
+      } else {
+        await apiClient("/order-sources", {
+          method: "POST",
+          body: {
+            code: formData.code,
+            name: formData.name,
+            api_key: formData.api_key,
+            phone: formData.phone,
+            postal_code: formData.postal_code,
+            address_prefecture: formData.address_prefecture,
+            address_city: formData.address_city,
+            address_building: formData.address_building || null,
+          },
+        });
+      }
+      onSuccess();
+    } catch {
+      // Error handling can be added here
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleChange = (field: keyof FormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (errors[field as keyof FormErrors]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "受注元編集" : "受注元登録"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="os-code">受注元コード</Label>
+              <Input
+                id="os-code"
+                value={formData.code}
+                onChange={(e) => handleChange("code", e.target.value)}
+              />
+              {errors.code && (
+                <p className="text-sm text-red-500">{errors.code}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="os-name">受注元名</Label>
+              <Input
+                id="os-name"
+                value={formData.name}
+                onChange={(e) => handleChange("name", e.target.value)}
+              />
+              {errors.name && (
+                <p className="text-sm text-red-500">{errors.name}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="os-api-key">APIキー</Label>
+              <Input
+                id="os-api-key"
+                value={formData.api_key}
+                onChange={(e) => handleChange("api_key", e.target.value)}
+              />
+              {errors.api_key && (
+                <p className="text-sm text-red-500">{errors.api_key}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="os-phone">電話番号</Label>
+              <Input
+                id="os-phone"
+                value={formData.phone}
+                onChange={(e) => handleChange("phone", e.target.value)}
+              />
+              {errors.phone && (
+                <p className="text-sm text-red-500">{errors.phone}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="os-postal-code">郵便番号</Label>
+              <Input
+                id="os-postal-code"
+                value={formData.postal_code}
+                onChange={(e) => handleChange("postal_code", e.target.value)}
+              />
+              {errors.postal_code && (
+                <p className="text-sm text-red-500">{errors.postal_code}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="os-prefecture">都道府県</Label>
+              <Input
+                id="os-prefecture"
+                value={formData.address_prefecture}
+                onChange={(e) =>
+                  handleChange("address_prefecture", e.target.value)
+                }
+              />
+              {errors.address_prefecture && (
+                <p className="text-sm text-red-500">
+                  {errors.address_prefecture}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="os-city">市区町村</Label>
+              <Input
+                id="os-city"
+                value={formData.address_city}
+                onChange={(e) => handleChange("address_city", e.target.value)}
+              />
+              {errors.address_city && (
+                <p className="text-sm text-red-500">{errors.address_city}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="os-building">建物名</Label>
+              <Input
+                id="os-building"
+                value={formData.address_building}
+                onChange={(e) =>
+                  handleChange("address_building", e.target.value)
+                }
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "保存中..." : "保存"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/order-sources/components/order-source-list.tsx
+++ b/web/src/features/order-sources/components/order-source-list.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { apiClient } from "@/lib/api/client";
+import { Button } from "@/components/ui/button";
+import { Plus, Pencil, Trash2 } from "lucide-react";
+import { OrderSourceFormDialog } from "./order-source-form-dialog";
+import { OrderSourceDeleteDialog } from "./order-source-delete-dialog";
+import type { OrderSource, OrderSourceListResponse } from "@/types/api";
+
+function maskApiKey(apiKey: string): string {
+  if (apiKey.length <= 4) {
+    return "****";
+  }
+  return apiKey.slice(0, 4) + "****";
+}
+
+export function OrderSourceList() {
+  const { data, isLoading, mutate } = useSWR<OrderSourceListResponse>(
+    "/order-sources?page=1&limit=20",
+    apiClient
+  );
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<OrderSource | undefined>(
+    undefined
+  );
+  const [deleteTarget, setDeleteTarget] = useState<OrderSource | undefined>(
+    undefined
+  );
+
+  const handleCreateClick = () => {
+    setEditTarget(undefined);
+    setFormOpen(true);
+  };
+
+  const handleEditClick = (source: OrderSource) => {
+    setEditTarget(source);
+    setFormOpen(true);
+  };
+
+  const handleDeleteClick = (source: OrderSource) => {
+    setDeleteTarget(source);
+  };
+
+  const handleFormSuccess = () => {
+    setFormOpen(false);
+    setEditTarget(undefined);
+    mutate();
+  };
+
+  const handleFormClose = () => {
+    setFormOpen(false);
+    setEditTarget(undefined);
+  };
+
+  const handleDeleteSuccess = () => {
+    setDeleteTarget(undefined);
+    mutate();
+  };
+
+  const handleDeleteClose = () => {
+    setDeleteTarget(undefined);
+  };
+
+  const items = data?.items ?? [];
+
+  if (isLoading) {
+    return (
+      <div>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">受注元一覧</h2>
+          <Button onClick={handleCreateClick}>
+            <Plus className="mr-1 h-4 w-4" />
+            新規登録
+          </Button>
+        </div>
+        <div className="flex items-center justify-center py-12">
+          <span className="text-muted-foreground">読み込み中...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold">受注元一覧</h2>
+        <Button onClick={handleCreateClick}>
+          <Plus className="mr-1 h-4 w-4" />
+          新規登録
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="flex items-center justify-center rounded-lg border py-12">
+          <p className="text-muted-foreground">データがありません</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">コード</th>
+                <th className="px-4 py-3 text-left font-medium">名前</th>
+                <th className="px-4 py-3 text-left font-medium">電話番号</th>
+                <th className="px-4 py-3 text-left font-medium">住所</th>
+                <th className="px-4 py-3 text-left font-medium">APIキー</th>
+                <th className="px-4 py-3 text-left font-medium">状態</th>
+                <th className="px-4 py-3 text-left font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((source) => (
+                <tr key={source.id} className="border-b">
+                  <td className="px-4 py-3">{source.code}</td>
+                  <td className="px-4 py-3">{source.name}</td>
+                  <td className="px-4 py-3">{source.phone}</td>
+                  <td className="px-4 py-3">
+                    {source.address_prefecture}
+                    {source.address_city}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs">
+                    {maskApiKey(source.api_key)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${
+                        source.is_active
+                          ? "bg-green-100 text-green-800"
+                          : "bg-red-100 text-red-800"
+                      }`}
+                    >
+                      {source.is_active ? "有効" : "無効"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleEditClick(source)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                        編集
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDeleteClick(source)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        削除
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <OrderSourceFormDialog
+        open={formOpen}
+        orderSource={editTarget}
+        onClose={handleFormClose}
+        onSuccess={handleFormSuccess}
+      />
+
+      {deleteTarget && (
+        <OrderSourceDeleteDialog
+          open={!!deleteTarget}
+          orderSource={deleteTarget}
+          onClose={handleDeleteClose}
+          onSuccess={handleDeleteSuccess}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/features/order-sources/hooks/use-order-sources.ts
+++ b/web/src/features/order-sources/hooks/use-order-sources.ts
@@ -1,0 +1,33 @@
+import useSWR from "swr";
+import { apiClient } from "@/lib/api/client";
+import type { OrderSourceListResponse } from "@/types/api";
+
+interface UseOrderSourcesParams {
+  page?: number;
+  limit?: number;
+  is_active?: boolean;
+}
+
+export function useOrderSources(params: UseOrderSourcesParams = {}) {
+  const { page = 1, limit = 20, is_active } = params;
+
+  const queryParams = new URLSearchParams();
+  queryParams.set("page", String(page));
+  queryParams.set("limit", String(limit));
+  if (is_active !== undefined) queryParams.set("is_active", String(is_active));
+
+  const { data, error, isLoading, mutate } = useSWR<OrderSourceListResponse>(
+    `/order-sources?${queryParams.toString()}`,
+    apiClient
+  );
+
+  return {
+    orderSources: data?.items ?? [],
+    total: data?.total ?? 0,
+    page: data?.page ?? page,
+    limit: data?.limit ?? limit,
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -140,6 +140,29 @@ export interface ManufacturerOrderStatusUpdate {
   note?: string;
 }
 
+// OrderSource types
+export interface OrderSource {
+  id: string;
+  code: string;
+  name: string;
+  api_key: string;
+  phone: string;
+  postal_code: string;
+  address_prefecture: string;
+  address_city: string;
+  address_building: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OrderSourceListResponse {
+  items: OrderSource[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
 // Shipment types
 export type ShipmentStatus = "pending" | "ready" | "shipped";
 

--- a/web/tests/unit/order-source-delete-dialog.test.tsx
+++ b/web/tests/unit/order-source-delete-dialog.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * OrderSourceDeleteDialog コンポーネントのテスト
+ *
+ * FEAT-0014: 受注元管理CRUD
+ *
+ * - AC-016: 受注元一覧ページから削除確認ダイアログを開いて受注元を削除できる
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OrderSourceDeleteDialog } from '@/features/order-sources/components/order-source-delete-dialog'
+import type { OrderSource } from '@/types/api'
+
+// API クライアントをモック
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(() => Promise.resolve({})),
+}))
+
+import { apiClient } from '@/lib/api/client'
+
+const mockApiClient = vi.mocked(apiClient)
+
+const createMockOrderSource = (overrides: Partial<OrderSource> = {}): OrderSource => ({
+  id: 'source-001',
+  code: 'RKSYO',
+  name: '楽商',
+  api_key: 'test-api-key-001',
+  phone: '03-1234-5678',
+  postal_code: '100-0001',
+  address_prefecture: '東京都',
+  address_city: '千代田区1-1-1',
+  address_building: null,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('OrderSourceDeleteDialog', () => {
+  const mockOnSuccess = vi.fn()
+  const mockOnClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('ダイアログ表示', () => {
+    it('open=true で削除確認ダイアログが表示される', () => {
+      const source = createMockOrderSource()
+
+      render(
+        <OrderSourceDeleteDialog
+          open={true}
+          orderSource={source}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('open=false でダイアログが表示されない', () => {
+      const source = createMockOrderSource()
+
+      render(
+        <OrderSourceDeleteDialog
+          open={false}
+          orderSource={source}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('削除確認メッセージに受注元名が含まれる', () => {
+      const source = createMockOrderSource({ name: '楽商' })
+
+      render(
+        <OrderSourceDeleteDialog
+          open={true}
+          orderSource={source}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // 受注元名を含む確認メッセージが表示される
+      expect(screen.getByText(/楽商/)).toBeInTheDocument()
+      expect(screen.getByText(/削除/)).toBeInTheDocument()
+    })
+  })
+
+  describe('AC-016: 削除確認ダイアログで削除できる', () => {
+    it('「削除」ボタンをクリックするとDELETE APIが呼ばれる', async () => {
+      const user = userEvent.setup()
+      const source = createMockOrderSource({ id: 'source-to-delete' })
+      mockApiClient.mockResolvedValueOnce({})
+
+      render(
+        <OrderSourceDeleteDialog
+          open={true}
+          orderSource={source}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // 削除ボタンをクリック
+      const deleteButton = screen.getByRole('button', { name: /削除/ })
+      await user.click(deleteButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/order-sources/source-to-delete'),
+          expect.objectContaining({
+            method: 'DELETE',
+          })
+        )
+        expect(mockOnSuccess).toHaveBeenCalled()
+      })
+    })
+
+    it('削除中はローディング表示がされる', async () => {
+      const user = userEvent.setup()
+      const source = createMockOrderSource()
+
+      // APIコールをハングさせる
+      mockApiClient.mockImplementationOnce(() => new Promise(() => {}))
+
+      render(
+        <OrderSourceDeleteDialog
+          open={true}
+          orderSource={source}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const deleteButton = screen.getByRole('button', { name: /削除/ })
+      await user.click(deleteButton)
+
+      await waitFor(() => {
+        // ローディング状態の表示（ボタンテキストの変化やスピナー）
+        expect(screen.getByText(/削除中|処理中/)).toBeInTheDocument()
+      })
+    })
+
+    it('削除エラー時にエラーメッセージが表示される', async () => {
+      const user = userEvent.setup()
+      const source = createMockOrderSource()
+      mockApiClient.mockRejectedValueOnce(new Error('Server error'))
+
+      render(
+        <OrderSourceDeleteDialog
+          open={true}
+          orderSource={source}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const deleteButton = screen.getByRole('button', { name: /削除/ })
+      await user.click(deleteButton)
+
+      await waitFor(() => {
+        expect(screen.getByText(/エラー|失敗|Server error/)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('キャンセル操作', () => {
+    it('キャンセルボタンでダイアログが閉じる', async () => {
+      const user = userEvent.setup()
+      const source = createMockOrderSource()
+
+      render(
+        <OrderSourceDeleteDialog
+          open={true}
+          orderSource={source}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const cancelButton = screen.getByRole('button', { name: /キャンセル/ })
+      await user.click(cancelButton)
+
+      expect(mockOnClose).toHaveBeenCalled()
+      // APIが呼ばれないこと
+      expect(mockApiClient).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/web/tests/unit/order-source-form-dialog.test.tsx
+++ b/web/tests/unit/order-source-form-dialog.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * OrderSourceFormDialog コンポーネントのテスト
+ *
+ * FEAT-0014: 受注元管理CRUD
+ *
+ * - AC-014: 新規登録ダイアログを開いて受注元を登録できる
+ * - AC-015: 編集ダイアログを開いて受注元を編集できる
+ * - AC-019: 受注元フォームのバリデーションが動作する
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OrderSourceFormDialog } from '@/features/order-sources/components/order-source-form-dialog'
+import type { OrderSource } from '@/types/api'
+
+// API クライアントをモック
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(() => Promise.resolve({})),
+}))
+
+import { apiClient } from '@/lib/api/client'
+
+const mockApiClient = vi.mocked(apiClient)
+
+const createMockOrderSource = (overrides: Partial<OrderSource> = {}): OrderSource => ({
+  id: 'source-001',
+  code: 'RKSYO',
+  name: '楽商',
+  api_key: 'test-api-key-001',
+  phone: '03-1234-5678',
+  postal_code: '100-0001',
+  address_prefecture: '東京都',
+  address_city: '千代田区1-1-1',
+  address_building: null,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('OrderSourceFormDialog', () => {
+  const mockOnSuccess = vi.fn()
+  const mockOnClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('ダイアログ表示', () => {
+    it('open=true でダイアログが表示される', () => {
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('open=false でダイアログが表示されない', () => {
+      render(
+        <OrderSourceFormDialog
+          open={false}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('新規登録時は「受注元登録」のタイトルが表示される', () => {
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.getByText(/受注元登録|新規登録|受注元を追加/)).toBeInTheDocument()
+    })
+
+    it('編集時は「受注元編集」のタイトルが表示される', () => {
+      const existingSource = createMockOrderSource()
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          orderSource={existingSource}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.getByText(/受注元編集|編集/)).toBeInTheDocument()
+    })
+  })
+
+  describe('AC-014: 新規登録ダイアログ', () => {
+    it('必要な入力フィールドが全て表示される', () => {
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // 必須フィールドのラベルまたはプレースホルダーが存在すること
+      expect(screen.getByLabelText(/受注元コード|コード/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/受注元名|名前|名称/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/APIキー|API キー/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/電話番号/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/郵便番号/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/都道府県/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/市区町村/)).toBeInTheDocument()
+    })
+
+    it('保存ボタンが表示される', () => {
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: /保存|登録|作成/ })).toBeInTheDocument()
+    })
+
+    it('フォーム送信時にPOST APIが呼ばれる', async () => {
+      const user = userEvent.setup()
+      mockApiClient.mockResolvedValueOnce({
+        id: 'new-source',
+        code: 'NEW01',
+        name: '新規受注元',
+      })
+
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // フォームに入力
+      await user.type(screen.getByLabelText(/受注元コード|コード/), 'NEW01')
+      await user.type(screen.getByLabelText(/受注元名|名前|名称/), '新規受注元')
+      await user.type(screen.getByLabelText(/APIキー|API キー/), 'new-api-key')
+      await user.type(screen.getByLabelText(/電話番号/), '03-0000-0000')
+      await user.type(screen.getByLabelText(/郵便番号/), '100-0001')
+      await user.type(screen.getByLabelText(/都道府県/), '東京都')
+      await user.type(screen.getByLabelText(/市区町村/), '千代田区')
+
+      // 保存ボタンをクリック
+      const submitButton = screen.getByRole('button', { name: /保存|登録|作成/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/order-sources'),
+          expect.objectContaining({
+            method: 'POST',
+          })
+        )
+        expect(mockOnSuccess).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('AC-015: 編集ダイアログ', () => {
+    it('既存データがフォームにプリセットされる', () => {
+      const existingSource = createMockOrderSource({
+        code: 'EXIST',
+        name: '既存受注元',
+        phone: '03-9999-8888',
+      })
+
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          orderSource={existingSource}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // 既存のデータが入力フィールドに表示されること
+      expect(screen.getByDisplayValue('EXIST')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('既存受注元')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('03-9999-8888')).toBeInTheDocument()
+    })
+
+    it('編集時にPATCH APIが呼ばれる', async () => {
+      const user = userEvent.setup()
+      const existingSource = createMockOrderSource({ id: 'source-001' })
+      mockApiClient.mockResolvedValueOnce({
+        ...existingSource,
+        name: '更新後の名前',
+      })
+
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          orderSource={existingSource}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // 名前フィールドを変更
+      const nameInput = screen.getByLabelText(/受注元名|名前|名称/)
+      await user.clear(nameInput)
+      await user.type(nameInput, '更新後の名前')
+
+      // 保存ボタンをクリック
+      const submitButton = screen.getByRole('button', { name: /保存|更新/ })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockApiClient).toHaveBeenCalledWith(
+          expect.stringContaining('/order-sources/source-001'),
+          expect.objectContaining({
+            method: 'PATCH',
+          })
+        )
+        expect(mockOnSuccess).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('AC-019: フォームバリデーション', () => {
+    it('必須項目を空のまま保存しようとするとバリデーションエラーが表示される', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // 何も入力せずに保存ボタンをクリック
+      const submitButton = screen.getByRole('button', { name: /保存|登録|作成/ })
+      await user.click(submitButton)
+
+      // バリデーションエラーが表示されること
+      await waitFor(() => {
+        // 必須フィールドのエラーメッセージが表示される
+        const errorMessages = screen.getAllByText(/必須|入力してください|required/i)
+        expect(errorMessages.length).toBeGreaterThan(0)
+      })
+
+      // APIが呼ばれないこと
+      expect(mockApiClient).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('キャンセルボタン', () => {
+    it('キャンセルボタンでダイアログが閉じる', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <OrderSourceFormDialog
+          open={true}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      const cancelButton = screen.getByRole('button', { name: /キャンセル|閉じる|戻る/ })
+      await user.click(cancelButton)
+
+      expect(mockOnClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/web/tests/unit/order-source-list.test.tsx
+++ b/web/tests/unit/order-source-list.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * OrderSourceList コンポーネントのテスト
+ *
+ * FEAT-0014: 受注元管理CRUD
+ *
+ * - AC-013: /order-sources ページで受注元一覧が表示される
+ * - AC-017: サイドバーに「受注元」メニューが表示される
+ * - AC-020: APIキーがマスク表示される
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { OrderSourceList } from '@/features/order-sources/components/order-source-list'
+import type { OrderSource } from '@/types/api'
+
+// SWR をモック
+vi.mock('swr', () => ({
+  default: vi.fn(),
+}))
+
+// API クライアントをモック
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(() => Promise.resolve({})),
+}))
+
+import useSWR from 'swr'
+
+const mockUseSWR = vi.mocked(useSWR)
+
+const createMockOrderSource = (overrides: Partial<OrderSource> = {}): OrderSource => ({
+  id: 'source-001',
+  code: 'RKSYO',
+  name: '楽商',
+  api_key: 'secret-api-key-12345',
+  phone: '03-1234-5678',
+  postal_code: '100-0001',
+  address_prefecture: '東京都',
+  address_city: '千代田区1-1-1',
+  address_building: null,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('OrderSourceList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('AC-013: 受注元一覧が表示される', () => {
+    it('受注元のコード、名前、電話番号が一覧表示される', () => {
+      const mockSources = [
+        createMockOrderSource({ id: 'src-1', code: 'RKSYO', name: '楽商', phone: '03-1234-5678' }),
+        createMockOrderSource({ id: 'src-2', code: 'BASE01', name: 'BASE', phone: '06-9876-5432' }),
+      ]
+
+      mockUseSWR.mockReturnValue({
+        data: { items: mockSources, total: 2, page: 1, limit: 20 },
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as any)
+
+      render(<OrderSourceList />)
+
+      // コードが表示されること
+      expect(screen.getByText('RKSYO')).toBeInTheDocument()
+      expect(screen.getByText('BASE01')).toBeInTheDocument()
+
+      // 名前が表示されること
+      expect(screen.getByText('楽商')).toBeInTheDocument()
+      expect(screen.getByText('BASE')).toBeInTheDocument()
+
+      // 電話番号が表示されること
+      expect(screen.getByText('03-1234-5678')).toBeInTheDocument()
+      expect(screen.getByText('06-9876-5432')).toBeInTheDocument()
+    })
+
+    it('有効/無効状態が一覧表示される', () => {
+      const mockSources = [
+        createMockOrderSource({ id: 'src-1', is_active: true }),
+        createMockOrderSource({ id: 'src-2', code: 'INACT', name: '無効元', is_active: false }),
+      ]
+
+      mockUseSWR.mockReturnValue({
+        data: { items: mockSources, total: 2, page: 1, limit: 20 },
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as any)
+
+      render(<OrderSourceList />)
+
+      // 有効/無効の表示がある（テキストまたはバッジで表示される想定）
+      const activeElements = screen.getAllByText(/有効|無効/)
+      expect(activeElements.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('ローディング中はローディング表示がされる', () => {
+      mockUseSWR.mockReturnValue({
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as any)
+
+      render(<OrderSourceList />)
+
+      // ローディング中の表示があること（テキストまたはスピナー）
+      // 具体的なUI実装に依存するが、テーブルにデータがないことを確認
+      expect(screen.queryByText('RKSYO')).not.toBeInTheDocument()
+    })
+
+    it('受注元が0件の場合は空状態が表示される', () => {
+      mockUseSWR.mockReturnValue({
+        data: { items: [], total: 0, page: 1, limit: 20 },
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as any)
+
+      render(<OrderSourceList />)
+
+      // 受注元がない場合のメッセージがある（実装依存）
+      expect(screen.queryByText('RKSYO')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('AC-020: APIキーがマスク表示される', () => {
+    it('APIキーがマスク表示される（先頭数文字 + ****）', () => {
+      const mockSources = [
+        createMockOrderSource({
+          id: 'src-1',
+          api_key: 'secret-api-key-12345',
+        }),
+      ]
+
+      mockUseSWR.mockReturnValue({
+        data: { items: mockSources, total: 1, page: 1, limit: 20 },
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as any)
+
+      render(<OrderSourceList />)
+
+      // APIキーの全文が表示されないこと
+      expect(screen.queryByText('secret-api-key-12345')).not.toBeInTheDocument()
+      // マスクされた表示があること（先頭数文字 + **** のパターン）
+      const maskedElement = screen.getByText(/secr.*\*/)
+      expect(maskedElement).toBeInTheDocument()
+    })
+  })
+
+  describe('新規登録ボタン', () => {
+    it('「新規登録」ボタンが表示される', () => {
+      mockUseSWR.mockReturnValue({
+        data: { items: [], total: 0, page: 1, limit: 20 },
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as any)
+
+      render(<OrderSourceList />)
+
+      expect(screen.getByRole('button', { name: /新規登録|新規|追加/ })).toBeInTheDocument()
+    })
+  })
+})

--- a/web/tests/unit/settings-order-sources-page.test.tsx
+++ b/web/tests/unit/settings-order-sources-page.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * /settings/order-sources ページのテスト
+ *
+ * FEAT-0014: 受注元管理CRUD
+ *
+ * - AC-017: サイドバーに「受注元」メニューが表示される
+ * - AC-018: /settings/order-sources にアクセスすると受注元管理ページが表示される
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import SettingsOrderSourcesPage from '@/app/(dashboard)/settings/order-sources/page'
+import { Sidebar } from '@/components/layout/sidebar'
+import type { User } from '@/types/api'
+
+// SWR をモック
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({
+    data: { items: [], total: 0, page: 1, limit: 20 },
+    error: undefined,
+    isLoading: false,
+    isValidating: false,
+    mutate: vi.fn(),
+  })),
+}))
+
+// API クライアントをモック
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(() => Promise.resolve({})),
+}))
+
+// useCurrentUser をモック
+vi.mock('@/features/auth/hooks/use-current-user', () => ({
+  useCurrentUser: vi.fn(),
+}))
+
+import { useCurrentUser } from '@/features/auth/hooks/use-current-user'
+
+const mockUseCurrentUser = vi.mocked(useCurrentUser)
+
+describe('Settings Order Sources Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('AC-018: /settings/order-sources にアクセスすると受注元管理ページが表示される', () => {
+    it('受注元管理ページが正常にレンダリングされる', () => {
+      render(<SettingsOrderSourcesPage />)
+
+      // ページが正常に表示されること（受注元に関連するテキストが存在）
+      expect(screen.getByText(/受注元/)).toBeInTheDocument()
+    })
+
+    it('受注元一覧コンポーネントが含まれている', () => {
+      render(<SettingsOrderSourcesPage />)
+
+      // 新規登録ボタンが表示されること（OrderSourceList が含まれている証拠）
+      expect(screen.getByRole('button', { name: /新規登録|新規|追加/ })).toBeInTheDocument()
+    })
+  })
+
+  describe('AC-017: サイドバーに「受注元」メニューが表示される', () => {
+    it('サイドバーに「受注元」メニューリンクが表示される', () => {
+      const mockUser: User = {
+        id: 'user-123',
+        email: 'admin@example.com',
+        name: 'Admin User',
+        role: 'admin',
+        is_active: true,
+      }
+
+      mockUseCurrentUser.mockReturnValue({
+        user: mockUser,
+        isLoading: false,
+        error: undefined,
+        mutate: vi.fn(),
+      })
+
+      render(<Sidebar />)
+
+      // 「受注元」メニューが表示されること
+      expect(screen.getByText('受注元')).toBeInTheDocument()
+    })
+
+    it('「受注元」メニューが /order-sources へのリンクを持つ', () => {
+      const mockUser: User = {
+        id: 'user-123',
+        email: 'admin@example.com',
+        name: 'Admin User',
+        role: 'admin',
+        is_active: true,
+      }
+
+      mockUseCurrentUser.mockReturnValue({
+        user: mockUser,
+        isLoading: false,
+        error: undefined,
+        mutate: vi.fn(),
+      })
+
+      render(<Sidebar />)
+
+      // 受注元リンクが /order-sources を指していること
+      const orderSourceLink = screen.getByText('受注元').closest('a')
+      expect(orderSourceLink).toHaveAttribute('href', '/order-sources')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- バックエンドAPI: 受注元のCRUDエンドポイント（一覧/詳細/作成/更新/削除）、サービス層、スキーマを追加
- フロントエンドUI: 受注元一覧表示、新規登録/編集/削除ダイアログ、サイドバーメニュー追加
- `/order-sources` および `/settings/order-sources` の両パスで受注元管理が可能
- APIキーのマスク表示、重複チェック（code/api_key）、バリデーション対応

## Test plan
- [x] バックエンドユニットテスト（13件パス）
- [x] バックエンド統合テスト（17件パス）
- [x] フロントエンドユニットテスト（28件パス、4テストファイル）
- [x] 全267バックエンドテスト + 全155フロントエンドテスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)