### PR TITLE
feat: 全メーカー横断の発注明細一覧ページを追加 (FEAT-0018)

### DIFF
--- a/.claude/specs/FEAT-0018-all-manufacturer-orders.yaml
+++ b/.claude/specs/FEAT-0018-all-manufacturer-orders.yaml
@@ -1,0 +1,235 @@
+id: FEAT-0018
+summary: 管理者が全メーカー分の発注明細を一覧で確認できる「すべての発注」ページを利用できる
+
+background:
+  why: |
+    現在の発注一覧（/purchase-orders）はメーカー別サマリーのみを表示し、
+    特定メーカーをクリックして初めて個別の発注明細が見られる構造になっている。
+    全メーカー横断で発注状況を一覧確認したいユースケース（例: 全体の発注量把握、
+    特定注文番号の検索、ステータスの横断的な確認）に対応できていない。
+    メーカーを跨いで全件の発注明細を閲覧できるビューを追加することで、
+    管理者の業務効率を向上させる。
+  who: 管理者（admin）
+  when: |
+    - 全メーカー分の発注明細を横断的に確認したいとき
+    - 特定の注文番号や商品名をメーカーに関係なく検索したいとき
+    - 全体の発注状況（ステータス分布、数量、金額）を俯瞰したいとき
+
+scope:
+  includes:
+    - バックエンド: 全メーカー分の発注明細を返すAPIエンドポイントの追加（GET /api/v1/manufacturers/all-order-items）
+    - バックエンド: OrderRepositoryに全メーカー横断の発注明細取得メソッドを追加
+    - バックエンド: ManufacturerOrderServiceに全メーカー横断の発注明細取得メソッドを追加
+    - バックエンド: レスポンススキーマに manufacturer_name フィールドを含める（どのメーカーの明細か識別可能にする）
+    - フロントエンド: 「すべての発注」ページの追加（/purchase-orders/all）
+    - フロントエンド: 全メーカー発注明細一覧テーブルコンポーネントの作成
+    - フロントエンド: フィルター機能（ステータス、キーワード検索、メーカー絞り込み）
+    - フロントエンド: 発注一覧ページ（/purchase-orders）に「すべての発注を見る」ナビゲーションボタンの追加
+    - フロントエンド: useAllManufacturerOrderItems カスタムフックの追加
+  excludes:
+    - 既存のメーカー別発注一覧ページ（/purchase-orders, /purchase-orders/[id]）の変更（レイアウト・機能はそのまま維持）
+    - サイドバーのナビゲーション変更（既存の「発注」リンクはそのまま）
+    - 全メーカービューからのステータス一括更新機能（個別メーカーページで実施する運用を想定）
+    - 全メーカービューからの発注資料ダウンロード機能（個別メーカーページで実施する運用を想定）
+    - E2Eテスト（明示的に依頼されていないため）
+  prerequisites:
+    - 既存のメーカー別発注明細取得API（GET /manufacturers/{id}/order-items）が稼働中
+    - OrderRepository.find_ordered_items_by_manufacturer_detail メソッドが存在
+    - ManufacturerOrderService が存在し、メーカー別明細取得が実装済み
+    - フロントエンドの ManufacturerOrderFilters コンポーネントが再利用可能
+
+input_output:
+  inputs:
+    - name: status
+      type: string
+      required: false
+      validation: OrderStatus enum値（ordered, manufacturing, delivered）のいずれか。Noneの場合はshipped以外の全て
+    - name: search
+      type: string
+      required: false
+      validation: 注文番号・製品番号・商品名に対する部分一致検索
+    - name: manufacturer_id
+      type: string
+      required: false
+      validation: UUID文字列（既存メーカーのID）。指定時はそのメーカーの明細のみに絞り込み
+    - name: product_type
+      type: string
+      required: false
+      validation: ProductType enum値（acrylic_keychain, acrylic_stand, sticker, tote_bag, tshirt）
+    - name: ordered_from
+      type: date
+      required: false
+      validation: ISO 8601 日付形式（YYYY-MM-DD）
+    - name: ordered_to
+      type: date
+      required: false
+      validation: ISO 8601 日付形式（YYYY-MM-DD）
+  outputs:
+    - name: AllManufacturerOrderItemListResponse
+      type: object
+      description: |
+        全メーカー横断の発注明細一覧レスポンス。
+        各明細に manufacturer_id と manufacturer_name を含み、どのメーカーの発注かを識別可能。
+        集計情報（total, total_quantity, total_amount）を含む。
+  state_changes:
+    - なし（読み取り専用のビュー機能、データ変更なし）
+
+acceptance_criteria:
+  # --- バックエンド: リポジトリ ---
+  - id: AC-001
+    description: OrderRepositoryが全メーカー横断で発注明細を取得できる
+    test_type: unit
+    given: 複数メーカーに紐づく発注明細がDBに存在する
+    when: find_all_ordered_items_detail メソッドをフィルターなしで呼び出す
+    then: 全メーカーの発注明細が返される（shipped以外の全ステータス）
+
+  - id: AC-002
+    description: 全メーカー発注明細をステータスでフィルターできる
+    test_type: unit
+    given: ordered, manufacturing, delivered の各ステータスの発注明細が存在する
+    when: find_all_ordered_items_detail を status="ordered" で呼び出す
+    then: ordered ステータスの明細のみが返される
+
+  - id: AC-003
+    description: 全メーカー発注明細をキーワードで検索できる
+    test_type: unit
+    given: 注文番号 "ORD-001" の発注明細が存在する
+    when: find_all_ordered_items_detail を search="ORD-001" で呼び出す
+    then: 注文番号に "ORD-001" を含む明細のみが返される
+
+  - id: AC-004
+    description: 全メーカー発注明細をメーカーIDでフィルターできる
+    test_type: unit
+    given: メーカーAとメーカーBの発注明細が存在する
+    when: find_all_ordered_items_detail を manufacturer_id=メーカーAのID で呼び出す
+    then: メーカーAの明細のみが返される
+
+  # --- バックエンド: サービス ---
+  - id: AC-005
+    description: ManufacturerOrderServiceが全メーカー発注明細一覧を正しく組み立てる
+    test_type: unit
+    given: 複数メーカーの発注明細が存在する
+    when: get_all_order_items メソッドを呼び出す
+    then: 各明細に manufacturer_name が付与され、total, total_quantity, total_amount が正しく集計されたレスポンスが返される
+
+  # --- バックエンド: API統合テスト ---
+  - id: AC-006
+    description: GET /manufacturers/all-order-items が全メーカーの発注明細を返す
+    test_type: integration
+    given: 複数メーカーに紐づく発注明細がDBに存在する
+    when: GET /api/v1/manufacturers/all-order-items を管理者トークンで呼び出す
+    then: ステータス200で全メーカーの発注明細一覧が返される。各明細にmanufacturer_nameが含まれる
+
+  - id: AC-007
+    description: GET /manufacturers/all-order-items がステータスフィルターに対応する
+    test_type: integration
+    given: orderedとmanufacturingの発注明細が存在する
+    when: GET /api/v1/manufacturers/all-order-items?status=ordered を呼び出す
+    then: orderedステータスの明細のみが返される
+
+  - id: AC-008
+    description: GET /manufacturers/all-order-items がキーワード検索に対応する
+    test_type: integration
+    given: 注文番号 "ORD-001" と "ORD-002" の発注明細が存在する
+    when: GET /api/v1/manufacturers/all-order-items?search=ORD-001 を呼び出す
+    then: 注文番号に "ORD-001" を含む明細のみが返される
+
+  - id: AC-009
+    description: GET /manufacturers/all-order-items がメーカーIDフィルターに対応する
+    test_type: integration
+    given: メーカーAとメーカーBの発注明細が存在する
+    when: GET /api/v1/manufacturers/all-order-items?manufacturer_id={メーカーA.id} を呼び出す
+    then: メーカーAの明細のみが返される
+
+  - id: AC-010
+    description: GET /manufacturers/all-order-items で認証なしの場合401が返る
+    test_type: integration
+    given: なし
+    when: 認証トークンなしでGET /api/v1/manufacturers/all-order-items を呼び出す
+    then: ステータス401が返される
+
+  - id: AC-011
+    description: 発注明細が0件の場合、空配列とtotal=0が返される
+    test_type: integration
+    given: 発注明細が存在しない（またはすべてshippedステータス）
+    when: GET /api/v1/manufacturers/all-order-items を呼び出す
+    then: items=[], total=0, total_quantity=0, total_amount=0 が返される
+
+  # --- フロントエンド: ページ・コンポーネント ---
+  - id: AC-012
+    description: /purchase-orders/all ページが「すべての発注」一覧を表示する
+    test_type: unit
+    given: 全メーカーの発注明細APIが正常にデータを返す
+    when: /purchase-orders/all ページを開く
+    then: 全メーカーの発注明細がテーブルに表示され、各行にメーカー名が表示される
+
+  - id: AC-013
+    description: 全メーカー発注一覧テーブルに必要なカラムが表示される
+    test_type: unit
+    given: 発注明細データが存在する
+    when: AllManufacturerOrderList コンポーネントが描画される
+    then: メーカー名、注文番号、製品番号、商品名、商品タイプ、ステータス、数量、金額、顧客名、受注日 のカラムが表示される
+
+  - id: AC-014
+    description: 発注一覧ページに「すべての発注を見る」ボタンが表示される
+    test_type: unit
+    given: /purchase-orders ページを開いている
+    when: ページが描画される
+    then: 「すべての発注を見る」ナビゲーションボタンが表示され、クリックで /purchase-orders/all に遷移する
+
+  - id: AC-015
+    description: フィルター（ステータス、キーワード検索）が正常に動作する
+    test_type: unit
+    given: /purchase-orders/all ページが表示されている
+    when: ステータスフィルターで「発注済み」を選択する
+    then: APIリクエストにstatus=orderedが含まれ、フィルタリングされた結果が表示される
+
+  - id: AC-016
+    description: メーカーフィルターで特定メーカーに絞り込みできる
+    test_type: unit
+    given: /purchase-orders/all ページが表示されている、メーカー一覧が取得済み
+    when: メーカーフィルターでメーカーAを選択する
+    then: APIリクエストにmanufacturer_id=メーカーAのIDが含まれ、そのメーカーの明細のみ表示される
+
+  - id: AC-017
+    description: 発注明細が0件の場合、空メッセージが表示される
+    test_type: unit
+    given: APIが空配列を返す
+    when: /purchase-orders/all ページが描画される
+    then: 「発注中の明細がありません」等の空メッセージが表示される
+
+  - id: AC-018
+    description: サマリーカード（合計明細数、合計数量、合計金額）が表示される
+    test_type: unit
+    given: 発注明細データが存在する
+    when: /purchase-orders/all ページが描画される
+    then: 合計明細数、合計数量、合計金額のサマリーカードが表示される
+
+constraints:
+  performance:
+    - 全メーカー発注明細一覧のAPI応答は500ms以内
+    - クエリは適切なJOINとインデックスを利用し、N+1問題を回避する
+  security:
+    - 管理者（admin）のみアクセス可能（get_current_admin依存性を使用）
+    - 認証なしのアクセスは401を返す
+  compatibility:
+    - 既存のメーカー別発注一覧（/purchase-orders, /purchase-orders/[id]）の動作を一切変更しない
+    - 既存APIエンドポイントに影響を与えない
+    - Chrome / Safari / Firefox で正常に動作する
+
+assumptions:
+  - APIエンドポイントは GET /api/v1/manufacturers/all-order-items として新規追加する（既存の /manufacturers/{id}/order-items は変更しない）
+  - エンドポイントのパスは /manufacturers/order-summary と同様に /{manufacturer_id} より前に定義し、パスの競合を回避する
+  - レスポンススキーマは既存の ManufacturerOrderItemResponse を拡張し、manufacturer_id と manufacturer_name を含める
+  - 全メーカービューは閲覧専用とし、ステータス更新や発注資料ダウンロードは既存のメーカー別ページで行う運用を想定
+  - デフォルトでは shipped 以外の全ステータスの明細を返す（既存のメーカー別一覧と同じデフォルト動作）
+  - フロントエンドのページパスは /purchase-orders/all とし、既存の /purchase-orders/[id] と競合しないようにする
+  - ページネーションは将来的に追加可能だが、初期実装ではスクロールで全件表示とする（明細数が多い場合は後続で対応）
+  - メーカーフィルターのセレクトボックスの選択肢は GET /api/v1/manufacturers から動的に取得する
+
+success_metrics:
+  - 全メーカー横断の発注明細一覧APIが正常に動作し、フィルター機能が機能する
+  - フロントエンドで全メーカーの発注明細が一覧表示され、メーカー名で識別できる
+  - 既存のメーカー別発注一覧ページが影響なく正常に動作する
+  - バックエンドのユニットテスト・統合テストが全てパスする
+  - フロントエンドのユニットテストが全てパスする

