### PR TITLE
fix: 商品マスター一覧のメーカー名が表示されない不具合を修正 (#28)

### DIFF
--- a/.claude/specs/FEAT-0016-product-manufacturer-name.yaml
+++ b/.claude/specs/FEAT-0016-product-manufacturer-name.yaml
@@ -1,0 +1,149 @@
+id: FEAT-0016
+summary: 商品マスター一覧で各商品のメーカー名が正しく表示される
+
+background:
+  why: |
+    商品マスター一覧画面にはメーカー列が存在するが、APIレスポンスにmanufacturer_nameフィールドが含まれていないため
+    常に「-」と表示されてしまう。原因は以下の3点:
+    1. バックエンドのProductResponseスキーマにmanufacturer_nameフィールドが定義されていない
+    2. ProductRepositoryのfind_allクエリでmanufacturerリレーションをeager loadしていない
+    3. ProductServiceでProductResponseを構築する際にmanufacturer.nameを含めていない
+    フロントエンド側は既にmanufacturer_nameを表示する実装が完了しているが（product-list.tsx 67行目）、
+    バックエンドがこのフィールドを返さないためnull/undefinedとなり「-」表示になっている。
+  who: 管理者（admin）
+  when: |
+    - 商品マスター一覧画面（/products）を開いて各商品のメーカーを確認するとき
+    - 商品をメーカー別にフィルタリングして確認するとき
+
+scope:
+  includes:
+    - バックエンド: ProductResponseスキーマにmanufacturer_name（Optional[str]）フィールドを追加
+    - バックエンド: ProductRepositoryのfind_all / find_by_idクエリでmanufacturerリレーションをeager load（selectinloadまたはjoinedload）
+    - バックエンド: ProductServiceでProductResponseを構築する際にmanufacturer_nameを含める
+    - バックエンド: ユニットテスト・統合テストの追加
+    - フロントエンド: TypeScript型定義は既にmanufacturer_nameを含んでいるため変更不要（確認のみ）
+    - フロントエンド: ProductListコンポーネントは既にmanufacturer_nameを表示する実装済みのため変更不要（確認のみ）
+  excludes:
+    - フロントエンドの変更（既にmanufacturer_name表示に対応済み）
+    - DBマイグレーション（Productテーブルにはmanufacturer_idカラムが既に存在し、manufacturersテーブルとのFKリレーションも正常）
+    - メーカーマスターのCRUD機能（既に実装済み）
+  prerequisites:
+    - Productモデルにmanufacturerリレーションが定義されていること（確認済み: app/models/product.py 41行目）
+    - Manufacturerモデルにproductsリレーションが定義されていること（確認済み: app/models/manufacturer.py 51行目）
+    - フロントエンドのProduct型にmanufacturer_nameフィールドが定義されていること（確認済み: web/src/types/api/index.ts 242行目）
+
+input_output:
+  inputs:
+    - name: page
+      type: number
+      required: false
+      validation: 1以上の整数（デフォルト1）
+    - name: limit
+      type: number
+      required: false
+      validation: 1〜100の整数（デフォルト20）
+    - name: product_type
+      type: string
+      required: false
+      validation: ProductTypeのenum値
+    - name: manufacturer_id
+      type: string
+      required: false
+      validation: UUID文字列
+    - name: is_active
+      type: boolean
+      required: false
+      validation: true/false
+  outputs:
+    - name: ProductListResponse
+      type: object
+      description: |
+        items配列の各ProductResponseに manufacturer_name: string | null が追加される。
+        manufacturer_idに対応するメーカーが存在する場合はその名前、存在しない場合はnull。
+    - name: ProductResponse（単体取得時も同様）
+      type: object
+      description: manufacturer_nameフィールドが含まれる
+  state_changes:
+    - なし（読み取り専用の修正、データ変更なし）
+
+acceptance_criteria:
+  # --- バックエンドAPI（統合テスト） ---
+  - id: AC-001
+    description: GET /products のレスポンスに各商品のmanufacturer_nameフィールドが含まれる
+    test_type: integration
+    given: メーカーAに紐づく商品が1件以上登録されている
+    when: GET /api/v1/products を管理者トークンで呼び出す
+    then: レスポンスのitems配列の各要素にmanufacturer_nameフィールドが含まれ、メーカーAの名前が設定されている
+
+  - id: AC-002
+    description: GET /products/{id} のレスポンスにmanufacturer_nameフィールドが含まれる
+    test_type: integration
+    given: メーカーAに紐づく商品が登録されている
+    when: GET /api/v1/products/{id} を管理者トークンで呼び出す
+    then: レスポンスにmanufacturer_nameフィールドが含まれ、メーカーAの名前が設定されている
+
+  - id: AC-003
+    description: POST /products で作成した商品のレスポンスにmanufacturer_nameが含まれる
+    test_type: integration
+    given: メーカーAが存在する
+    when: POST /api/v1/products でメーカーAのIDを指定して商品を作成する
+    then: 201レスポンスのmanufacturer_nameにメーカーAの名前が設定されている
+
+  - id: AC-004
+    description: PATCH /products/{id} で更新した商品のレスポンスにmanufacturer_nameが含まれる
+    test_type: integration
+    given: メーカーAに紐づく商品が登録されている
+    when: PATCH /api/v1/products/{id} で商品を更新する
+    then: レスポンスのmanufacturer_nameにメーカーAの名前が設定されている
+
+  # --- バックエンドサービスロジック（ユニットテスト） ---
+  - id: AC-005
+    description: ProductResponseスキーマにmanufacturer_nameフィールドが定義されている
+    test_type: unit
+    given: ProductResponseスキーマが定義されている
+    when: manufacturer_nameフィールドの存在を確認する
+    then: manufacturer_name: Optional[str]（デフォルトnull）が定義されている
+
+  - id: AC-006
+    description: ProductServiceのlistメソッドがmanufacturer_nameを含むレスポンスを返す
+    test_type: unit
+    given: manufacturer.name = "テストメーカー"のリレーションを持つProductオブジェクトがリポジトリから返される
+    when: ProductService.list()を呼び出す
+    then: 各ProductResponseのmanufacturer_nameに"テストメーカー"が設定されている
+
+  - id: AC-007
+    description: ProductServiceのget_by_idメソッドがmanufacturer_nameを含むレスポンスを返す
+    test_type: unit
+    given: manufacturer.name = "テストメーカー"のリレーションを持つProductオブジェクトがリポジトリから返される
+    when: ProductService.get_by_id()を呼び出す
+    then: ProductResponseのmanufacturer_nameに"テストメーカー"が設定されている
+
+  - id: AC-008
+    description: manufacturerリレーションがNoneの場合、manufacturer_nameはnullになる
+    test_type: unit
+    given: manufacturerリレーションが未ロードまたはNoneのProductオブジェクトがある
+    when: ProductResponseを構築する
+    then: manufacturer_nameがnullになる
+
+constraints:
+  performance:
+    - manufacturerリレーションのeager loadによるN+1問題の回避（selectinloadまたはjoinedloadを使用）
+    - 一覧取得のレスポンスは500ms以内（既存要件維持）
+  security:
+    - 管理者（admin）のみアクセス可能（既存のget_current_admin依存性を維持）
+  compatibility:
+    - 既存のProductResponse消費元（受注画面、メーカー発注画面等）に影響を与えない（フィールド追加のみ、既存フィールドの変更なし）
+    - フロントエンドのProduct型定義との整合性を保つ
+
+assumptions:
+  - manufacturerリレーションのeager loadにはselectinloadを使用する（joinedloadだとページネーションに影響する可能性があるため）
+  - ProductResponseにmanufacturer_nameフィールドを追加する際、Pydanticのmodel_validate時にORMモデルから自動的にリレーション経由で値を取得するため、カスタムバリデータまたはプロパティが必要になる可能性がある
+  - find_by_idでもeager loadを適用し、単体取得時もmanufacturer_nameが返るようにする
+  - 既存のcreate/updateメソッドでも返却時にmanufacturer_nameを含める（リポジトリのrefresh後にリレーションをロードする、またはリポジトリのrefreshでeager loadを適用する）
+
+success_metrics:
+  - 商品マスター一覧画面（/products）で各商品のメーカー列にメーカー名が正しく表示される
+  - 商品詳細取得APIでmanufacturer_nameが正しく返される
+  - 商品作成・更新APIのレスポンスにもmanufacturer_nameが含まれる
+  - バックエンドのユニット・統合テストが全てパスする
+  - 既存テストが影響を受けず全てパスする

--- a/api/app/repositories/product_repository.py
+++ b/api/app/repositories/product_repository.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models.product import Product, ProductType
 
@@ -14,7 +15,11 @@ class ProductRepository:
 
     async def find_by_id(self, product_id: str) -> Product | None:
         """Find a product by ID."""
-        result = await self._db.execute(select(Product).where(Product.id == product_id))
+        result = await self._db.execute(
+            select(Product)
+            .options(selectinload(Product.manufacturer))
+            .where(Product.id == product_id)
+        )
         return result.scalar_one_or_none()
 
     async def find_all(
@@ -51,7 +56,7 @@ class ProductRepository:
 
         # Apply pagination
         offset = (page - 1) * limit
-        query = query.order_by(Product.created_at.desc()).offset(offset).limit(limit)
+        query = query.options(selectinload(Product.manufacturer)).order_by(Product.created_at.desc()).offset(offset).limit(limit)
 
         result = await self._db.execute(query)
         products = list(result.scalars().all())
@@ -63,13 +68,15 @@ class ProductRepository:
         self._db.add(product)
         await self._db.flush()
         await self._db.refresh(product)
-        return product
+        # Re-fetch with manufacturer relation loaded
+        return await self.find_by_id(product.id)  # type: ignore[return-value]
 
     async def update(self, product: Product) -> Product:
         """Update an existing product."""
         await self._db.flush()
         await self._db.refresh(product)
-        return product
+        # Re-fetch with manufacturer relation loaded
+        return await self.find_by_id(product.id)  # type: ignore[return-value]
 
     async def delete(self, product: Product) -> None:
         """Delete a product."""

--- a/api/app/schemas/product.py
+++ b/api/app/schemas/product.py
@@ -47,6 +47,7 @@ class ProductResponse(ProductBase):
 
     id: str
     is_active: bool
+    manufacturer_name: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/api/app/services/product_service.py
+++ b/api/app/services/product_service.py
@@ -27,6 +27,32 @@ class ProductService:
         self._product_repo = product_repo
         self._manufacturer_repo = manufacturer_repo
 
+    @staticmethod
+    def _to_response(product) -> ProductResponse:
+        """Convert a Product model to ProductResponse with manufacturer_name."""
+        manufacturer = getattr(product, "manufacturer", None)
+        manufacturer_name: str | None = None
+        if manufacturer is not None:
+            name = getattr(manufacturer, "name", None)
+            if isinstance(name, str):
+                manufacturer_name = name
+        data = {
+            "id": product.id,
+            "product_type": product.product_type,
+            "size": product.size,
+            "position": product.position,
+            "color": product.color,
+            "manufacturer_id": product.manufacturer_id,
+            "cost": product.cost,
+            "lead_time_days": product.lead_time_days,
+            "order_limit": product.order_limit,
+            "is_active": product.is_active,
+            "manufacturer_name": manufacturer_name,
+            "created_at": product.created_at,
+            "updated_at": product.updated_at,
+        }
+        return ProductResponse(**data)
+
     async def _check_duplicate(
         self,
         product_type: str,
@@ -78,14 +104,14 @@ class ProductService:
         )
 
         product = await self._product_repo.create(product)
-        return ProductResponse.model_validate(product)
+        return self._to_response(product)
 
     async def get_by_id(self, product_id: str) -> ProductResponse:
         """Get a product by ID."""
         product = await self._product_repo.find_by_id(product_id)
         if not product:
             raise ProductNotFoundError(product_id)
-        return ProductResponse.model_validate(product)
+        return self._to_response(product)
 
     async def list(
         self,
@@ -107,7 +133,7 @@ class ProductService:
         )
 
         return ProductListResponse(
-            items=[ProductResponse.model_validate(p) for p in products],
+            items=[self._to_response(p) for p in products],
             total=total,
             page=page,
             limit=limit,
@@ -162,7 +188,7 @@ class ProductService:
                 setattr(product, field, value)
 
         product = await self._product_repo.update(product)
-        return ProductResponse.model_validate(product)
+        return self._to_response(product)
 
     async def delete(self, product_id: str) -> None:
         """Delete a product."""

--- a/api/tests/integration/test_product_manufacturer_name.py
+++ b/api/tests/integration/test_product_manufacturer_name.py
@@ -1,0 +1,302 @@
+"""商品のメーカー名（manufacturer_name）API統合テスト
+
+FEAT-0016: 商品マスター一覧で各商品のメーカー名が正しく表示される
+
+テスト対象: /api/v1/products エンドポイント
+- AC-001: GET /products のレスポンスに各商品の manufacturer_name フィールドが含まれる
+- AC-002: GET /products/{id} のレスポンスに manufacturer_name フィールドが含まれる
+- AC-003: POST /products で作成した商品のレスポンスに manufacturer_name が含まれる
+- AC-004: PATCH /products/{id} で更新した商品のレスポンスに manufacturer_name が含まれる
+"""
+
+import pytest
+from uuid import uuid4
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+
+
+# APIプレフィックス
+API_PREFIX = settings.API_V1_PREFIX
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def test_manufacturer(db_session: AsyncSession):
+    """テスト用のメーカーを作成"""
+    manufacturer_id = str(uuid4())
+
+    await db_session.execute(
+        text("""
+            INSERT INTO manufacturers (
+                id, name, email, phone, supported_products, unit_prices,
+                lead_time_days, daily_order_limit, sharing_method, is_active,
+                created_at, updated_at
+            )
+            VALUES (
+                :id, :name, :email, :phone, :supported_products, :unit_prices,
+                :lead_time_days, :daily_order_limit, :sharing_method, :is_active,
+                NOW(), NOW()
+            )
+        """),
+        {
+            "id": manufacturer_id,
+            "name": f"テストメーカー_{manufacturer_id[:8]}",
+            "email": f"test-{manufacturer_id[:8]}@example.com",
+            "phone": "03-1234-5678",
+            "supported_products": ["acrylic_keychain", "sticker"],
+            "unit_prices": "{}",
+            "lead_time_days": 7,
+            "daily_order_limit": 100,
+            "sharing_method": "portal",
+            "is_active": True,
+        }
+    )
+    await db_session.commit()
+
+    yield {
+        "id": manufacturer_id,
+        "name": f"テストメーカー_{manufacturer_id[:8]}",
+    }
+
+
+@pytest.fixture
+async def test_product(db_session: AsyncSession, test_manufacturer: dict):
+    """テスト用の商品を作成（メーカーに紐づく）"""
+    product_id = str(uuid4())
+    unique_suffix = product_id[:8]
+
+    await db_session.execute(
+        text("""
+            INSERT INTO products (
+                id, product_type, size, position, color,
+                manufacturer_id, cost, lead_time_days, order_limit,
+                is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :product_type, :size, :position, :color,
+                :manufacturer_id, :cost, :lead_time_days, :order_limit,
+                :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": product_id,
+            "product_type": "acrylic_keychain",
+            "size": f"50x50mm_{unique_suffix}",
+            "position": f"center_{unique_suffix}",
+            "color": f"clear_{unique_suffix}",
+            "manufacturer_id": test_manufacturer["id"],
+            "cost": 500,
+            "lead_time_days": 7,
+            "order_limit": 100,
+            "is_active": True,
+        }
+    )
+    await db_session.commit()
+
+    yield {
+        "id": product_id,
+        "manufacturer_id": test_manufacturer["id"],
+        "manufacturer_name": test_manufacturer["name"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC-001: GET /products のレスポンスに manufacturer_name が含まれる
+# ---------------------------------------------------------------------------
+
+class TestListProductsManufacturerName:
+    """AC-001: 商品一覧APIのmanufacturer_nameテスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac001_list_products_includes_manufacturer_name(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_product: dict,
+    ):
+        """AC-001: GET /products のレスポンスに各商品の manufacturer_name フィールドが含まれる
+
+        given: メーカーAに紐づく商品が1件以上登録されている
+        when: GET /api/v1/products を管理者トークンで呼び出す
+        then: レスポンスの items 配列の各要素に manufacturer_name フィールドが含まれ、
+              メーカーAの名前が設定されている
+        """
+        response = await client.get(
+            f"{API_PREFIX}/products",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert len(data["items"]) >= 1
+
+        # テストで作成した商品を探す
+        test_item = None
+        for item in data["items"]:
+            if item["id"] == test_product["id"]:
+                test_item = item
+                break
+
+        assert test_item is not None, (
+            f"Test product {test_product['id']} not found in response items"
+        )
+
+        # manufacturer_name フィールドが存在し、正しい値であること
+        assert "manufacturer_name" in test_item, (
+            "manufacturer_name field should be present in product response"
+        )
+        assert test_item["manufacturer_name"] == test_product["manufacturer_name"], (
+            f"Expected manufacturer_name to be '{test_product['manufacturer_name']}', "
+            f"got '{test_item['manufacturer_name']}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-002: GET /products/{id} のレスポンスに manufacturer_name が含まれる
+# ---------------------------------------------------------------------------
+
+class TestGetProductManufacturerName:
+    """AC-002: 商品詳細APIのmanufacturer_nameテスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac002_get_product_includes_manufacturer_name(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_product: dict,
+    ):
+        """AC-002: GET /products/{id} のレスポンスに manufacturer_name フィールドが含まれる
+
+        given: メーカーAに紐づく商品が登録されている
+        when: GET /api/v1/products/{id} を管理者トークンで呼び出す
+        then: レスポンスに manufacturer_name フィールドが含まれ、メーカーAの名前が設定されている
+        """
+        product_id = test_product["id"]
+
+        response = await client.get(
+            f"{API_PREFIX}/products/{product_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # manufacturer_name フィールドが存在し、正しい値であること
+        assert "manufacturer_name" in data, (
+            "manufacturer_name field should be present in product response"
+        )
+        assert data["manufacturer_name"] == test_product["manufacturer_name"], (
+            f"Expected manufacturer_name to be '{test_product['manufacturer_name']}', "
+            f"got '{data['manufacturer_name']}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-003: POST /products で作成した商品のレスポンスに manufacturer_name が含まれる
+# ---------------------------------------------------------------------------
+
+class TestCreateProductManufacturerName:
+    """AC-003: 商品作成APIのmanufacturer_nameテスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac003_create_product_includes_manufacturer_name(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_manufacturer: dict,
+    ):
+        """AC-003: POST /products で作成した商品のレスポンスに manufacturer_name が含まれる
+
+        given: メーカーAが存在する
+        when: POST /api/v1/products でメーカーAのIDを指定して商品を作成する
+        then: 201レスポンスの manufacturer_name にメーカーAの名前が設定されている
+        """
+        unique_suffix = str(uuid4())[:8]
+        create_data = {
+            "product_type": "sticker",
+            "size": f"100x100mm_{unique_suffix}",
+            "position": f"top_{unique_suffix}",
+            "color": f"white_{unique_suffix}",
+            "manufacturer_id": test_manufacturer["id"],
+            "cost": 300,
+            "lead_time_days": 5,
+            "order_limit": 50,
+        }
+
+        response = await client.post(
+            f"{API_PREFIX}/products",
+            json=create_data,
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 201, (
+            f"Expected 201, got {response.status_code}: {response.json()}"
+        )
+
+        data = response.json()
+
+        # manufacturer_name フィールドが存在し、正しい値であること
+        assert "manufacturer_name" in data, (
+            "manufacturer_name field should be present in create product response"
+        )
+        assert data["manufacturer_name"] == test_manufacturer["name"], (
+            f"Expected manufacturer_name to be '{test_manufacturer['name']}', "
+            f"got '{data['manufacturer_name']}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-004: PATCH /products/{id} で更新した商品のレスポンスに manufacturer_name が含まれる
+# ---------------------------------------------------------------------------
+
+class TestUpdateProductManufacturerName:
+    """AC-004: 商品更新APIのmanufacturer_nameテスト"""
+
+    @pytest.mark.asyncio
+    async def test_ac004_update_product_includes_manufacturer_name(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_product: dict,
+    ):
+        """AC-004: PATCH /products/{id} で更新した商品のレスポンスに manufacturer_name が含まれる
+
+        given: メーカーAに紐づく商品が登録されている
+        when: PATCH /api/v1/products/{id} で商品を更新する
+        then: レスポンスの manufacturer_name にメーカーAの名前が設定されている
+        """
+        product_id = test_product["id"]
+        update_data = {
+            "cost": 600,
+        }
+
+        response = await client.patch(
+            f"{API_PREFIX}/products/{product_id}",
+            json=update_data,
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.json()}"
+        )
+
+        data = response.json()
+
+        # manufacturer_name フィールドが存在し、正しい値であること
+        assert "manufacturer_name" in data, (
+            "manufacturer_name field should be present in update product response"
+        )
+        assert data["manufacturer_name"] == test_product["manufacturer_name"], (
+            f"Expected manufacturer_name to be '{test_product['manufacturer_name']}', "
+            f"got '{data['manufacturer_name']}'"
+        )
+
+        # 更新した値も正しいこと
+        assert data["cost"] == 600

--- a/api/tests/unit/test_product_manufacturer_name.py
+++ b/api/tests/unit/test_product_manufacturer_name.py
@@ -1,0 +1,405 @@
+"""ProductService / ProductResponse の manufacturer_name ユニットテスト
+
+FEAT-0016: 商品マスター一覧で各商品のメーカー名が正しく表示される
+
+テスト対象:
+- AC-005: ProductResponseスキーマに manufacturer_name フィールドが定義されている
+- AC-006: ProductService.list() が manufacturer_name を含むレスポンスを返す
+- AC-007: ProductService.get_by_id() が manufacturer_name を含むレスポンスを返す
+- AC-008: manufacturer リレーションが None の場合、manufacturer_name は null になる
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+from uuid import uuid4
+
+from app.models.product import ProductType
+from app.schemas.product import ProductCreate, ProductResponse, ProductListResponse
+from app.services.product_service import ProductService
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock Product model factory
+# ---------------------------------------------------------------------------
+
+def _make_product(
+    *,
+    id: str | None = None,
+    product_type: str = ProductType.ACRYLIC_KEYCHAIN.value,
+    size: str = "50x50mm",
+    position: str | None = "center",
+    color: str | None = "clear",
+    manufacturer_id: str | None = None,
+    cost: int = 500,
+    lead_time_days: int = 7,
+    order_limit: int | None = 100,
+    is_active: bool = True,
+    manufacturer_name: str | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> MagicMock:
+    """Create a mock Product model instance with optional manufacturer relation."""
+    product = MagicMock()
+    product.id = id or str(uuid4())
+    product.product_type = product_type
+    product.size = size
+    product.position = position
+    product.color = color
+    product.manufacturer_id = manufacturer_id or str(uuid4())
+    product.cost = cost
+    product.lead_time_days = lead_time_days
+    product.order_limit = order_limit
+    product.is_active = is_active
+    product.created_at = created_at or datetime(2026, 1, 1, 0, 0, 0)
+    product.updated_at = updated_at or datetime(2026, 1, 1, 0, 0, 0)
+
+    # manufacturer リレーション
+    if manufacturer_name is not None:
+        manufacturer = MagicMock()
+        manufacturer.name = manufacturer_name
+        product.manufacturer = manufacturer
+    else:
+        product.manufacturer = None
+
+    return product
+
+
+# ---------------------------------------------------------------------------
+# AC-005: ProductResponseスキーマに manufacturer_name フィールドが定義されている
+# ---------------------------------------------------------------------------
+
+class TestProductResponseSchema:
+    """AC-005: ProductResponse スキーマのテスト"""
+
+    def test_ac005_product_response_has_manufacturer_name_field(self):
+        """AC-005: ProductResponseスキーマに manufacturer_name フィールドが定義されている
+
+        given: ProductResponseスキーマが定義されている
+        when: manufacturer_name フィールドの存在を確認する
+        then: manufacturer_name: Optional[str]（デフォルト null）が定義されている
+        """
+        # フィールドが存在することを確認
+        assert "manufacturer_name" in ProductResponse.model_fields, (
+            "ProductResponse should have 'manufacturer_name' field"
+        )
+
+        # フィールドのデフォルト値が None であることを確認
+        field_info = ProductResponse.model_fields["manufacturer_name"]
+        assert field_info.default is None, (
+            "manufacturer_name should have default value of None"
+        )
+
+    def test_ac005_product_response_manufacturer_name_accepts_string(self):
+        """manufacturer_name に文字列を設定できる
+
+        given: ProductResponseのデータにmanufacturer_name文字列が含まれている
+        when: ProductResponseを構築する
+        then: manufacturer_nameが文字列として設定される
+        """
+        data = {
+            "id": str(uuid4()),
+            "product_type": ProductType.ACRYLIC_KEYCHAIN,
+            "size": "50x50mm",
+            "position": "center",
+            "color": "clear",
+            "manufacturer_id": str(uuid4()),
+            "cost": 500,
+            "lead_time_days": 7,
+            "order_limit": 100,
+            "is_active": True,
+            "manufacturer_name": "テストメーカー",
+            "created_at": datetime(2026, 1, 1),
+            "updated_at": datetime(2026, 1, 1),
+        }
+
+        response = ProductResponse(**data)
+        assert response.manufacturer_name == "テストメーカー"
+
+    def test_ac005_product_response_manufacturer_name_defaults_to_none(self):
+        """manufacturer_name を省略した場合 None になる
+
+        given: ProductResponseのデータにmanufacturer_nameが含まれていない
+        when: ProductResponseを構築する
+        then: manufacturer_nameがNoneになる
+        """
+        data = {
+            "id": str(uuid4()),
+            "product_type": ProductType.ACRYLIC_KEYCHAIN,
+            "size": "50x50mm",
+            "position": "center",
+            "color": "clear",
+            "manufacturer_id": str(uuid4()),
+            "cost": 500,
+            "lead_time_days": 7,
+            "order_limit": 100,
+            "is_active": True,
+            "created_at": datetime(2026, 1, 1),
+            "updated_at": datetime(2026, 1, 1),
+        }
+
+        response = ProductResponse(**data)
+        assert response.manufacturer_name is None
+
+
+# ---------------------------------------------------------------------------
+# AC-006: ProductService.list() が manufacturer_name を含むレスポンスを返す
+# ---------------------------------------------------------------------------
+
+class TestProductServiceList:
+    """AC-006: ProductService.list() のテスト"""
+
+    @pytest.fixture
+    def mock_product_repo(self):
+        """モック ProductRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_manufacturer_repo(self):
+        """モック ManufacturerRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_product_repo, mock_manufacturer_repo):
+        """テスト対象のサービスインスタンス"""
+        return ProductService(mock_product_repo, mock_manufacturer_repo)
+
+    @pytest.mark.asyncio
+    async def test_ac006_list_returns_manufacturer_name(
+        self,
+        service: ProductService,
+        mock_product_repo: AsyncMock,
+    ):
+        """AC-006: ProductService.list() が manufacturer_name を含むレスポンスを返す
+
+        given: manufacturer.name = "テストメーカー" のリレーションを持つ Product がリポジトリから返される
+        when: ProductService.list() を呼び出す
+        then: 各 ProductResponse の manufacturer_name に "テストメーカー" が設定されている
+        """
+        product = _make_product(manufacturer_name="テストメーカー")
+        mock_product_repo.find_all.return_value = ([product], 1)
+
+        result = await service.list(page=1, limit=20)
+
+        assert isinstance(result, ProductListResponse)
+        assert len(result.items) == 1
+        assert result.items[0].manufacturer_name == "テストメーカー"
+
+    @pytest.mark.asyncio
+    async def test_ac006_list_returns_multiple_products_with_manufacturer_names(
+        self,
+        service: ProductService,
+        mock_product_repo: AsyncMock,
+    ):
+        """複数商品それぞれに正しい manufacturer_name が返される
+
+        given: 異なるメーカーに紐づく商品が2件ある
+        when: ProductService.list() を呼び出す
+        then: 各商品のmanufacturer_nameにそれぞれのメーカー名が設定される
+        """
+        product1 = _make_product(manufacturer_name="メーカーA")
+        product2 = _make_product(manufacturer_name="メーカーB")
+        mock_product_repo.find_all.return_value = ([product1, product2], 2)
+
+        result = await service.list(page=1, limit=20)
+
+        assert len(result.items) == 2
+        assert result.items[0].manufacturer_name == "メーカーA"
+        assert result.items[1].manufacturer_name == "メーカーB"
+
+
+# ---------------------------------------------------------------------------
+# AC-007: ProductService.get_by_id() が manufacturer_name を含むレスポンスを返す
+# ---------------------------------------------------------------------------
+
+class TestProductServiceGetById:
+    """AC-007: ProductService.get_by_id() のテスト"""
+
+    @pytest.fixture
+    def mock_product_repo(self):
+        """モック ProductRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_manufacturer_repo(self):
+        """モック ManufacturerRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_product_repo, mock_manufacturer_repo):
+        """テスト対象のサービスインスタンス"""
+        return ProductService(mock_product_repo, mock_manufacturer_repo)
+
+    @pytest.mark.asyncio
+    async def test_ac007_get_by_id_returns_manufacturer_name(
+        self,
+        service: ProductService,
+        mock_product_repo: AsyncMock,
+    ):
+        """AC-007: ProductService.get_by_id() が manufacturer_name を含むレスポンスを返す
+
+        given: manufacturer.name = "テストメーカー" のリレーションを持つ Product がリポジトリから返される
+        when: ProductService.get_by_id() を呼び出す
+        then: ProductResponse の manufacturer_name に "テストメーカー" が設定されている
+        """
+        product_id = str(uuid4())
+        product = _make_product(id=product_id, manufacturer_name="テストメーカー")
+        mock_product_repo.find_by_id.return_value = product
+
+        result = await service.get_by_id(product_id)
+
+        assert isinstance(result, ProductResponse)
+        assert result.manufacturer_name == "テストメーカー"
+
+
+# ---------------------------------------------------------------------------
+# AC-008: manufacturer リレーションが None の場合、manufacturer_name は null
+# ---------------------------------------------------------------------------
+
+class TestProductManufacturerNameNull:
+    """AC-008: manufacturer リレーションが None の場合のテスト"""
+
+    @pytest.fixture
+    def mock_product_repo(self):
+        """モック ProductRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_manufacturer_repo(self):
+        """モック ManufacturerRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_product_repo, mock_manufacturer_repo):
+        """テスト対象のサービスインスタンス"""
+        return ProductService(mock_product_repo, mock_manufacturer_repo)
+
+    @pytest.mark.asyncio
+    async def test_ac008_manufacturer_none_returns_null_name(
+        self,
+        service: ProductService,
+        mock_product_repo: AsyncMock,
+    ):
+        """AC-008: manufacturer リレーションが None の場合、manufacturer_name は null になる
+
+        given: manufacturer リレーションが None の Product オブジェクトがある
+        when: ProductService.get_by_id() を呼び出す
+        then: manufacturer_name が None になる
+        """
+        product_id = str(uuid4())
+        product = _make_product(id=product_id, manufacturer_name=None)
+        mock_product_repo.find_by_id.return_value = product
+
+        result = await service.get_by_id(product_id)
+
+        assert isinstance(result, ProductResponse)
+        assert result.manufacturer_name is None
+
+    @pytest.mark.asyncio
+    async def test_ac008_list_with_manufacturer_none_returns_null_name(
+        self,
+        service: ProductService,
+        mock_product_repo: AsyncMock,
+    ):
+        """一覧取得時も manufacturer が None の場合は manufacturer_name が null になる
+
+        given: manufacturer リレーションが None の Product がリポジトリから返される
+        when: ProductService.list() を呼び出す
+        then: ProductResponse の manufacturer_name が None になる
+        """
+        product = _make_product(manufacturer_name=None)
+        mock_product_repo.find_all.return_value = ([product], 1)
+
+        result = await service.list(page=1, limit=20)
+
+        assert len(result.items) == 1
+        assert result.items[0].manufacturer_name is None
+
+    @pytest.mark.asyncio
+    async def test_ac008_create_returns_manufacturer_name(
+        self,
+        service: ProductService,
+        mock_product_repo: AsyncMock,
+        mock_manufacturer_repo: AsyncMock,
+    ):
+        """商品作成後のレスポンスにも manufacturer_name が含まれる
+
+        given: メーカー "テストメーカー" が存在する
+        when: ProductService.create() で商品を作成する
+        then: レスポンスの manufacturer_name に "テストメーカー" が設定されている
+        """
+        manufacturer_id = str(uuid4())
+        manufacturer = MagicMock()
+        manufacturer.id = manufacturer_id
+        manufacturer.name = "テストメーカー"
+        mock_manufacturer_repo.find_by_id.return_value = manufacturer
+
+        # find_duplicate が None を返す（重複なし）
+        mock_product_repo.find_duplicate.return_value = None
+
+        # create が manufacturer リレーション付きの Product を返す
+        created_product = _make_product(
+            manufacturer_id=manufacturer_id,
+            manufacturer_name="テストメーカー",
+        )
+        mock_product_repo.create.return_value = created_product
+
+        data = ProductCreate(
+            product_type=ProductType.ACRYLIC_KEYCHAIN,
+            size="50x50mm",
+            position="center",
+            color="clear",
+            manufacturer_id=manufacturer_id,
+            cost=500,
+            lead_time_days=7,
+            order_limit=100,
+        )
+
+        result = await service.create(data)
+
+        assert isinstance(result, ProductResponse)
+        assert result.manufacturer_name == "テストメーカー"
+
+    @pytest.mark.asyncio
+    async def test_ac008_update_returns_manufacturer_name(
+        self,
+        service: ProductService,
+        mock_product_repo: AsyncMock,
+        mock_manufacturer_repo: AsyncMock,
+    ):
+        """商品更新後のレスポンスにも manufacturer_name が含まれる
+
+        given: メーカー "テストメーカー" に紐づく商品が存在する
+        when: ProductService.update() で商品を更新する
+        then: レスポンスの manufacturer_name に "テストメーカー" が設定されている
+        """
+        product_id = str(uuid4())
+        manufacturer_id = str(uuid4())
+
+        existing_product = _make_product(
+            id=product_id,
+            manufacturer_id=manufacturer_id,
+            manufacturer_name="テストメーカー",
+        )
+        mock_product_repo.find_by_id.return_value = existing_product
+
+        # find_duplicate が None を返す（重複なし）
+        mock_product_repo.find_duplicate.return_value = None
+
+        # update が manufacturer リレーション付きの Product を返す
+        updated_product = _make_product(
+            id=product_id,
+            manufacturer_id=manufacturer_id,
+            manufacturer_name="テストメーカー",
+            cost=600,
+        )
+        mock_product_repo.update.return_value = updated_product
+
+        from app.schemas.product import ProductUpdate
+
+        data = ProductUpdate(cost=600)
+
+        result = await service.update(product_id, data)
+
+        assert isinstance(result, ProductResponse)
+        assert result.manufacturer_name == "テストメーカー"


### PR DESCRIPTION
## 概要

**Intent Spec:** `.claude/specs/FEAT-0016-product-manufacturer-name.yaml`

### なぜこの変更が必要か

商品マスター一覧画面でメーカー名が表示されないバグ（issue #28）を修正。
フロントエンドは既にメーカー名表示に対応済みだが、バックエンドAPIがレスポンスに`manufacturer_name`を含めていなかった。

**根本原因:**
1. `ProductResponse`スキーマに`manufacturer_name`フィールドが未定義
2. `ProductRepository`でmanufacturerリレーションがeager loadされていない
3. `ProductService`でmanufacturer_nameをレスポンスに含めていない

**修正内容:**
- `ProductResponse`に`manufacturer_name: str | None = None`を追加
- `ProductRepository`の`find_all`/`find_by_id`に`selectinload(Product.manufacturer)`を追加
- `ProductService`に`_to_response()`メソッドを追加し、manufacturer_nameを明示的にマッピング
- `create`/`update`後に`find_by_id`で再取得してリレーションを確実にロード

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | |
| リンター | ✅ | FEAT-0016関連ファイルはクリーン |
| ユニットテスト | ✅ | Backend 225/225, Frontend 172/172 |
| 統合テスト | ✅ | 101/101 パス |
| Playwright E2E | ⏭️ SKIP | 本機能にE2Eは不要 |
| 仕様適合 | ✅ | AC: 8/8 カバー |
| AI意味レビュー | ✅ | Critical issue なし |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| AC-001: GET /products がmanufacturer_nameを返す | `tests/integration/test_product_manufacturer_name.py::test_ac001` | ✅ |
| AC-002: GET /products/{id} がmanufacturer_nameを返す | `tests/integration/test_product_manufacturer_name.py::test_ac002` | ✅ |
| AC-003: POST /products がmanufacturer_nameを返す | `tests/integration/test_product_manufacturer_name.py::test_ac003` | ✅ |
| AC-004: PATCH /products/{id} がmanufacturer_nameを返す | `tests/integration/test_product_manufacturer_name.py::test_ac004` | ✅ |
| AC-005: ProductResponseスキーマにmanufacturer_nameフィールドがある | `tests/unit/test_product_manufacturer_name.py::test_ac005` | ✅ |
| AC-006: ProductService.list()がmanufacturer_nameを返す | `tests/unit/test_product_manufacturer_name.py::test_ac006` | ✅ |
| AC-007: ProductService.get_by_id()がmanufacturer_nameを返す | `tests/unit/test_product_manufacturer_name.py::test_ac007` | ✅ |
| AC-008: manufacturer=Noneの場合manufacturer_nameがnullになる | `tests/unit/test_product_manufacturer_name.py::test_ac008` | ✅ |

## レビューのポイント

- バックエンドのみの修正（フロントエンドは既に対応済み）
- `selectinload`を使用しN+1クエリ問題を回避
- `_to_response`メソッドでMagicMockとの互換性を保ちつつ安全にmanufacturer_nameを抽出
- 既存テスト326件すべてパス、リグレッションなし

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)