--- a/api/app/repositories/order_repository.py
+++ b/api/app/repositories/order_repository.py
@@ -299,6 +299,82 @@ class OrderRepository:
         result = await self._db.execute(query)
         return result.all()
 
+    async def find_all_ordered_items_detail(
+        self,
+        status: str | None = None,
+        ordered_from: date | None = None,
+        ordered_to: date | None = None,
+        product_type: str | None = None,
+        search: str | None = None,
+        manufacturer_id: str | None = None,
+    ) -> list[tuple]:
+        """全メーカー横断の受注明細を詳細情報付きで取得
+
+        Args:
+            status: ステータスフィルター（None の場合は shipped 以外の全て）
+            ordered_from: 発注日From
+            ordered_to: 発注日To
+            product_type: 商品タイプ
+            search: キーワード検索（注文番号・製品番号・商品名）
+            manufacturer_id: メーカーIDフィルター
+
+        Returns:
+            受注明細のタプルリスト（OrderItem, order_number, ordered_at, customer_name, cost, status, manufacturer_id, manufacturer_name）
+        """
+        from app.models.product import Product
+        from app.models.manufacturer import Manufacturer
+
+        query = (
+            select(
+                OrderItem,
+                Order.order_number,
+                Order.ordered_at,
+                Order.customer_name,
+                Product.cost,
+                Order.status,
+                Manufacturer.id.label("manufacturer_id"),
+                Manufacturer.name.label("manufacturer_name"),
+            )
+            .join(Order, OrderItem.order_id == Order.id)
+            .join(Product, OrderItem.product_id == Product.id)
+            .join(Manufacturer, Product.manufacturer_id == Manufacturer.id)
+        )
+
+        # ステータスフィルター
+        if status:
+            query = query.where(Order.status == status)
+        else:
+            # デフォルトは shipped 以外の全ステータス
+            query = query.where(Order.status != OrderStatus.SHIPPED.value)
+
+        # メーカーIDフィルター
+        if manufacturer_id:
+            query = query.where(Manufacturer.id == manufacturer_id)
+
+        if ordered_from:
+            query = query.where(func.date(Order.ordered_at) >= ordered_from)
+
+        if ordered_to:
+            query = query.where(func.date(Order.ordered_at) <= ordered_to)
+
+        if product_type:
+            query = query.where(OrderItem.product_type == product_type)
+
+        # キーワード検索（注文番号・製品番号・商品名）
+        if search:
+            search_pattern = f"%{search}%"
+            search_filter = (
+                Order.order_number.ilike(search_pattern)
+                | OrderItem.uid.ilike(search_pattern)
+                | OrderItem.product_name.ilike(search_pattern)
+            )
+            query = query.where(search_filter)
+
+        query = query.order_by(Order.ordered_at.desc())
+
+        result = await self._db.execute(query)
+        return result.all()
+
     async def update_status_by_manufacturer(
         self,
         manufacturer_id: str,

--- a/api/app/routers/manufacturers.py
+++ b/api/app/routers/manufacturers.py
@@ -26,6 +26,7 @@ from app.schemas.chat import (
 )
 from app.schemas.invoice import InvoiceItemRequest
 from app.schemas.manufacturer import (
+    AllManufacturerOrderItemListResponse,
     ManufacturerCreate,
     ManufacturerListResponse,
     ManufacturerOrderItemListResponse,
@@ -88,6 +89,40 @@ async def get_manufacturer_order_summary(
     各メーカーの発注明細数、合計数量、合計金額を集計して返します。
     """
     return await service.get_order_summary_list(page=page, limit=limit)
+
+
+@router.get("/all-order-items", response_model=AllManufacturerOrderItemListResponse)
+async def get_all_manufacturer_order_items(
+    service: Annotated[ManufacturerOrderService, Depends(get_manufacturer_order_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+    ordered_from: date | None = None,
+    ordered_to: date | None = None,
+    product_type: str | None = None,
+    status: str | None = None,
+    search: str | None = None,
+    manufacturer_id: str | None = None,
+) -> AllManufacturerOrderItemListResponse:
+    """全メーカー横断の受注明細一覧を取得
+
+    全メーカーの発注明細を横断的に一覧表示します。
+    デフォルトでは shipped 以外の全ステータスを返します。
+
+    Args:
+        ordered_from: 発注日From
+        ordered_to: 発注日To
+        product_type: 商品タイプフィルター
+        status: ステータスフィルター（ordered, manufacturing, delivered）
+        search: キーワード検索（注文番号、製品番号、商品名）
+        manufacturer_id: メーカーIDフィルター
+    """
+    return await service.get_all_order_items(
+        ordered_from=ordered_from,
+        ordered_to=ordered_to,
+        product_type=product_type,
+        status=status,
+        search=search,
+        manufacturer_id=manufacturer_id,
+    )
 
 
 @router.get("/{manufacturer_id}", response_model=ManufacturerResponse)

--- a/api/app/schemas/manufacturer.py
+++ b/api/app/schemas/manufacturer.py
@@ -143,6 +143,41 @@ class ManufacturerOrderItemListResponse(BaseModel):
     total_amount: int
 
 
+class AllManufacturerOrderItemResponse(BaseModel):
+    """全メーカー横断受注明細レスポンス"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str  # OrderItem.id
+    order_id: str
+    order_number: str
+    uid: str | None
+    product_id: str
+    product_name: str
+    product_type: str
+    price: int
+    quantity: int
+    size: str | None
+    position: str | None
+    color: str | None
+    design_image_url: str | None
+    thumbnail_image_url: str | None
+    ordered_at: datetime
+    customer_name: str
+    status: str  # Order.status (ordered, manufacturing, delivered)
+    manufacturer_id: str
+    manufacturer_name: str
+
+
+class AllManufacturerOrderItemListResponse(BaseModel):
+    """全メーカー横断受注明細一覧レスポンス"""
+
+    items: list[AllManufacturerOrderItemResponse]
+    total: int
+    total_quantity: int
+    total_amount: int
+
+
 class ManufacturerOrderStatusUpdate(BaseModel):
     """メーカー別受注ステータス一括更新"""
 

--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -16,6 +16,8 @@ from app.schemas.manufacturer import (
     ManufacturerOrderItemResponse,
     ManufacturerOrderItemListResponse,
     ManufacturerOrderStatusUpdate,
+    AllManufacturerOrderItemResponse,
+    AllManufacturerOrderItemListResponse,
 )
 from app.utils.exceptions import NotFoundError, NoOrderedItemsError
 from app.utils.order_list_generator import OrderListGenerator, get_product_type_name
@@ -135,6 +137,72 @@ class ManufacturerOrderService:
         return ManufacturerOrderItemListResponse(
             manufacturer_id=manufacturer_id,
             manufacturer_name=manufacturer.name,
+            items=items,
+            total=len(items),
+            total_quantity=total_quantity,
+            total_amount=total_amount,
+        )
+
+    async def get_all_order_items(
+        self,
+        ordered_from: date | None = None,
+        ordered_to: date | None = None,
+        product_type: str | None = None,
+        status: str | None = None,
+        search: str | None = None,
+        manufacturer_id: str | None = None,
+    ) -> AllManufacturerOrderItemListResponse:
+        """全メーカー横断の受注明細一覧を取得
+
+        Args:
+            ordered_from: 発注日From
+            ordered_to: 発注日To
+            product_type: 商品タイプ
+            status: ステータスフィルター（None の場合は shipped 以外の全て）
+            search: キーワード検索（注文番号・製品番号・商品名）
+            manufacturer_id: メーカーIDフィルター
+        """
+        rows = await self._order_repo.find_all_ordered_items_detail(
+            ordered_from=ordered_from,
+            ordered_to=ordered_to,
+            product_type=product_type,
+            status=status,
+            search=search,
+            manufacturer_id=manufacturer_id,
+        )
+
+        items = []
+        total_quantity = 0
+        total_amount = 0
+
+        for order_item, order_number, ordered_at, customer_name, cost, order_status, mfr_id, mfr_name in rows:
+            items.append(
+                AllManufacturerOrderItemResponse(
+                    id=order_item.id,
+                    order_id=order_item.order_id,
+                    order_number=order_number,
+                    uid=order_item.uid,
+                    product_id=order_item.product_id,
+                    product_name=order_item.product_name,
+                    product_type=order_item.product_type,
+                    price=order_item.price,
+                    quantity=order_item.quantity,
+                    size=order_item.size,
+                    position=order_item.position,
+                    color=order_item.color,
+                    design_image_url=order_item.design_image_url,
+                    thumbnail_image_url=order_item.thumbnail_image_url,
+                    ordered_at=ordered_at,
+                    customer_name=customer_name,
+                    status=order_status,
+                    manufacturer_id=mfr_id,
+                    manufacturer_name=mfr_name,
+                )
+            )
+            total_quantity += order_item.quantity
+            total_amount += order_item.price * order_item.quantity
+
+        return AllManufacturerOrderItemListResponse(
             items=items,
             total=len(items),
             total_quantity=total_quantity,

--- a/api/tests/integration/test_all_manufacturer_order_items.py
+++ b/api/tests/integration/test_all_manufacturer_order_items.py
@@ -1,0 +1,575 @@
+"""全メーカー横断発注明細一覧 API 統合テスト
+
+FEAT-0018: 全メーカー分の発注明細を一覧で確認できる「すべての発注」ページ
+
+テスト対象: GET /api/v1/manufacturers/all-order-items
+- AC-006: 全メーカーの発注明細を返す
+- AC-007: ステータスフィルターに対応する
+- AC-008: キーワード検索に対応する
+- AC-009: メーカーIDフィルターに対応する
+- AC-010: 認証なしの場合401が返る
+- AC-011: 発注明細が0件の場合、空配列とtotal=0が返される
+"""
+
+import json
+import pytest
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: テストデータ
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def test_manufacturer_a(db_session: AsyncSession):
+    """テスト用メーカーA"""
+    manufacturer_id = str(uuid4())
+    manufacturer_name = f"テストメーカーA_{manufacturer_id[:8]}"
+
+    await db_session.execute(
+        text("""
+            INSERT INTO manufacturers (
+                id, name, email, supported_products, unit_prices, lead_time_days,
+                daily_order_limit, sharing_method, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :name, :email, :supported_products, :unit_prices, :lead_time_days,
+                :daily_order_limit, :sharing_method, :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": manufacturer_id,
+            "name": manufacturer_name,
+            "email": f"mfr-a-{manufacturer_id[:8]}@example.com",
+            "supported_products": ["tshirt", "acrylic_keychain"],
+            "unit_prices": json.dumps({"tshirt": 500, "acrylic_keychain": 300}),
+            "lead_time_days": 7,
+            "daily_order_limit": 100,
+            "sharing_method": "portal",
+            "is_active": True,
+        }
+    )
+    await db_session.commit()
+
+    yield {"id": manufacturer_id, "name": manufacturer_name}
+
+
+@pytest.fixture
+async def test_manufacturer_b(db_session: AsyncSession):
+    """テスト用メーカーB"""
+    manufacturer_id = str(uuid4())
+    manufacturer_name = f"テストメーカーB_{manufacturer_id[:8]}"
+
+    await db_session.execute(
+        text("""
+            INSERT INTO manufacturers (
+                id, name, email, supported_products, unit_prices, lead_time_days,
+                daily_order_limit, sharing_method, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :name, :email, :supported_products, :unit_prices, :lead_time_days,
+                :daily_order_limit, :sharing_method, :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": manufacturer_id,
+            "name": manufacturer_name,
+            "email": f"mfr-b-{manufacturer_id[:8]}@example.com",
+            "supported_products": ["sticker"],
+            "unit_prices": json.dumps({"sticker": 200}),
+            "lead_time_days": 5,
+            "daily_order_limit": 200,
+            "sharing_method": "portal",
+            "is_active": True,
+        }
+    )
+    await db_session.commit()
+
+    yield {"id": manufacturer_id, "name": manufacturer_name}
+
+
+@pytest.fixture
+async def test_product_a(db_session: AsyncSession, test_manufacturer_a: dict):
+    """テスト用商品A（メーカーA）"""
+    product_id = str(uuid4())
+    unique_size = f"ALL-A-{product_id[:8]}"
+
+    await db_session.execute(
+        text("""
+            INSERT INTO products (
+                id, product_type, size, position, color, manufacturer_id, cost,
+                lead_time_days, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :product_type, :size, :position, :color, :manufacturer_id, :cost,
+                :lead_time_days, :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": product_id,
+            "product_type": "tshirt",
+            "size": unique_size,
+            "position": "正面",
+            "color": "白",
+            "manufacturer_id": test_manufacturer_a["id"],
+            "cost": 500,
+            "lead_time_days": 7,
+            "is_active": True,
+        }
+    )
+    await db_session.commit()
+
+    yield {"id": product_id, "manufacturer_id": test_manufacturer_a["id"]}
+
+
+@pytest.fixture
+async def test_product_b(db_session: AsyncSession, test_manufacturer_b: dict):
+    """テスト用商品B（メーカーB）"""
+    product_id = str(uuid4())
+    unique_size = f"ALL-B-{product_id[:8]}"
+
+    await db_session.execute(
+        text("""
+            INSERT INTO products (
+                id, product_type, size, position, color, manufacturer_id, cost,
+                lead_time_days, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :product_type, :size, :position, :color, :manufacturer_id, :cost,
+                :lead_time_days, :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": product_id,
+            "product_type": "sticker",
+            "size": unique_size,
+            "position": None,
+            "color": "ホワイト",
+            "manufacturer_id": test_manufacturer_b["id"],
+            "cost": 200,
+            "lead_time_days": 5,
+            "is_active": True,
+        }
+    )
+    await db_session.commit()
+
+    yield {"id": product_id, "manufacturer_id": test_manufacturer_b["id"]}
+
+
+@pytest.fixture
+async def test_all_orders(
+    db_session: AsyncSession,
+    test_order_source: dict,
+    test_product_a: dict,
+    test_product_b: dict,
+    test_manufacturer_a: dict,
+    test_manufacturer_b: dict,
+):
+    """複数メーカーの発注明細を作成するフィクスチャ
+
+    以下のデータを作成:
+    メーカーA:
+    - ordered ステータス: 注文番号 ORD-{prefix}-AAA, 商品名 キーホルダーA
+    - ordered ステータス: 注文番号 ORD-{prefix}-BBB, 商品名 Tシャツ特大
+    - manufacturing ステータス: 注文番号 ORD-{prefix}-CCC, 商品名 キーホルダーB
+    メーカーB:
+    - ordered ステータス: 注文番号 ORD-{prefix}-DDD, 商品名 ステッカー大
+    - delivered ステータス: 注文番号 ORD-{prefix}-EEE, 商品名 ステッカー小
+    - shipped ステータス: 注文番号 ORD-{prefix}-FFF, 商品名 ステッカー中（除外対象）
+    """
+    unique_prefix = str(uuid4())[:8]
+
+    test_data = [
+        # (status, order_suffix, product_name, uid_suffix, product_id)
+        ("ordered", "AAA", "キーホルダーA", "001", test_product_a["id"]),
+        ("ordered", "BBB", "Tシャツ特大", "002", test_product_a["id"]),
+        ("manufacturing", "CCC", "キーホルダーB", "003", test_product_a["id"]),
+        ("ordered", "DDD", "ステッカー大", "004", test_product_b["id"]),
+        ("delivered", "EEE", "ステッカー小", "005", test_product_b["id"]),
+        ("shipped", "FFF", "ステッカー中", "006", test_product_b["id"]),
+    ]
+
+    orders = []
+    order_items = []
+
+    for i, (status, suffix, product_name, uid_suffix, product_id) in enumerate(test_data):
+        order_number = f"ORD-{unique_prefix}-{suffix}"
+        uid = f"UID-{unique_prefix}-{uid_suffix}"
+        order_id = str(uuid4())
+        order_item_id = str(uuid4())
+        ordered_at = datetime.now() - timedelta(days=i)
+
+        await db_session.execute(
+            text("""
+                INSERT INTO orders (
+                    id, order_number, order_source_id, product_name, quantity,
+                    customer_name, customer_email, customer_phone, customer_postal_code,
+                    customer_address_prefecture, customer_address_city, status, ordered_at,
+                    total_price, created_at, updated_at
+                )
+                VALUES (
+                    :id, :order_number, :order_source_id, :product_name, :quantity,
+                    :customer_name, :customer_email, :customer_phone, :customer_postal_code,
+                    :customer_address_prefecture, :customer_address_city, :status, :ordered_at,
+                    :total_price, NOW(), NOW()
+                )
+            """),
+            {
+                "id": order_id,
+                "order_number": order_number,
+                "order_source_id": test_order_source["id"],
+                "product_name": product_name,
+                "quantity": 1,
+                "customer_name": f"顧客{i+1}",
+                "customer_email": f"customer-all-{i+1}@example.com",
+                "customer_phone": "090-0000-0000",
+                "customer_postal_code": "100-0001",
+                "customer_address_prefecture": "東京都",
+                "customer_address_city": "千代田区",
+                "status": status,
+                "ordered_at": ordered_at,
+                "total_price": 1000,
+            }
+        )
+
+        product_type = "tshirt" if product_id == test_product_a["id"] else "sticker"
+        await db_session.execute(
+            text("""
+                INSERT INTO order_items (
+                    id, order_id, uid, product_id, product_name, product_type,
+                    price, quantity, created_at, updated_at
+                )
+                VALUES (
+                    :id, :order_id, :uid, :product_id, :product_name, :product_type,
+                    :price, :quantity, NOW(), NOW()
+                )
+            """),
+            {
+                "id": order_item_id,
+                "order_id": order_id,
+                "uid": uid,
+                "product_id": product_id,
+                "product_name": product_name,
+                "product_type": product_type,
+                "price": 1000,
+                "quantity": 1,
+            }
+        )
+
+        orders.append({
+            "id": order_id,
+            "order_number": order_number,
+            "status": status,
+            "product_name": product_name,
+        })
+        order_items.append({
+            "id": order_item_id,
+            "order_id": order_id,
+            "uid": uid,
+            "product_name": product_name,
+            "status": status,
+        })
+
+    await db_session.commit()
+
+    yield {
+        "manufacturer_a_id": test_manufacturer_a["id"],
+        "manufacturer_a_name": test_manufacturer_a["name"],
+        "manufacturer_b_id": test_manufacturer_b["id"],
+        "manufacturer_b_name": test_manufacturer_b["name"],
+        "orders": orders,
+        "order_items": order_items,
+        "unique_prefix": unique_prefix,
+    }
+
+
+# ===========================================================================
+# 統合テスト
+# ===========================================================================
+
+class TestAllManufacturerOrderItemsAPI:
+    """GET /manufacturers/all-order-items API の統合テスト"""
+
+    @pytest.mark.asyncio
+    async def test_api_returns_all_manufacturers_order_items(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_all_orders: dict,
+    ):
+        """AC-006: 全メーカーの発注明細を返す
+
+        given: メーカーAとメーカーBに紐づく発注明細がDBに存在する
+        when: GET /api/v1/manufacturers/all-order-items を管理者トークンで呼び出す
+        then: ステータス200で全メーカーの発注明細一覧が返される。
+              各明細にmanufacturer_nameが含まれる。
+              shipped以外の5件が返される。
+        """
+        unique_prefix = test_all_orders["unique_prefix"]
+
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            params={"search": unique_prefix},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # shipped 以外の5件が返される
+        assert data["total"] == 5
+
+        # 各明細に manufacturer_id と manufacturer_name が含まれる
+        for item in data["items"]:
+            assert "manufacturer_id" in item
+            assert "manufacturer_name" in item
+            assert item["manufacturer_name"] is not None
+
+        # 両方のメーカーの明細が含まれる
+        manufacturer_names = {item["manufacturer_name"] for item in data["items"]}
+        assert test_all_orders["manufacturer_a_name"] in manufacturer_names
+        assert test_all_orders["manufacturer_b_name"] in manufacturer_names
+
+        # shipped のアイテムが含まれていないことを確認
+        product_names = [item["product_name"] for item in data["items"]]
+        assert "ステッカー中" not in product_names
+
+    @pytest.mark.asyncio
+    async def test_api_filters_by_status_ordered(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_all_orders: dict,
+    ):
+        """AC-007: ステータスフィルターに対応する
+
+        given: orderedとmanufacturingの発注明細が存在する
+        when: GET /api/v1/manufacturers/all-order-items?status=ordered を呼び出す
+        then: orderedステータスの明細のみが返される
+        """
+        unique_prefix = test_all_orders["unique_prefix"]
+
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            params={"status": "ordered", "search": unique_prefix},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # ordered ステータスの3件（メーカーA: 2件 + メーカーB: 1件）が返される
+        assert data["total"] == 3
+        for item in data["items"]:
+            assert item["status"] == "ordered"
+
+    @pytest.mark.asyncio
+    async def test_api_search_by_keyword(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_all_orders: dict,
+    ):
+        """AC-008: キーワード検索に対応する
+
+        given: 注文番号 "ORD-{prefix}-AAA" と "ORD-{prefix}-BBB" の発注明細が存在する
+        when: GET /api/v1/manufacturers/all-order-items?search={prefix}-AAA を呼び出す
+        then: 注文番号に "{prefix}-AAA" を含む明細のみが返される
+        """
+        unique_prefix = test_all_orders["unique_prefix"]
+
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            params={"search": f"{unique_prefix}-AAA"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total"] == 1
+        assert "AAA" in data["items"][0]["order_number"]
+
+    @pytest.mark.asyncio
+    async def test_api_search_by_product_name(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_all_orders: dict,
+    ):
+        """AC-008: 商品名でキーワード検索
+
+        given: 商品名に「キーホルダー」を含む明細が存在する
+        when: GET /api/v1/manufacturers/all-order-items?search=キーホルダー&manufacturer_id={A} でAPIを呼び出す
+        then: 商品名に「キーホルダー」を含む、メーカーAの明細のみが返される
+        """
+        manufacturer_a_id = test_all_orders["manufacturer_a_id"]
+
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            params={"search": "キーホルダー", "manufacturer_id": manufacturer_a_id},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # メーカーAのキーホルダーA (ordered) + キーホルダーB (manufacturing) = 2件
+        assert data["total"] == 2
+        for item in data["items"]:
+            assert "キーホルダー" in item["product_name"]
+
+    @pytest.mark.asyncio
+    async def test_api_filters_by_manufacturer_id(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_all_orders: dict,
+    ):
+        """AC-009: メーカーIDフィルターに対応する
+
+        given: メーカーAとメーカーBの発注明細が存在する
+        when: GET /api/v1/manufacturers/all-order-items?manufacturer_id={メーカーA.id} を呼び出す
+        then: メーカーAの明細のみが返される
+        """
+        manufacturer_a_id = test_all_orders["manufacturer_a_id"]
+
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            params={"manufacturer_id": manufacturer_a_id},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # メーカーAの明細のみ（ordered: 2件 + manufacturing: 1件 = 3件）
+        assert data["total"] == 3
+        for item in data["items"]:
+            assert item["manufacturer_id"] == manufacturer_a_id
+
+    @pytest.mark.asyncio
+    async def test_api_returns_401_without_auth(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """AC-010: 認証なしの場合401が返される
+
+        given: エンドポイントが存在する（認証ありでアクセス可能）
+        when: 認証トークンなしでGET /api/v1/manufacturers/all-order-items を呼び出す
+        then: ステータス401が返される
+        """
+        # まず認証ありでエンドポイントが存在することを確認
+        # (200が返ればエンドポイントが存在する)
+        auth_response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            headers=auth_headers,
+        )
+        assert auth_response.status_code == 200, \
+            "Endpoint /api/v1/manufacturers/all-order-items should exist and return 200 with auth"
+
+        # 認証なしでアクセス
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_api_returns_empty_when_no_items(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """AC-011: 発注明細が0件の場合、空配列とtotal=0が返される
+
+        given: 発注明細が存在しない（またはすべてshippedステータス）
+        when: GET /api/v1/manufacturers/all-order-items を呼び出す
+        then: items=[], total=0, total_quantity=0, total_amount=0 が返される
+
+        Note: テスト固有のデータを使用するため、他のテストのデータに影響されないように
+              存在しないメーカーIDでフィルターして0件を確認する
+        """
+        nonexistent_manufacturer_id = str(uuid4())
+
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            params={"manufacturer_id": nonexistent_manufacturer_id},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["items"] == []
+        assert data["total"] == 0
+        assert data["total_quantity"] == 0
+        assert data["total_amount"] == 0
+
+    @pytest.mark.asyncio
+    async def test_api_combines_status_and_search_filters(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_all_orders: dict,
+    ):
+        """ステータスとキーワード検索を組み合わせて使用できる
+
+        given: 複数のステータスと商品名の明細が存在する
+        when: search=キーホルダー と status=ordered と manufacturer_id でAPIを呼び出す
+        then: 商品名に「キーホルダー」を含み、かつステータスが ordered の明細のみが返される
+        """
+        manufacturer_a_id = test_all_orders["manufacturer_a_id"]
+
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            params={
+                "search": "キーホルダー",
+                "status": "ordered",
+                "manufacturer_id": manufacturer_a_id,
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # キーホルダーA (ordered) の1件のみ
+        # キーホルダーB は manufacturing なので含まれない
+        assert data["total"] == 1
+        assert "キーホルダー" in data["items"][0]["product_name"]
+        assert data["items"][0]["status"] == "ordered"
+
+    @pytest.mark.asyncio
+    async def test_api_response_has_summary_fields(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_all_orders: dict,
+    ):
+        """レスポンスに集計情報（total, total_quantity, total_amount）が含まれる
+
+        given: 発注明細が存在する
+        when: GET /api/v1/manufacturers/all-order-items を呼び出す
+        then: total, total_quantity, total_amount が正しい値で返される
+        """
+        response = await client.get(
+            "/api/v1/manufacturers/all-order-items",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert "total" in data
+        assert "total_quantity" in data
+        assert "total_amount" in data
+        assert data["total"] >= 1
+        assert data["total_quantity"] >= 1
+        assert data["total_amount"] >= 1

--- a/api/tests/unit/test_all_manufacturer_order_items.py
+++ b/api/tests/unit/test_all_manufacturer_order_items.py
@@ -1,0 +1,429 @@
+"""全メーカー横断発注明細一覧のユニットテスト
+
+FEAT-0018: 全メーカー分の発注明細を一覧で確認できる「すべての発注」ページ
+
+テスト対象:
+- OrderRepository.find_all_ordered_items_detail メソッド
+  - AC-001: フィルターなしで全メーカーの発注明細取得
+  - AC-002: ステータスフィルター
+  - AC-003: キーワード検索
+  - AC-004: メーカーIDフィルター
+- ManufacturerOrderService.get_all_order_items メソッド
+  - AC-005: 全メーカー発注明細一覧のレスポンス組み立て
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from app.services.manufacturer_order_service import ManufacturerOrderService
+from app.models.order import OrderStatus
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock order item tuple factory (matching repository return format)
+# ---------------------------------------------------------------------------
+
+def _make_order_item_tuple(
+    *,
+    item_id: str | None = None,
+    order_id: str | None = None,
+    order_number: str = "ORD-001",
+    uid: str = "UID-001",
+    product_id: str | None = None,
+    product_name: str = "テスト商品",
+    product_type: str = "tshirt",
+    price: int = 1000,
+    quantity: int = 1,
+    size: str = "M",
+    position: str | None = "正面",
+    color: str | None = "白",
+    design_image_url: str | None = None,
+    thumbnail_image_url: str | None = None,
+    ordered_at: datetime | None = None,
+    customer_name: str = "テスト顧客",
+    cost: int = 500,
+    status: str = "ordered",
+    manufacturer_id: str | None = None,
+    manufacturer_name: str = "テストメーカー",
+) -> tuple:
+    """リポジトリの find_all_ordered_items_detail の戻り値形式に合わせたタプルを生成"""
+    order_item = MagicMock()
+    order_item.id = item_id or str(uuid4())
+    order_item.order_id = order_id or str(uuid4())
+    order_item.uid = uid
+    order_item.product_id = product_id or str(uuid4())
+    order_item.product_name = product_name
+    order_item.product_type = product_type
+    order_item.price = price
+    order_item.quantity = quantity
+    order_item.size = size
+    order_item.position = position
+    order_item.color = color
+    order_item.design_image_url = design_image_url
+    order_item.thumbnail_image_url = thumbnail_image_url
+
+    return (
+        order_item,
+        order_number,
+        ordered_at or datetime(2026, 2, 24, 10, 0, 0),
+        customer_name,
+        cost,
+        status,
+        manufacturer_id or str(uuid4()),
+        manufacturer_name,
+    )
+
+
+# ===========================================================================
+# AC-001: OrderRepository が全メーカー横断で発注明細を取得できる
+# ===========================================================================
+
+class TestFindAllOrderedItemsDetail:
+    """OrderRepository.find_all_ordered_items_detail メソッドのテスト"""
+
+    @pytest.fixture
+    def mock_db(self):
+        """モック AsyncSession（execute().all() チェーンを正しくセットアップ）"""
+        db = AsyncMock()
+        # execute() が返す結果オブジェクトのモック
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        db.execute.return_value = mock_result
+        return db
+
+    @pytest.fixture
+    def repo(self, mock_db):
+        """テスト対象のリポジトリインスタンス"""
+        from app.repositories.order_repository import OrderRepository
+        return OrderRepository(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_find_all_ordered_items_detail_returns_all_manufacturers(
+        self, repo, mock_db,
+    ):
+        """AC-001: フィルターなしで全メーカーの発注明細が返される
+
+        given: 複数メーカーに紐づく発注明細がDBに存在する
+        when: find_all_ordered_items_detail メソッドをフィルターなしで呼び出す
+        then: 全メーカーの発注明細が返される（shipped以外の全ステータス）
+        """
+        # find_all_ordered_items_detail メソッドが存在することを確認
+        assert hasattr(repo, 'find_all_ordered_items_detail'), \
+            "OrderRepository should have find_all_ordered_items_detail method"
+
+        # メソッドを呼び出す
+        result = await repo.find_all_ordered_items_detail()
+
+        # 結果はリスト
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_find_all_ordered_items_detail_filters_by_status(
+        self, repo, mock_db,
+    ):
+        """AC-002: ステータスでフィルターできる
+
+        given: ordered, manufacturing, delivered の各ステータスの発注明細が存在する
+        when: find_all_ordered_items_detail を status="ordered" で呼び出す
+        then: ordered ステータスの明細のみが返される
+        """
+        assert hasattr(repo, 'find_all_ordered_items_detail'), \
+            "OrderRepository should have find_all_ordered_items_detail method"
+
+        result = await repo.find_all_ordered_items_detail(status="ordered")
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_find_all_ordered_items_detail_filters_by_search(
+        self, repo, mock_db,
+    ):
+        """AC-003: キーワードで検索できる
+
+        given: 注文番号 "ORD-001" の発注明細が存在する
+        when: find_all_ordered_items_detail を search="ORD-001" で呼び出す
+        then: 注文番号に "ORD-001" を含む明細のみが返される
+        """
+        assert hasattr(repo, 'find_all_ordered_items_detail'), \
+            "OrderRepository should have find_all_ordered_items_detail method"
+
+        result = await repo.find_all_ordered_items_detail(search="ORD-001")
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_find_all_ordered_items_detail_filters_by_manufacturer_id(
+        self, repo, mock_db,
+    ):
+        """AC-004: メーカーIDでフィルターできる
+
+        given: メーカーAとメーカーBの発注明細が存在する
+        when: find_all_ordered_items_detail を manufacturer_id=メーカーAのID で呼び出す
+        then: メーカーAの明細のみが返される
+        """
+        assert hasattr(repo, 'find_all_ordered_items_detail'), \
+            "OrderRepository should have find_all_ordered_items_detail method"
+
+        manufacturer_a_id = str(uuid4())
+        result = await repo.find_all_ordered_items_detail(
+            manufacturer_id=manufacturer_a_id
+        )
+        assert isinstance(result, list)
+
+
+# ===========================================================================
+# AC-005: ManufacturerOrderService.get_all_order_items
+# ===========================================================================
+
+class TestGetAllOrderItems:
+    """ManufacturerOrderService.get_all_order_items メソッドのテスト"""
+
+    @pytest.fixture
+    def mock_order_repo(self):
+        """モック OrderRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_manufacturer_repo(self):
+        """モック ManufacturerRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_shipment_repo(self):
+        """モック ShipmentRepository"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_order_repo, mock_manufacturer_repo, mock_shipment_repo):
+        """テスト対象のサービスインスタンス"""
+        return ManufacturerOrderService(
+            order_repo=mock_order_repo,
+            manufacturer_repo=mock_manufacturer_repo,
+            shipment_repo=mock_shipment_repo,
+        )
+
+    @pytest.fixture
+    def mock_all_order_items_data(self):
+        """複数メーカーの発注明細データ"""
+        manufacturer_a_id = str(uuid4())
+        manufacturer_b_id = str(uuid4())
+
+        return [
+            _make_order_item_tuple(
+                order_number="ORD-001",
+                uid="UID-001",
+                product_name="アクリルキーホルダーA",
+                product_type="acrylic_keychain",
+                price=1000,
+                quantity=2,
+                status="ordered",
+                manufacturer_id=manufacturer_a_id,
+                manufacturer_name="メーカーA",
+            ),
+            _make_order_item_tuple(
+                order_number="ORD-002",
+                uid="UID-002",
+                product_name="Tシャツ白M",
+                product_type="tshirt",
+                price=2000,
+                quantity=1,
+                status="manufacturing",
+                manufacturer_id=manufacturer_a_id,
+                manufacturer_name="メーカーA",
+            ),
+            _make_order_item_tuple(
+                order_number="ORD-003",
+                uid="UID-003",
+                product_name="ステッカー大",
+                product_type="sticker",
+                price=500,
+                quantity=5,
+                status="ordered",
+                manufacturer_id=manufacturer_b_id,
+                manufacturer_name="メーカーB",
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_all_order_items_method_exists(
+        self,
+        service: ManufacturerOrderService,
+    ):
+        """AC-005: get_all_order_items メソッドが存在する
+
+        given: ManufacturerOrderService インスタンス
+        when: get_all_order_items メソッドの存在を確認する
+        then: メソッドが存在する
+        """
+        assert hasattr(service, 'get_all_order_items'), \
+            "ManufacturerOrderService should have get_all_order_items method"
+
+    @pytest.mark.asyncio
+    async def test_get_all_order_items_returns_response_with_manufacturer_name(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+        mock_all_order_items_data,
+    ):
+        """AC-005: 各明細に manufacturer_name が付与されたレスポンスが返される
+
+        given: 複数メーカーの発注明細が存在する
+        when: get_all_order_items メソッドを呼び出す
+        then: 各明細に manufacturer_name が付与され、
+              total, total_quantity, total_amount が正しく集計されたレスポンスが返される
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = mock_all_order_items_data
+
+        result = await service.get_all_order_items()
+
+        # レスポンスが正しい構造を持つこと
+        assert hasattr(result, 'items')
+        assert hasattr(result, 'total')
+        assert hasattr(result, 'total_quantity')
+        assert hasattr(result, 'total_amount')
+
+        # 3件の明細が含まれること
+        assert result.total == 3
+
+        # 各明細に manufacturer_id と manufacturer_name が含まれること
+        for item in result.items:
+            assert hasattr(item, 'manufacturer_id')
+            assert hasattr(item, 'manufacturer_name')
+            assert item.manufacturer_name is not None
+
+        # メーカー名が正しいこと
+        manufacturer_names = {item.manufacturer_name for item in result.items}
+        assert "メーカーA" in manufacturer_names
+        assert "メーカーB" in manufacturer_names
+
+    @pytest.mark.asyncio
+    async def test_get_all_order_items_total_quantity_calculation(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+        mock_all_order_items_data,
+    ):
+        """AC-005: total_quantity が正しく集計される
+
+        given: quantity=2, quantity=1, quantity=5 の3件
+        when: get_all_order_items を呼び出す
+        then: total_quantity = 8
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = mock_all_order_items_data
+
+        result = await service.get_all_order_items()
+
+        # total_quantity = 2 + 1 + 5 = 8
+        assert result.total_quantity == 8
+
+    @pytest.mark.asyncio
+    async def test_get_all_order_items_total_amount_calculation(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+        mock_all_order_items_data,
+    ):
+        """AC-005: total_amount が正しく集計される
+
+        given: price*quantity = 1000*2, 2000*1, 500*5 の3件
+        when: get_all_order_items を呼び出す
+        then: total_amount = 2000 + 2000 + 2500 = 6500
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = mock_all_order_items_data
+
+        result = await service.get_all_order_items()
+
+        # total_amount = (1000*2) + (2000*1) + (500*5) = 2000 + 2000 + 2500 = 6500
+        assert result.total_amount == 6500
+
+    @pytest.mark.asyncio
+    async def test_get_all_order_items_passes_filters_to_repository(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """AC-005: フィルターパラメータがリポジトリに正しく渡される
+
+        given: フィルター条件を指定する
+        when: get_all_order_items をフィルター付きで呼び出す
+        then: リポジトリの find_all_ordered_items_detail にパラメータが渡される
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = []
+
+        manufacturer_id = str(uuid4())
+        await service.get_all_order_items(
+            status="ordered",
+            search="キーホルダー",
+            manufacturer_id=manufacturer_id,
+            product_type="acrylic_keychain",
+        )
+
+        # リポジトリが正しいパラメータで呼ばれたことを確認
+        mock_order_repo.find_all_ordered_items_detail.assert_called_once()
+        call_kwargs = mock_order_repo.find_all_ordered_items_detail.call_args.kwargs
+        assert call_kwargs.get("status") == "ordered"
+        assert call_kwargs.get("search") == "キーホルダー"
+        assert call_kwargs.get("manufacturer_id") == manufacturer_id
+        assert call_kwargs.get("product_type") == "acrylic_keychain"
+
+    @pytest.mark.asyncio
+    async def test_get_all_order_items_empty_result(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """AC-005: 明細が0件の場合は空レスポンスが返される
+
+        given: 発注明細が0件
+        when: get_all_order_items を呼び出す
+        then: items=[], total=0, total_quantity=0, total_amount=0 が返される
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = []
+
+        result = await service.get_all_order_items()
+
+        assert result.items == []
+        assert result.total == 0
+        assert result.total_quantity == 0
+        assert result.total_amount == 0
+
+
+# ===========================================================================
+# AllManufacturerOrderItemResponse スキーマのテスト
+# ===========================================================================
+
+class TestAllManufacturerOrderItemResponseSchema:
+    """AllManufacturerOrderItemResponse スキーマのテスト"""
+
+    def test_schema_exists(self):
+        """AllManufacturerOrderItemResponse スキーマが存在する"""
+        from app.schemas.manufacturer import AllManufacturerOrderItemResponse
+        assert AllManufacturerOrderItemResponse is not None
+
+    def test_schema_has_manufacturer_id_field(self):
+        """AllManufacturerOrderItemResponse に manufacturer_id フィールドがある"""
+        from app.schemas.manufacturer import AllManufacturerOrderItemResponse
+        fields = AllManufacturerOrderItemResponse.model_fields
+        assert "manufacturer_id" in fields, \
+            "AllManufacturerOrderItemResponse should have 'manufacturer_id' field"
+
+    def test_schema_has_manufacturer_name_field(self):
+        """AllManufacturerOrderItemResponse に manufacturer_name フィールドがある"""
+        from app.schemas.manufacturer import AllManufacturerOrderItemResponse
+        fields = AllManufacturerOrderItemResponse.model_fields
+        assert "manufacturer_name" in fields, \
+            "AllManufacturerOrderItemResponse should have 'manufacturer_name' field"
+
+    def test_list_response_schema_exists(self):
+        """AllManufacturerOrderItemListResponse スキーマが存在する"""
+        from app.schemas.manufacturer import AllManufacturerOrderItemListResponse
+        assert AllManufacturerOrderItemListResponse is not None
+
+    def test_list_response_has_required_fields(self):
+        """AllManufacturerOrderItemListResponse に必要なフィールドがある"""
+        from app.schemas.manufacturer import AllManufacturerOrderItemListResponse
+        fields = AllManufacturerOrderItemListResponse.model_fields
+        assert "items" in fields
+        assert "total" in fields
+        assert "total_quantity" in fields
+        assert "total_amount" in fields

--- a/api/tests/unit/test_all_manufacturer_order_service.py
+++ b/api/tests/unit/test_all_manufacturer_order_service.py
@@ -1,0 +1,313 @@
+"""ManufacturerOrderService.get_all_order_items のユニットテスト
+
+FEAT-0018: 全メーカー横断発注明細一覧
+
+テスト対象: get_all_order_items メソッド
+- 全メーカーの発注明細を横断的に取得
+- manufacturer_id, manufacturer_name が各明細に含まれる
+- total, total_quantity, total_amount が正しく集計される
+- フィルター（status, search, manufacturer_id）が正しく渡される
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from app.services.manufacturer_order_service import ManufacturerOrderService
+from app.models.order import OrderStatus
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock order item factory for all-manufacturer queries
+# ---------------------------------------------------------------------------
+
+def _make_all_order_item(
+    *,
+    order_number: str = "POD-20260101-0001",
+    uid: str = "abc123",
+    product_name: str = "Tシャツ - M - 正面 - 白",
+    product_type: str = "tshirt",
+    quantity: int = 1,
+    price: int = 1000,
+    size: str = "M",
+    position: str = "正面",
+    color: str = "白",
+    design_image_url: str | None = None,
+    thumbnail_image_url: str | None = None,
+    status: str = "ordered",
+    cost: int = 500,
+    ordered_at: datetime | None = None,
+    customer_name: str = "顧客名",
+    manufacturer_id: str | None = None,
+    manufacturer_name: str = "テストメーカー",
+) -> tuple:
+    """Create a mock order item tuple matching the repository return format
+    for find_all_ordered_items_detail."""
+    order_item = MagicMock()
+    order_item.id = str(uuid4())
+    order_item.order_id = str(uuid4())
+    order_item.uid = uid
+    order_item.product_id = str(uuid4())
+    order_item.product_name = product_name
+    order_item.product_type = product_type
+    order_item.quantity = quantity
+    order_item.price = price
+    order_item.size = size
+    order_item.position = position
+    order_item.color = color
+    order_item.design_image_url = design_image_url
+    order_item.thumbnail_image_url = thumbnail_image_url
+
+    mfr_id = manufacturer_id or str(uuid4())
+
+    return (
+        order_item,
+        order_number,
+        ordered_at or datetime(2026, 2, 24, 10, 0, 0),
+        customer_name,
+        cost,
+        status,
+        mfr_id,
+        manufacturer_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+class TestGetAllOrderItems:
+    """get_all_order_items メソッドのユニットテスト"""
+
+    @pytest.fixture
+    def mock_order_repo(self):
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_manufacturer_repo(self):
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_shipment_repo(self):
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_order_repo, mock_manufacturer_repo, mock_shipment_repo):
+        return ManufacturerOrderService(
+            order_repo=mock_order_repo,
+            manufacturer_repo=mock_manufacturer_repo,
+            shipment_repo=mock_shipment_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_items_from_multiple_manufacturers(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """AC-001/AC-005: 複数メーカーの発注明細が全て返される
+
+        given: メーカーAとメーカーBに紐づく発注明細がある
+        when: get_all_order_items をフィルターなしで呼び出す
+        then: 全メーカーの発注明細が返され、各明細に manufacturer_name が付与される
+        """
+        mfr_a_id = str(uuid4())
+        mfr_b_id = str(uuid4())
+
+        mock_order_repo.find_all_ordered_items_detail.return_value = [
+            _make_all_order_item(
+                order_number="ORD-001",
+                manufacturer_id=mfr_a_id,
+                manufacturer_name="メーカーA",
+                quantity=2,
+                price=1000,
+            ),
+            _make_all_order_item(
+                order_number="ORD-002",
+                manufacturer_id=mfr_a_id,
+                manufacturer_name="メーカーA",
+                quantity=1,
+                price=2000,
+            ),
+            _make_all_order_item(
+                order_number="ORD-003",
+                manufacturer_id=mfr_b_id,
+                manufacturer_name="メーカーB",
+                quantity=5,
+                price=500,
+            ),
+        ]
+
+        result = await service.get_all_order_items()
+
+        assert result.total == 3
+        assert len(result.items) == 3
+
+        # 各明細に manufacturer_name が含まれる
+        names = [item.manufacturer_name for item in result.items]
+        assert "メーカーA" in names
+        assert "メーカーB" in names
+
+        # 各明細に manufacturer_id が含まれる
+        ids = [item.manufacturer_id for item in result.items]
+        assert mfr_a_id in ids
+        assert mfr_b_id in ids
+
+    @pytest.mark.asyncio
+    async def test_correct_total_quantity_and_amount(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """AC-005: total, total_quantity, total_amount が正しく集計される
+
+        given: 明細3件（数量2*1000, 1*2000, 5*500）
+        when: get_all_order_items を呼び出す
+        then: total=3, total_quantity=8, total_amount=6500
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = [
+            _make_all_order_item(quantity=2, price=1000),
+            _make_all_order_item(quantity=1, price=2000),
+            _make_all_order_item(quantity=5, price=500),
+        ]
+
+        result = await service.get_all_order_items()
+
+        assert result.total == 3
+        assert result.total_quantity == 8
+        assert result.total_amount == 2000 + 2000 + 2500  # 6500
+
+    @pytest.mark.asyncio
+    async def test_empty_result(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """AC-011: 発注明細が0件の場合、空配列とtotal=0が返される
+
+        given: 発注明細が存在しない
+        when: get_all_order_items を呼び出す
+        then: items=[], total=0, total_quantity=0, total_amount=0
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = []
+
+        result = await service.get_all_order_items()
+
+        assert result.total == 0
+        assert result.items == []
+        assert result.total_quantity == 0
+        assert result.total_amount == 0
+
+    @pytest.mark.asyncio
+    async def test_passes_status_filter_to_repository(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """AC-002: ステータスフィルターが正しくリポジトリに渡される
+
+        given: status="ordered" でフィルターする
+        when: get_all_order_items を status="ordered" で呼び出す
+        then: リポジトリに status="ordered" が渡される
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = []
+
+        await service.get_all_order_items(status="ordered")
+
+        mock_order_repo.find_all_ordered_items_detail.assert_called_once_with(
+            ordered_from=None,
+            ordered_to=None,
+            product_type=None,
+            status="ordered",
+            search=None,
+            manufacturer_id=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_passes_search_filter_to_repository(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """AC-003: キーワード検索が正しくリポジトリに渡される
+
+        given: search="ORD-001" で検索する
+        when: get_all_order_items を search="ORD-001" で呼び出す
+        then: リポジトリに search="ORD-001" が渡される
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = []
+
+        await service.get_all_order_items(search="ORD-001")
+
+        mock_order_repo.find_all_ordered_items_detail.assert_called_once_with(
+            ordered_from=None,
+            ordered_to=None,
+            product_type=None,
+            status=None,
+            search="ORD-001",
+            manufacturer_id=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_passes_manufacturer_id_filter_to_repository(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """AC-004: メーカーIDフィルターが正しくリポジトリに渡される
+
+        given: manufacturer_id="mfr-001" でフィルターする
+        when: get_all_order_items を manufacturer_id="mfr-001" で呼び出す
+        then: リポジトリに manufacturer_id="mfr-001" が渡される
+        """
+        mock_order_repo.find_all_ordered_items_detail.return_value = []
+
+        await service.get_all_order_items(manufacturer_id="mfr-001")
+
+        mock_order_repo.find_all_ordered_items_detail.assert_called_once_with(
+            ordered_from=None,
+            ordered_to=None,
+            product_type=None,
+            status=None,
+            search=None,
+            manufacturer_id="mfr-001",
+        )
+
+    @pytest.mark.asyncio
+    async def test_item_fields_are_correctly_mapped(
+        self,
+        service: ManufacturerOrderService,
+        mock_order_repo: AsyncMock,
+    ):
+        """レスポンスの各フィールドが正しくマッピングされる"""
+        mfr_id = str(uuid4())
+        mock_order_repo.find_all_ordered_items_detail.return_value = [
+            _make_all_order_item(
+                order_number="ORD-TEST",
+                uid="UID-TEST",
+                product_name="テスト商品",
+                product_type="acrylic_keychain",
+                quantity=3,
+                price=800,
+                status="manufacturing",
+                customer_name="テスト顧客",
+                manufacturer_id=mfr_id,
+                manufacturer_name="テストメーカー",
+            ),
+        ]
+
+        result = await service.get_all_order_items()
+
+        assert len(result.items) == 1
+        item = result.items[0]
+        assert item.order_number == "ORD-TEST"
+        assert item.uid == "UID-TEST"
+        assert item.product_name == "テスト商品"
+        assert item.product_type == "acrylic_keychain"
+        assert item.quantity == 3
+        assert item.price == 800
+        assert item.status == "manufacturing"
+        assert item.customer_name == "テスト顧客"
+        assert item.manufacturer_id == mfr_id
+        assert item.manufacturer_name == "テストメーカー"

--- a/web/src/app/(dashboard)/purchase-orders/all/page.tsx
+++ b/web/src/app/(dashboard)/purchase-orders/all/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { PageContainer } from "@/components/layout/page-container";
+import { LoadingSpinner } from "@/components/common/loading-spinner";
+import { AllManufacturerOrderList } from "@/features/purchase-orders/components/all-manufacturer-order-list";
+import { AllManufacturerOrderFilters } from "@/features/purchase-orders/components/all-manufacturer-order-filters";
+import { useAllManufacturerOrderItems } from "@/features/purchase-orders/hooks/use-manufacturer-orders";
+import { useManufacturers } from "@/features/manufacturers/hooks/use-manufacturers";
+
+// デバウンスフック
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default function AllPurchaseOrdersPage() {
+  const router = useRouter();
+
+  // フィルター状態
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+  const [manufacturerId, setManufacturerId] = useState<string | null>(null);
+  const [productType, setProductType] = useState<string | null>(null);
+  const [orderedFrom, setOrderedFrom] = useState("");
+  const [orderedTo, setOrderedTo] = useState("");
+
+  // デバウンスされた検索値（300ms）
+  const debouncedSearch = useDebounce(search, 300);
+
+  // メーカー一覧取得（フィルター用）
+  const { manufacturers } = useManufacturers({ limit: 100 });
+
+  const { data, isLoading, isFiltering } = useAllManufacturerOrderItems({
+    search: debouncedSearch || undefined,
+    status: status || undefined,
+    manufacturer_id: manufacturerId || undefined,
+    product_type: productType || undefined,
+    ordered_from: orderedFrom || undefined,
+    ordered_to: orderedTo || undefined,
+  });
+
+  const handleFilterReset = () => {
+    setSearch("");
+    setStatus(null);
+    setManufacturerId(null);
+    setProductType(null);
+    setOrderedFrom("");
+    setOrderedTo("");
+  };
+
+  // メーカー一覧をフィルターコンポーネント用に変換
+  const manufacturerOptions = manufacturers.map((m) => ({
+    id: m.id,
+    name: m.name,
+  }));
+
+  // 初回ロード時のみ全画面ローディングを表示
+  if (isLoading && !data) {
+    return (
+      <PageContainer title="すべての発注" description="読み込み中...">
+        <div className="flex items-center justify-center py-12">
+          <LoadingSpinner />
+        </div>
+      </PageContainer>
+    );
+  }
+
+  const displayData = data ?? {
+    items: [],
+    total: 0,
+    total_quantity: 0,
+    total_amount: 0,
+  };
+
+  return (
+    <PageContainer
+      title="すべての発注"
+      description="全メーカーの発注明細を横断的に表示"
+      actions={
+        <Button
+          variant="outline"
+          onClick={() => router.push("/purchase-orders")}
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          発注一覧に戻る
+        </Button>
+      }
+    >
+      <div className="space-y-4">
+        <AllManufacturerOrderFilters
+          search={search}
+          status={status}
+          manufacturerId={manufacturerId}
+          productType={productType}
+          orderedFrom={orderedFrom}
+          orderedTo={orderedTo}
+          onSearchChange={setSearch}
+          onStatusChange={setStatus}
+          onManufacturerIdChange={setManufacturerId}
+          onProductTypeChange={setProductType}
+          onOrderedFromChange={setOrderedFrom}
+          onOrderedToChange={setOrderedTo}
+          onReset={handleFilterReset}
+          manufacturers={manufacturerOptions}
+        />
+
+        <AllManufacturerOrderList
+          data={displayData}
+          isLoading={isFiltering}
+        />
+      </div>
+    </PageContainer>
+  );
+}

--- a/web/src/app/(dashboard)/purchase-orders/page.tsx
+++ b/web/src/app/(dashboard)/purchase-orders/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { List } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -39,6 +41,15 @@ export default function PurchaseOrdersPage() {
     <PageContainer
       title="発注一覧"
       description="発注中の商品をメーカー別に表示"
+      actions={
+        <Button
+          variant="outline"
+          onClick={() => router.push("/purchase-orders/all")}
+        >
+          <List className="h-4 w-4 mr-2" />
+          すべての発注を見る
+        </Button>
+      }
     >
       <div className="space-y-4">
         <div className="flex items-center gap-4">

--- a/web/src/features/purchase-orders/components/all-manufacturer-order-filters.tsx
+++ b/web/src/features/purchase-orders/components/all-manufacturer-order-filters.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import type { OrderStatus } from "@/types/api";
+
+const statusOptions: { value: OrderStatus | "all"; label: string }[] = [
+  { value: "all", label: "全てのステータス" },
+  { value: "ordered", label: "発注済み" },
+  { value: "manufacturing", label: "製造中" },
+  { value: "delivered", label: "納入済" },
+];
+
+interface ManufacturerOption {
+  id: string;
+  name: string;
+}
+
+interface AllManufacturerOrderFiltersProps {
+  search: string;
+  status: string | null;
+  manufacturerId: string | null;
+  productType: string | null;
+  orderedFrom: string;
+  orderedTo: string;
+  onSearchChange: (value: string) => void;
+  onStatusChange: (value: string | null) => void;
+  onManufacturerIdChange: (value: string | null) => void;
+  onProductTypeChange: (value: string | null) => void;
+  onOrderedFromChange: (value: string) => void;
+  onOrderedToChange: (value: string) => void;
+  onReset: () => void;
+  manufacturers: ManufacturerOption[];
+}
+
+export function AllManufacturerOrderFilters({
+  search,
+  status,
+  manufacturerId,
+  productType,
+  orderedFrom,
+  orderedTo,
+  onSearchChange,
+  onStatusChange,
+  onManufacturerIdChange,
+  onProductTypeChange,
+  onOrderedFromChange,
+  onOrderedToChange,
+  onReset,
+  manufacturers,
+}: AllManufacturerOrderFiltersProps) {
+  const hasActiveFilters = search || status || manufacturerId || productType || orderedFrom || orderedTo;
+
+  return (
+    <div className="flex flex-wrap items-end gap-4 mb-4">
+      {/* キーワード検索 */}
+      <div className="space-y-1">
+        <Input
+          type="text"
+          placeholder="注文番号、製品番号、商品名で検索..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-[280px]"
+        />
+      </div>
+
+      {/* ステータスフィルター */}
+      <div className="space-y-1">
+        <Select
+          value={status ?? "all"}
+          onValueChange={(value) =>
+            onStatusChange(value === "all" ? null : value)
+          }
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="全てのステータス" />
+          </SelectTrigger>
+          <SelectContent>
+            {statusOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* メーカーフィルター */}
+      <div className="space-y-1">
+        <Select
+          value={manufacturerId ?? "all"}
+          onValueChange={(value) =>
+            onManufacturerIdChange(value === "all" ? null : value)
+          }
+        >
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="全てのメーカー" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">全てのメーカー</SelectItem>
+            {manufacturers.map((mfr) => (
+              <SelectItem key={mfr.id} value={mfr.id}>
+                {mfr.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* リセットボタン */}
+      {hasActiveFilters && (
+        <Button variant="ghost" size="sm" onClick={onReset}>
+          <X className="h-4 w-4 mr-1" />
+          フィルタをリセット
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/purchase-orders/components/all-manufacturer-order-list.tsx
+++ b/web/src/features/purchase-orders/components/all-manufacturer-order-list.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, Package } from "lucide-react";
+import type { AllManufacturerOrderItemListResponse } from "@/types/api";
+
+interface AllManufacturerOrderListProps {
+  data: AllManufacturerOrderItemListResponse;
+  isLoading?: boolean;
+}
+
+const productTypeLabels: Record<string, string> = {
+  acrylic_keychain: "アクリルキーホルダー",
+  acrylic_stand: "アクリルスタンド",
+  sticker: "ステッカー",
+  tote_bag: "トートバッグ",
+  tshirt: "Tシャツ",
+};
+
+const statusLabels: Record<string, string> = {
+  ordered: "発注済み",
+  manufacturing: "製造中",
+  delivered: "納入済",
+  shipped: "配送完了",
+};
+
+const statusVariants: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
+  ordered: "default",
+  manufacturing: "secondary",
+  delivered: "outline",
+  shipped: "outline",
+};
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function AllManufacturerOrderList({
+  data,
+  isLoading = false,
+}: AllManufacturerOrderListProps) {
+  return (
+    <div className="space-y-6">
+      {/* サマリーカード */}
+      <Card>
+        <CardContent className="pt-6">
+          <dl className="grid grid-cols-3 gap-4">
+            <div>
+              <dt className="text-sm text-muted-foreground">明細数</dt>
+              <dd className="text-2xl font-bold">{data.total}件</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">合計数量</dt>
+              <dd className="text-2xl font-bold">{data.total_quantity}点</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">合計金額</dt>
+              <dd className="text-2xl font-bold">
+                ¥{data.total_amount.toLocaleString()}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      {/* 受注明細一覧 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Package className="h-5 w-5" />
+            すべての発注明細 ({data.total}件)
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>メーカー名</TableHead>
+                  <TableHead>注文番号</TableHead>
+                  <TableHead>製品番号</TableHead>
+                  <TableHead>商品名</TableHead>
+                  <TableHead>商品タイプ</TableHead>
+                  <TableHead>ステータス</TableHead>
+                  <TableHead className="text-center">数量</TableHead>
+                  <TableHead className="text-right">金額</TableHead>
+                  <TableHead>顧客名</TableHead>
+                  <TableHead>受注日</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isLoading ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={10}
+                      className="h-24 text-center text-muted-foreground"
+                    >
+                      <div className="flex items-center justify-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        読み込み中...
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ) : data.items.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={10}
+                      className="h-24 text-center text-muted-foreground"
+                    >
+                      発注中の明細がありません
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  data.items.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell className="font-medium">
+                        {item.manufacturer_name}
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        {item.order_number}
+                      </TableCell>
+                      <TableCell>{item.uid || "-"}</TableCell>
+                      <TableCell>{item.product_name}</TableCell>
+                      <TableCell>
+                        <Badge variant="secondary">
+                          {productTypeLabels[item.product_type] ||
+                            item.product_type}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={statusVariants[item.status] || "default"}>
+                          {statusLabels[item.status] || item.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        {item.quantity}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        ¥{(item.price * item.quantity).toLocaleString()}
+                      </TableCell>
+                      <TableCell>{item.customer_name}</TableCell>
+                      <TableCell>{formatDate(item.ordered_at)}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/features/purchase-orders/hooks/use-manufacturer-orders.ts
+++ b/web/src/features/purchase-orders/hooks/use-manufacturer-orders.ts
@@ -3,6 +3,7 @@ import { apiClient } from "@/lib/api/client";
 import type {
   ManufacturerOrderSummaryListResponse,
   ManufacturerOrderItemListResponse,
+  AllManufacturerOrderItemListResponse,
   OrderStatus,
 } from "@/types/api";
 
@@ -52,6 +53,44 @@ export function useManufacturerOrderItems(
     data,
     isLoading,
     // フィルター変更中はisValidatingがtrueになる（データ再取得中）
+    isFiltering: isValidating && !isLoading,
+    error,
+    mutate,
+  };
+}
+
+export interface AllManufacturerOrderFiltersParams {
+  status?: string | null;
+  search?: string;
+  manufacturer_id?: string | null;
+  product_type?: string | null;
+  ordered_from?: string;
+  ordered_to?: string;
+}
+
+export function useAllManufacturerOrderItems(
+  filters?: AllManufacturerOrderFiltersParams
+) {
+  // クエリパラメータ構築
+  const queryParams = new URLSearchParams();
+  if (filters?.status) queryParams.set("status", filters.status);
+  if (filters?.search) queryParams.set("search", filters.search);
+  if (filters?.manufacturer_id) queryParams.set("manufacturer_id", filters.manufacturer_id);
+  if (filters?.product_type) queryParams.set("product_type", filters.product_type);
+  if (filters?.ordered_from) queryParams.set("ordered_from", filters.ordered_from);
+  if (filters?.ordered_to) queryParams.set("ordered_to", filters.ordered_to);
+
+  const queryString = queryParams.toString();
+  const url = `/manufacturers/all-order-items${queryString ? `?${queryString}` : ""}`;
+
+  const { data, error, isLoading, isValidating, mutate } =
+    useSWR<AllManufacturerOrderItemListResponse>(url, apiClient, {
+      keepPreviousData: true,
+    });
+
+  return {
+    data,
+    isLoading,
     isFiltering: isValidating && !isLoading,
     error,
     mutate,

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -125,6 +125,36 @@ export interface ManufacturerOrderStatusUpdate {
   note?: string;
 }
 
+// All Manufacturer Order types (全メーカー横断発注明細)
+export interface AllManufacturerOrderItem {
+  id: string;
+  order_id: string;
+  order_number: string;
+  uid: string | null;
+  product_id: string;
+  product_name: string;
+  product_type: ProductType;
+  price: number;
+  quantity: number;
+  size: string | null;
+  position: string | null;
+  color: string | null;
+  design_image_url: string | null;
+  thumbnail_image_url: string | null;
+  ordered_at: string;
+  customer_name: string;
+  status: OrderStatus;
+  manufacturer_id: string;
+  manufacturer_name: string;
+}
+
+export interface AllManufacturerOrderItemListResponse {
+  items: AllManufacturerOrderItem[];
+  total: number;
+  total_quantity: number;
+  total_amount: number;
+}
+
 // Shipment types
 export type ShipmentStatus = "pending" | "ready" | "shipped";
 

--- a/web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx
+++ b/web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx
@@ -1,0 +1,693 @@
+/**
+ * Unit tests for FEAT-0018: 全メーカー横断発注明細一覧「すべての発注」ページ
+ *
+ * Covers:
+ * - AC-012: /purchase-orders/all ページが全メーカーの発注明細を表示する
+ * - AC-013: テーブルに必要なカラムが表示される（メーカー名カラム含む）
+ * - AC-014: 発注一覧ページに「すべての発注を見る」ボタンが表示される
+ * - AC-015: フィルター（ステータス、キーワード検索）が正常に動作する
+ * - AC-016: メーカーフィルターで特定メーカーに絞り込みできる
+ * - AC-017: 発注明細が0件の場合、空メッセージが表示される
+ * - AC-018: サマリーカード（合計明細数、合計数量、合計金額）が表示される
+ *
+ * NOTE: TDD Red phase - tests will fail until implementation is completed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderHook } from '@testing-library/react'
+
+// Mock API client
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+}))
+
+// Mock SWR
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({
+    data: undefined,
+    error: undefined,
+    isLoading: false,
+    isValidating: false,
+    mutate: vi.fn(),
+  })),
+}))
+
+// Mock sonner
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+// Mock next/navigation with controllable values
+const mockPush = vi.fn()
+const mockReplace = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: mockReplace,
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/purchase-orders/all',
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}))
+
+// ======================================
+// Types (for the new AllManufacturerOrderItem)
+// ======================================
+
+interface AllManufacturerOrderItem {
+  id: string
+  order_id: string
+  order_number: string
+  uid: string | null
+  product_id: string
+  product_name: string
+  product_type: string
+  price: number
+  quantity: number
+  size: string | null
+  position: string | null
+  color: string | null
+  design_image_url: string | null
+  thumbnail_image_url: string | null
+  ordered_at: string
+  customer_name: string
+  status: string
+  manufacturer_id: string
+  manufacturer_name: string
+}
+
+interface AllManufacturerOrderItemListResponse {
+  items: AllManufacturerOrderItem[]
+  total: number
+  total_quantity: number
+  total_amount: number
+}
+
+// ======================================
+// Mock data factory
+// ======================================
+
+function createMockAllOrderItemsData(): AllManufacturerOrderItemListResponse {
+  return {
+    items: [
+      {
+        id: 'item-001',
+        order_id: 'order-001',
+        order_number: 'ORD-001',
+        uid: 'UID-001',
+        product_id: 'prod-001',
+        product_name: 'アクリルキーホルダーA',
+        product_type: 'acrylic_keychain',
+        price: 1000,
+        quantity: 2,
+        size: '50x50mm',
+        position: null,
+        color: 'アクリル',
+        design_image_url: null,
+        thumbnail_image_url: null,
+        ordered_at: '2026-01-15T10:00:00Z',
+        customer_name: '田中太郎',
+        status: 'ordered',
+        manufacturer_id: 'mfr-001',
+        manufacturer_name: 'メーカーA',
+      },
+      {
+        id: 'item-002',
+        order_id: 'order-002',
+        order_number: 'ORD-002',
+        uid: 'UID-002',
+        product_id: 'prod-002',
+        product_name: 'Tシャツ白M',
+        product_type: 'tshirt',
+        price: 2000,
+        quantity: 1,
+        size: 'M',
+        position: '正面',
+        color: '白',
+        design_image_url: null,
+        thumbnail_image_url: null,
+        ordered_at: '2026-01-14T10:00:00Z',
+        customer_name: '鈴木花子',
+        status: 'manufacturing',
+        manufacturer_id: 'mfr-001',
+        manufacturer_name: 'メーカーA',
+      },
+      {
+        id: 'item-003',
+        order_id: 'order-003',
+        order_number: 'ORD-003',
+        uid: 'UID-003',
+        product_id: 'prod-003',
+        product_name: 'ステッカー大',
+        product_type: 'sticker',
+        price: 500,
+        quantity: 5,
+        size: '100x100mm',
+        position: null,
+        color: 'ホワイト',
+        design_image_url: null,
+        thumbnail_image_url: null,
+        ordered_at: '2026-01-13T10:00:00Z',
+        customer_name: '山田一郎',
+        status: 'ordered',
+        manufacturer_id: 'mfr-002',
+        manufacturer_name: 'メーカーB',
+      },
+    ],
+    total: 3,
+    total_quantity: 8,
+    total_amount: 6500,
+  }
+}
+
+function createEmptyMockData(): AllManufacturerOrderItemListResponse {
+  return {
+    items: [],
+    total: 0,
+    total_quantity: 0,
+    total_amount: 0,
+  }
+}
+
+// ======================================
+// AC-012: /purchase-orders/all ページが「すべての発注」一覧を表示する
+// ======================================
+
+describe('AC-012: /purchase-orders/all page displays all manufacturer order items', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the AllManufacturerOrderList component with order items', async () => {
+    // Import the new component
+    const { AllManufacturerOrderList } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-list'
+    )
+
+    const mockData = createMockAllOrderItemsData()
+
+    render(
+      <AllManufacturerOrderList
+        data={mockData}
+        isLoading={false}
+      />
+    )
+
+    // 全メーカーの発注明細がテーブルに表示される
+    expect(screen.getByText('ORD-001')).toBeInTheDocument()
+    expect(screen.getByText('ORD-002')).toBeInTheDocument()
+    expect(screen.getByText('ORD-003')).toBeInTheDocument()
+  })
+
+  it('renders manufacturer name for each order item row', async () => {
+    const { AllManufacturerOrderList } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-list'
+    )
+
+    const mockData = createMockAllOrderItemsData()
+
+    render(
+      <AllManufacturerOrderList
+        data={mockData}
+        isLoading={false}
+      />
+    )
+
+    // 各行にメーカー名が表示される（メーカーAは2行あるのでgetAllByTextを使用）
+    expect(screen.getAllByText('メーカーA').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('メーカーB')).toBeInTheDocument()
+  })
+})
+
+// ======================================
+// AC-013: テーブルに必要なカラムが表示される
+// ======================================
+
+describe('AC-013: AllManufacturerOrderList table has required columns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders table with all required column headers', async () => {
+    const { AllManufacturerOrderList } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-list'
+    )
+
+    const mockData = createMockAllOrderItemsData()
+
+    render(
+      <AllManufacturerOrderList
+        data={mockData}
+        isLoading={false}
+      />
+    )
+
+    const headers = screen.getAllByRole('columnheader')
+    const headerTexts = headers.map(h => h.textContent)
+
+    // 必要なカラムが全て存在すること
+    expect(headerTexts.some(t => t?.includes('メーカー名'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('注文番号'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('製品番号'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('商品名'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('商品タイプ'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('ステータス'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('数量'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('金額'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('顧客名'))).toBe(true)
+    expect(headerTexts.some(t => t?.includes('受注日'))).toBe(true)
+  })
+})
+
+// ======================================
+// AC-014: 発注一覧ページに「すべての発注を見る」ボタンが表示される
+// ======================================
+
+describe('AC-014: Purchase orders page has "すべての発注を見る" navigation button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders "すべての発注を見る" button on purchase orders page', async () => {
+    const { default: PurchaseOrdersPage } = await import(
+      '@/app/(dashboard)/purchase-orders/page'
+    )
+
+    render(<PurchaseOrdersPage />)
+
+    // 「すべての発注を見る」ボタンが表示される
+    const navButton = screen.getByText(/すべての発注を見る/)
+    expect(navButton).toBeInTheDocument()
+  })
+
+  it('navigates to /purchase-orders/all when button is clicked', async () => {
+    const user = userEvent.setup()
+
+    const { default: PurchaseOrdersPage } = await import(
+      '@/app/(dashboard)/purchase-orders/page'
+    )
+
+    render(<PurchaseOrdersPage />)
+
+    // ボタンをクリック
+    const navButton = screen.getByText(/すべての発注を見る/)
+    await user.click(navButton)
+
+    // /purchase-orders/all に遷移する
+    // Link コンポーネントの場合は href を確認
+    const linkElement = navButton.closest('a')
+    if (linkElement) {
+      expect(linkElement).toHaveAttribute('href', '/purchase-orders/all')
+    } else {
+      // Button の場合は router.push を確認
+      expect(mockPush).toHaveBeenCalledWith('/purchase-orders/all')
+    }
+  })
+})
+
+// ======================================
+// AC-015: フィルター（ステータス、キーワード検索）が正常に動作する
+// ======================================
+
+describe('AC-015: Filters (status, keyword search) work correctly', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders AllManufacturerOrderFilters component with search and status inputs', async () => {
+    const { AllManufacturerOrderFilters } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-filters'
+    )
+
+    const props = {
+      search: '',
+      status: null as string | null,
+      manufacturerId: null as string | null,
+      productType: null as string | null,
+      orderedFrom: '',
+      orderedTo: '',
+      onSearchChange: vi.fn(),
+      onStatusChange: vi.fn(),
+      onManufacturerIdChange: vi.fn(),
+      onProductTypeChange: vi.fn(),
+      onOrderedFromChange: vi.fn(),
+      onOrderedToChange: vi.fn(),
+      onReset: vi.fn(),
+      manufacturers: [
+        { id: 'mfr-001', name: 'メーカーA' },
+        { id: 'mfr-002', name: 'メーカーB' },
+      ],
+    }
+
+    render(<AllManufacturerOrderFilters {...props} />)
+
+    // 検索入力が存在する
+    const searchInput = screen.getByPlaceholderText(/注文番号.*商品名.*検索/i)
+      || screen.getByPlaceholderText(/検索/i)
+    expect(searchInput).toBeInTheDocument()
+  })
+
+  it('calls onStatusChange when status filter is changed', async () => {
+    const user = userEvent.setup()
+
+    const { AllManufacturerOrderFilters } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-filters'
+    )
+
+    const onStatusChange = vi.fn()
+
+    const props = {
+      search: '',
+      status: null as string | null,
+      manufacturerId: null as string | null,
+      productType: null as string | null,
+      orderedFrom: '',
+      orderedTo: '',
+      onSearchChange: vi.fn(),
+      onStatusChange,
+      onManufacturerIdChange: vi.fn(),
+      onProductTypeChange: vi.fn(),
+      onOrderedFromChange: vi.fn(),
+      onOrderedToChange: vi.fn(),
+      onReset: vi.fn(),
+      manufacturers: [],
+    }
+
+    render(<AllManufacturerOrderFilters {...props} />)
+
+    // ステータスフィルターのセレクトを探してクリック
+    const statusText = screen.getByText('全てのステータス')
+    expect(statusText).toBeInTheDocument()
+
+    // セレクトを開いて「発注済み」を選択
+    const combobox = screen.getAllByRole('combobox').find(
+      el => el.textContent?.includes('全てのステータス')
+    )
+    if (combobox) {
+      await user.click(combobox)
+      const orderedOption = screen.getByText('発注済み')
+      await user.click(orderedOption)
+      expect(onStatusChange).toHaveBeenCalledWith('ordered')
+    }
+  })
+})
+
+// ======================================
+// AC-016: メーカーフィルターで特定メーカーに絞り込みできる
+// ======================================
+
+describe('AC-016: Manufacturer filter allows filtering by specific manufacturer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders manufacturer filter select with manufacturer options', async () => {
+    const { AllManufacturerOrderFilters } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-filters'
+    )
+
+    const props = {
+      search: '',
+      status: null as string | null,
+      manufacturerId: null as string | null,
+      productType: null as string | null,
+      orderedFrom: '',
+      orderedTo: '',
+      onSearchChange: vi.fn(),
+      onStatusChange: vi.fn(),
+      onManufacturerIdChange: vi.fn(),
+      onProductTypeChange: vi.fn(),
+      onOrderedFromChange: vi.fn(),
+      onOrderedToChange: vi.fn(),
+      onReset: vi.fn(),
+      manufacturers: [
+        { id: 'mfr-001', name: 'メーカーA' },
+        { id: 'mfr-002', name: 'メーカーB' },
+      ],
+    }
+
+    render(<AllManufacturerOrderFilters {...props} />)
+
+    // メーカーフィルターが存在する（「全てのメーカー」デフォルト表示）
+    const makerText = screen.getByText('全てのメーカー')
+    expect(makerText).toBeInTheDocument()
+  })
+
+  it('calls onManufacturerIdChange when a manufacturer is selected', async () => {
+    const user = userEvent.setup()
+
+    const { AllManufacturerOrderFilters } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-filters'
+    )
+
+    const onManufacturerIdChange = vi.fn()
+
+    const props = {
+      search: '',
+      status: null as string | null,
+      manufacturerId: null as string | null,
+      productType: null as string | null,
+      orderedFrom: '',
+      orderedTo: '',
+      onSearchChange: vi.fn(),
+      onStatusChange: vi.fn(),
+      onManufacturerIdChange,
+      onProductTypeChange: vi.fn(),
+      onOrderedFromChange: vi.fn(),
+      onOrderedToChange: vi.fn(),
+      onReset: vi.fn(),
+      manufacturers: [
+        { id: 'mfr-001', name: 'メーカーA' },
+        { id: 'mfr-002', name: 'メーカーB' },
+      ],
+    }
+
+    render(<AllManufacturerOrderFilters {...props} />)
+
+    // メーカーフィルターのセレクトを開いて「メーカーA」を選択
+    const combobox = screen.getAllByRole('combobox').find(
+      el => el.textContent?.includes('全てのメーカー')
+    )
+    if (combobox) {
+      await user.click(combobox)
+      const makerOption = screen.getByText('メーカーA')
+      await user.click(makerOption)
+      expect(onManufacturerIdChange).toHaveBeenCalledWith('mfr-001')
+    }
+  })
+})
+
+// ======================================
+// AC-017: 発注明細が0件の場合、空メッセージが表示される
+// ======================================
+
+describe('AC-017: Empty message is displayed when no order items exist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows empty message when items array is empty', async () => {
+    const { AllManufacturerOrderList } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-list'
+    )
+
+    const emptyData = createEmptyMockData()
+
+    render(
+      <AllManufacturerOrderList
+        data={emptyData}
+        isLoading={false}
+      />
+    )
+
+    // 「発注中の明細がありません」等の空メッセージが表示される
+    const emptyMessage = screen.getByText(/明細がありません/i)
+      || screen.getByText(/データがありません/i)
+    expect(emptyMessage).toBeInTheDocument()
+  })
+})
+
+// ======================================
+// AC-018: サマリーカード（合計明細数、合計数量、合計金額）が表示される
+// ======================================
+
+describe('AC-018: Summary cards display total count, total quantity, total amount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders summary cards with correct values', async () => {
+    const { AllManufacturerOrderList } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-list'
+    )
+
+    const mockData = createMockAllOrderItemsData()
+
+    render(
+      <AllManufacturerOrderList
+        data={mockData}
+        isLoading={false}
+      />
+    )
+
+    // 合計明細数が表示される（サマリーカード内の "3件"）
+    expect(screen.getAllByText(/3件/).length).toBeGreaterThanOrEqual(1)
+
+    // 合計数量が表示される（サマリーカード内の "8点"）
+    expect(screen.getByText(/8点/)).toBeInTheDocument()
+
+    // 合計金額が表示される（6,500 の表示形式）
+    expect(screen.getByText(/¥6,500/)).toBeInTheDocument()
+  })
+
+  it('renders summary labels for count, quantity, and amount', async () => {
+    const { AllManufacturerOrderList } = await import(
+      '@/features/purchase-orders/components/all-manufacturer-order-list'
+    )
+
+    const mockData = createMockAllOrderItemsData()
+
+    render(
+      <AllManufacturerOrderList
+        data={mockData}
+        isLoading={false}
+      />
+    )
+
+    // サマリーのラベルが存在すること
+    expect(screen.getByText(/明細数/)).toBeInTheDocument()
+    expect(screen.getByText(/合計数量/)).toBeInTheDocument()
+    expect(screen.getByText(/合計金額/)).toBeInTheDocument()
+  })
+})
+
+// ======================================
+// useAllManufacturerOrderItems hook test
+// ======================================
+
+describe('useAllManufacturerOrderItems hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('hook exists and can be imported', async () => {
+    const hookModule = await import(
+      '@/features/purchase-orders/hooks/use-manufacturer-orders'
+    )
+
+    expect(hookModule.useAllManufacturerOrderItems).toBeDefined()
+    expect(typeof hookModule.useAllManufacturerOrderItems).toBe('function')
+  })
+
+  it('constructs correct API URL with filters', async () => {
+    const useSWR = vi.mocked(
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('swr').default
+    )
+
+    const { useAllManufacturerOrderItems } = await import(
+      '@/features/purchase-orders/hooks/use-manufacturer-orders'
+    )
+
+    renderHook(() =>
+      useAllManufacturerOrderItems({
+        status: 'ordered',
+        search: 'テスト',
+        manufacturer_id: 'mfr-001',
+      })
+    )
+
+    // useSWR が正しいURLパラメータで呼ばれたことを確認
+    expect(useSWR).toHaveBeenCalledWith(
+      expect.stringContaining('/manufacturers/all-order-items'),
+      expect.anything(),
+      expect.anything(),
+    )
+
+    const callArgs = useSWR.mock.calls
+    const lastCallKey = callArgs[callArgs.length - 1]?.[0] as string
+    expect(lastCallKey).toContain('status=ordered')
+    expect(lastCallKey).toContain('search=')
+    expect(lastCallKey).toContain('manufacturer_id=mfr-001')
+  })
+
+  it('does not include empty filter parameters in URL', async () => {
+    const useSWR = vi.mocked(
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('swr').default
+    )
+
+    const { useAllManufacturerOrderItems } = await import(
+      '@/features/purchase-orders/hooks/use-manufacturer-orders'
+    )
+
+    renderHook(() => useAllManufacturerOrderItems({}))
+
+    // フィルターなしの場合はクエリパラメータなし
+    const callArgs = useSWR.mock.calls
+    const lastCallKey = callArgs[callArgs.length - 1]?.[0] as string
+    expect(lastCallKey).toContain('/manufacturers/all-order-items')
+    expect(lastCallKey).not.toContain('status=')
+    expect(lastCallKey).not.toContain('search=')
+    expect(lastCallKey).not.toContain('manufacturer_id=')
+  })
+})
+
+// ======================================
+// AllManufacturerOrderItemListResponse type includes correct fields
+// ======================================
+
+describe('AllManufacturerOrderItem type includes manufacturer fields', () => {
+  it('each item has manufacturer_id and manufacturer_name fields', () => {
+    const mockData = createMockAllOrderItemsData()
+
+    for (const item of mockData.items) {
+      expect(item).toHaveProperty('manufacturer_id')
+      expect(item).toHaveProperty('manufacturer_name')
+      expect(item.manufacturer_id).toBeTruthy()
+      expect(item.manufacturer_name).toBeTruthy()
+    }
+  })
+
+  it('response has total, total_quantity, total_amount fields', () => {
+    const mockData = createMockAllOrderItemsData()
+
+    expect(mockData).toHaveProperty('total')
+    expect(mockData).toHaveProperty('total_quantity')
+    expect(mockData).toHaveProperty('total_amount')
+    expect(typeof mockData.total).toBe('number')
+    expect(typeof mockData.total_quantity).toBe('number')
+    expect(typeof mockData.total_amount).toBe('number')
+  })
+})
+
+// ======================================
+// /purchase-orders/all page integration test
+// ======================================
+
+describe('/purchase-orders/all page renders correctly', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('page component can be imported and rendered', async () => {
+    // This test verifies the page file exists at the expected path
+    const pageModule = await import(
+      '@/app/(dashboard)/purchase-orders/all/page'
+    )
+
+    expect(pageModule.default).toBeDefined()
+    expect(typeof pageModule.default).toBe('function')
+  })
+})


### PR DESCRIPTION
## 概要

**Intent Spec:** `.claude/specs/FEAT-0018-all-manufacturer-orders.yaml`

### なぜこの変更が必要か

Issue #25: メーカーごとの発注一覧はそのままに、「すべての発注」として全メーカー分を一覧で確認できるページが必要。管理者が全メーカーの発注状況を横断的に把握できるようにする。

### 変更内容
- `GET /api/v1/manufacturers/all-order-items` エンドポイントを新規追加（全メーカー横断の発注明細取得）
- `/purchase-orders/all` ページを新規追加（サマリーカード＋フィルター＋テーブル）
- 発注一覧ページに「すべての発注を見る」ナビゲーションボタンを追加
- フィルター対応: ステータス、キーワード検索、メーカー絞り込み

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| ビルド検証 | ✅ | FE/BE共にビルド成功 |
| 起動検証 | ✅ | 全サービス正常稼働 |
| ユニットテスト | ✅ | BE: 207 passed / FE: 176 passed |
| 統合テスト | ✅ | 90 passed |
| Playwright E2E | ⏭️ SKIP | ポリシーによりスキップ |
| 仕様適合 | ✅ | AC: 18/18 カバー |
| AI意味レビュー | ✅ | 重大問題なし |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| AC-001: 全メーカーの発注明細をJOINで取得 | `api/tests/unit/test_all_manufacturer_order_items.py` | ✅ |
| AC-002: ステータスフィルター | `api/tests/unit/test_all_manufacturer_order_items.py` | ✅ |
| AC-003: キーワード検索フィルター | `api/tests/unit/test_all_manufacturer_order_items.py` | ✅ |
| AC-004: メーカーIDフィルター | `api/tests/unit/test_all_manufacturer_order_items.py` | ✅ |
| AC-005: サービス層のレスポンス組み立て・集計 | `api/tests/unit/test_all_manufacturer_order_service.py` | ✅ |
| AC-006: API全メーカー明細返却 | `api/tests/integration/test_all_manufacturer_order_items.py` | ✅ |
| AC-007: APIステータスフィルター | `api/tests/integration/test_all_manufacturer_order_items.py` | ✅ |
| AC-008: APIキーワード検索 | `api/tests/integration/test_all_manufacturer_order_items.py` | ✅ |
| AC-009: APIメーカーIDフィルター | `api/tests/integration/test_all_manufacturer_order_items.py` | ✅ |
| AC-010: 認証なし401 | `api/tests/integration/test_all_manufacturer_order_items.py` | ✅ |
| AC-011: 0件時の空レスポンス | `api/tests/integration/test_all_manufacturer_order_items.py` | ✅ |
| AC-012: ページ表示 | `web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx` | ✅ |
| AC-013: テーブルカラム（メーカー名含む） | `web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx` | ✅ |
| AC-014: ナビゲーションボタン | `web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx` | ✅ |
| AC-015: ステータス・キーワードフィルター | `web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx` | ✅ |
| AC-016: メーカーフィルター | `web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx` | ✅ |
| AC-017: 空メッセージ | `web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx` | ✅ |
| AC-018: サマリーカード | `web/tests/unit/feat-0018-all-manufacturer-orders.test.tsx` | ✅ |

## レビューのポイント

- 既存のメーカー別発注一覧（`/purchase-orders/[id]`）は一切変更せず、新規エンドポイント・ページとして追加
- `GET /manufacturers/all-order-items` は `/{manufacturer_id}` より前に配置してパス競合を回避
- 閲覧専用ビュー（ステータス更新・発注資料ダウンロードは既存メーカー別ページで実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)