### PR TITLE
feat: CSV/XLSXファイルによる伝票番号一括インポート機能 (FEAT-0018)

### DIFF
--- a/.claude/specs/FEAT-0018-shipment-tracking-import.yaml
+++ b/.claude/specs/FEAT-0018-shipment-tracking-import.yaml
@@ -1,0 +1,221 @@
+id: FEAT-0018
+summary: 管理者が注文番号・伝票番号・運送会社名を含むCSV/XLSXファイルをアップロードし、対応する配送レコードの伝票番号・運送会社を一括更新できる
+
+background:
+  why: |
+    現在、伝票番号の登録はテキストエリアに「配送ID,伝票番号」形式で手入力する必要があり、
+    配送業者から受け取ったCSV/XLSXファイルを直接インポートできない。
+    注文番号ベースで伝票番号を一括登録できれば、運用効率が大幅に向上する。
+  who: 管理者（admin）
+  when: |
+    配送業者から伝票番号一覧をCSV/XLSXで受け取った際に、
+    配送管理画面からファイルをアップロードして伝票番号を一括登録する場面。
+
+scope:
+  includes:
+    - "バックエンド: POST /api/v1/shipments/import エンドポイント（CSV/XLSXファイルアップロード対応）"
+    - "バックエンド: CSV/XLSXファイルの解析ロジック（注文番号・伝票番号・運送会社名の3列）"
+    - "バックエンド: 注文番号からshipmentを特定し、tracking_number・carrierを更新する処理"
+    - "バックエンド: 行ごとのバリデーション・エラーハンドリング（エラー行をスキップし結果を返す）"
+    - "バックエンド: サンプルCSVテンプレートダウンロード用エンドポイント GET /api/v1/shipments/import-template"
+    - "フロントエンド: 配送一覧画面にCSV/XLSXインポートダイアログを追加"
+    - "フロントエンド: ファイル選択（ドラッグ&ドロップ対応）UIコンポーネント"
+    - "フロントエンド: インポート結果の表示（成功件数・失敗件数・エラー詳細）"
+    - "フロントエンド: サンプルCSVテンプレートのダウンロードリンク"
+  excludes:
+    - "配送ステータスの自動更新（伝票番号登録時にステータスをshippedに変更する等は対象外）"
+    - "既存のPOST /shipments/import-tracking（JSON形式）エンドポイントの廃止・変更"
+    - "配送レコード自体の新規作成（既存のshipmentに対する更新のみ）"
+  prerequisites:
+    - "shipmentレコードが注文（Order）と紐づいている（ShipmentItem経由）"
+    - "注文番号（order_number）がOrders.order_numberとしてユニーク"
+    - "1つの注文に対して1つのshipmentが紐づく想定"
+
+input_output:
+  inputs:
+    - name: file
+      type: file (CSV or XLSX)
+      required: true
+      validation: |
+        - ファイル拡張子が .csv または .xlsx であること
+        - ファイルサイズが10MB以下であること
+        - CSVの場合: UTF-8（BOM付き可）またはShift-JIS対応
+        - ヘッダー行が存在すること
+        - 必須列「注文番号」「伝票番号」が存在すること
+        - 「運送会社名」列はオプション（省略時はnull）
+  outputs:
+    - name: import_result
+      type: object
+      description: |
+        {
+          "total_count": int,        // 処理対象行数（ヘッダー除く）
+          "success_count": int,      // 更新成功件数
+          "error_count": int,        // エラー件数
+          "errors": [                // エラー詳細配列
+            {
+              "row": int,            // 行番号（1始まり、ヘッダー除く）
+              "order_number": str,   // 注文番号（解析できた場合）
+              "message": str         // エラーメッセージ
+            }
+          ],
+          "updated_shipments": [     // 更新されたshipmentのレスポンス
+            ShipmentResponse
+          ]
+        }
+    - name: template_csv
+      type: file (CSV)
+      description: |
+        サンプルCSVテンプレート。ヘッダー行とサンプルデータ行。
+        列: 注文番号, 伝票番号, 運送会社名
+  state_changes:
+    - "対象shipmentのtracking_numberが更新される"
+    - "対象shipmentのcarrierが更新される（運送会社名列が提供された場合）"
+    - "shipmentのupdated_atが更新される"
+
+acceptance_criteria:
+  - id: AC-001
+    description: CSVファイル（UTF-8）をアップロードすると、注文番号に紐づくshipmentの伝票番号・運送会社が更新される
+    test_type: integration
+    given: shipmentが存在し、注文番号"ORD-001"に紐づいている
+    when: 注文番号"ORD-001"、伝票番号"1234-5678-9012"、運送会社名"ヤマト運輸"のCSVをPOST /api/v1/shipments/importにアップロードする
+    then: 対応するshipmentのtracking_numberが"1234-5678-9012"に、carrierが"ヤマト運輸"に更新される
+
+  - id: AC-002
+    description: XLSXファイルをアップロードしても同様に伝票番号・運送会社が更新される
+    test_type: integration
+    given: shipmentが存在し、注文番号"ORD-002"に紐づいている
+    when: 同内容のXLSXファイルをPOST /api/v1/shipments/importにアップロードする
+    then: CSVと同じ結果になる
+
+  - id: AC-003
+    description: 複数行のCSVで一括更新ができる
+    test_type: integration
+    given: 3件のshipmentが存在する
+    when: 3行のCSVをアップロードする
+    then: 3件すべてのshipmentが更新され、success_count=3が返される
+
+  - id: AC-004
+    description: 存在しない注文番号の行はエラーとして報告され、他の行は正常に処理される
+    test_type: integration
+    given: "ORD-001"は存在するが"ORD-999"は存在しない
+    when: 2行のCSV（ORD-001とORD-999）をアップロードする
+    then: success_count=1、error_count=1、errorsにORD-999のエラーが含まれる
+
+  - id: AC-005
+    description: shipmentが紐づいていない注文番号の行はエラーとして報告される
+    test_type: integration
+    given: 注文"ORD-003"は存在するがshipmentが紐づいていない
+    when: ORD-003を含むCSVをアップロードする
+    then: error_count=1、errorsに「配送レコードが存在しません」エラーが含まれる
+
+  - id: AC-006
+    description: 必須列（注文番号、伝票番号）がないCSVはバリデーションエラーになる
+    test_type: unit
+    given: ヘッダーが「注文番号」列のみのCSV
+    when: ファイルを解析する
+    then: "「伝票番号」列が見つかりません"というバリデーションエラーが返される
+
+  - id: AC-007
+    description: 空行はスキップされる
+    test_type: unit
+    given: データ行の間に空行が含まれるCSV
+    when: ファイルを解析する
+    then: 空行は無視され、有効な行のみが処理される
+
+  - id: AC-008
+    description: 伝票番号が空の行はエラーとして報告される
+    test_type: unit
+    given: 注文番号は入力されているが伝票番号が空の行
+    when: ファイルを解析する
+    then: error_count=1、errorsに「伝票番号が空です」エラーが含まれる
+
+  - id: AC-009
+    description: 運送会社名列が省略されている場合（列自体がない場合）、carrierはnullのまま
+    test_type: unit
+    given: ヘッダーが「注文番号,伝票番号」のみのCSV
+    when: ファイルを解析する
+    then: 正常に処理され、carrierは更新されない（nullのまま）
+
+  - id: AC-010
+    description: CSV/XLSX以外のファイルはバリデーションエラーになる
+    test_type: unit
+    given: .txtファイル
+    when: POST /api/v1/shipments/importにアップロードする
+    then: 422エラー「対応していないファイル形式です。CSVまたはXLSXファイルをアップロードしてください」が返される
+
+  - id: AC-011
+    description: 10MBを超えるファイルはバリデーションエラーになる
+    test_type: unit
+    given: 11MBのCSVファイル
+    when: POST /api/v1/shipments/importにアップロードする
+    then: 422エラー「ファイルサイズが上限（10MB）を超えています」が返される
+
+  - id: AC-012
+    description: GET /api/v1/shipments/import-templateでサンプルCSVテンプレートがダウンロードできる
+    test_type: integration
+    given: 認証済み管理者
+    when: GET /api/v1/shipments/import-templateにリクエストする
+    then: UTF-8 BOM付きCSVファイルが返され、ヘッダー行「注文番号,伝票番号,運送会社名」とサンプルデータ行が含まれる
+
+  - id: AC-013
+    description: Shift-JISエンコードのCSVも正しく解析できる
+    test_type: unit
+    given: Shift-JISでエンコードされたCSV
+    when: ファイルを解析する
+    then: 日本語の注文番号・運送会社名が正しく読み取れる
+
+  - id: AC-014
+    description: フロントエンドのインポートダイアログでファイルを選択してインポートが実行できる
+    test_type: unit
+    given: 配送一覧画面が表示されている
+    when: インポートボタンをクリックし、CSVファイルを選択して「インポート」を実行する
+    then: APIが呼び出され、結果（成功件数・失敗件数・エラー詳細）がダイアログ内に表示される
+
+  - id: AC-015
+    description: インポート成功後に配送一覧が自動リフレッシュされる
+    test_type: unit
+    given: インポートが成功した
+    when: ダイアログを閉じる
+    then: 配送一覧が最新のデータに更新されている
+
+  - id: AC-016
+    description: サンプルテンプレートダウンロードリンクがインポートダイアログ内に表示される
+    test_type: unit
+    given: インポートダイアログが表示されている
+    when: テンプレートダウンロードリンクをクリックする
+    then: CSVテンプレートファイルがダウンロードされる
+
+  - id: AC-017
+    description: 同一注文番号が複数行に存在する場合、最後の行の値で上書きされる
+    test_type: unit
+    given: 同じ注文番号"ORD-001"が2行存在し、伝票番号がそれぞれ異なる
+    when: ファイルを解析・処理する
+    then: 最後の行の伝票番号で更新される（警告なし）
+
+constraints:
+  performance:
+    - "1000行のCSVファイルを10秒以内に処理できること"
+    - "ファイルサイズ上限は10MB"
+  security:
+    - "管理者（admin）のみアクセス可能（get_current_admin依存）"
+    - "アップロードされたファイルはメモリ上で処理し、サーバーに保存しない"
+  compatibility:
+    - "CSVエンコーディング: UTF-8（BOM付き/なし）、Shift-JIS対応"
+    - "XLSXファイル: openpyxlライブラリで解析"
+
+assumptions:
+  - "1つの注文番号に対して複数のshipmentが紐づくケースはないと想定（1:1関係）"
+  - "注文番号は注文テーブルのorder_numberフィールドに対応する"
+  - "CSVの列名は日本語（「注文番号」「伝票番号」「運送会社名」）を想定"
+  - "XLSXの解析にはopenpyxlライブラリを使用する（pyproject.tomlへの追加が必要な場合あり）"
+  - "エラー行はスキップし、他の行は正常に処理する（ロールバックではなく部分成功方式）"
+  - "既存のPOST /shipments/import-tracking（JSON形式）は残し、新しいエンドポイントを追加する"
+  - "既存のTrackingImportコンポーネント（テキストエリア方式）は新しいファイルアップロード方式に置き換える"
+  - "サンプルテンプレートにはヘッダー行に加えてサンプルデータ行1行を含める"
+  - "運送会社名の列ヘッダーは「運送会社名」「運送会社」のいずれも許容する"
+
+success_metrics:
+  - "CSV/XLSXファイルアップロードによる伝票番号一括登録が正常に動作する"
+  - "エラー行がある場合も他の行は正常に処理され、エラー詳細が返される"
+  - "サンプルCSVテンプレートがダウンロードできる"
+  - "フロントエンドのインポートUIが直感的に操作できる"

--- a/api/app/routers/shipments.py
+++ b/api/app/routers/shipments.py
@@ -18,6 +18,7 @@ from app.schemas.shipment import (
     ShipmentListResponse,
     ShipmentResponse,
     ShipmentStatusUpdate,
+    TrackingFileImportResult,
     TrackingImportRequest,
 )
 from app.services.shipment_service import ShipmentService
@@ -92,6 +93,39 @@ async def export_shipments_csv(
         UTF-8 BOM付きCSVファイル
     """
     csv_bytes, filename = await service.export_csv(data.shipment_ids)
+
+    encoded_filename = quote(filename)
+
+    return StreamingResponse(
+        iter([csv_bytes]),
+        media_type="text/csv; charset=utf-8",
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"
+        },
+    )
+
+
+@router.post("/import", response_model=TrackingFileImportResult)
+async def import_tracking_from_file(
+    service: Annotated[ShipmentService, Depends(get_shipment_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+    file: UploadFile = File(...),
+) -> TrackingFileImportResult:
+    """CSV/XLSXファイルから伝票番号を一括インポート.
+
+    注文番号・伝票番号・運送会社名を含むCSV/XLSXファイルをアップロードし、
+    対応する配送レコードの伝票番号・運送会社を一括更新します。
+    """
+    return await service.import_tracking_from_file(file)
+
+
+@router.get("/import-template")
+async def download_import_template(
+    service: Annotated[ShipmentService, Depends(get_shipment_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> StreamingResponse:
+    """伝票番号インポート用のサンプルCSVテンプレートをダウンロード."""
+    csv_bytes, filename = await service.generate_import_template()
 
     encoded_filename = quote(filename)
 

--- a/api/app/schemas/shipment.py
+++ b/api/app/schemas/shipment.py
@@ -115,3 +115,21 @@ class ShipmentExportRequest(BaseModel):
     """配送CSVエクスポートリクエスト"""
 
     shipment_ids: list[str] = Field(..., min_length=1)
+
+
+class TrackingFileImportError(BaseModel):
+    """伝票番号ファイルインポートのエラー詳細"""
+
+    row: int
+    order_number: str | None = None
+    message: str
+
+
+class TrackingFileImportResult(BaseModel):
+    """伝票番号ファイルインポートの結果"""
+
+    total_count: int
+    success_count: int
+    error_count: int
+    errors: list[TrackingFileImportError]
+    updated_shipments: list[ShipmentResponse] = []

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -22,10 +22,15 @@ from app.schemas.shipment import (
     ShipmentListResponse,
     ShipmentResponse,
     ShipmentStatusUpdate,
+    TrackingFileImportError,
+    TrackingFileImportResult,
     TrackingImportRequest,
 )
 from app.utils.exceptions import InvalidStatusTransitionError, NotFoundError, ValidationError
 from app.utils.file_storage import FileStorage
+
+import chardet
+import openpyxl
 
 
 class ShipmentService:
@@ -262,6 +267,204 @@ class ShipmentService:
             failed_count=failed_count,
             failed_ids=failed_ids,
         )
+
+    async def import_tracking_from_file(
+        self, file: UploadFile
+    ) -> TrackingFileImportResult:
+        """CSV/XLSXファイルから伝票番号を一括インポート.
+
+        Args:
+            file: アップロードされたCSVまたはXLSXファイル
+
+        Returns:
+            TrackingFileImportResult: インポート結果
+
+        Raises:
+            ValidationError: ファイル形式やサイズが不正な場合
+        """
+        # ファイル拡張子チェック
+        filename = file.filename or ""
+        ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        if ext not in ("csv", "xlsx"):
+            raise ValidationError(
+                "対応していないファイル形式です。CSVまたはXLSXファイルをアップロードしてください"
+            )
+
+        # ファイルサイズチェック (10MB上限)
+        max_size = 10 * 1024 * 1024
+        if file.size is not None and file.size > max_size:
+            raise ValidationError("ファイルサイズが上限（10MB）を超えています")
+
+        # ファイル内容を読み込み
+        content = await file.read()
+
+        # 読み込んだ内容でもサイズチェック
+        if len(content) > max_size:
+            raise ValidationError("ファイルサイズが上限（10MB）を超えています")
+
+        # ファイル解析
+        if ext == "xlsx":
+            rows = self._parse_xlsx(content)
+        else:
+            rows = self._parse_csv(content)
+
+        # ヘッダーバリデーション
+        if not rows:
+            raise ValidationError("ファイルにデータがありません")
+
+        header = [col.strip() for col in rows[0]]
+
+        # 必須列チェック
+        if "注文番号" not in header:
+            raise ValidationError("「注文番号」列が見つかりません")
+        if "伝票番号" not in header:
+            raise ValidationError("「伝票番号」列が見つかりません")
+
+        order_number_idx = header.index("注文番号")
+        tracking_number_idx = header.index("伝票番号")
+
+        # 運送会社名列（オプション）
+        carrier_idx = None
+        for carrier_name in ("運送会社名", "運送会社"):
+            if carrier_name in header:
+                carrier_idx = header.index(carrier_name)
+                break
+
+        # データ行の解析（空行スキップ、重複はlast-write-wins）
+        # parsed_entries: order_number -> (tracking_number, carrier, row_number)
+        parsed_entries: dict[str, tuple[str, str | None, int]] = {}
+        errors: list[TrackingFileImportError] = []
+        data_rows = rows[1:]
+        valid_row_count = 0
+
+        for i, row in enumerate(data_rows, start=1):
+            # 空行スキップ
+            if not row or all(cell.strip() == "" for cell in row):
+                continue
+
+            valid_row_count += 1
+
+            # 列数が足りない場合
+            order_number = row[order_number_idx].strip() if order_number_idx < len(row) else ""
+            tracking_number = row[tracking_number_idx].strip() if tracking_number_idx < len(row) else ""
+
+            # 注文番号チェック
+            if not order_number:
+                errors.append(TrackingFileImportError(
+                    row=i,
+                    order_number=None,
+                    message="注文番号が空です",
+                ))
+                continue
+
+            # 伝票番号チェック
+            if not tracking_number:
+                errors.append(TrackingFileImportError(
+                    row=i,
+                    order_number=order_number,
+                    message="伝票番号が空です",
+                ))
+                continue
+
+            carrier_value = None
+            if carrier_idx is not None and carrier_idx < len(row):
+                carrier_value = row[carrier_idx].strip() or None
+
+            # last-write-wins
+            parsed_entries[order_number] = (tracking_number, carrier_value, i)
+
+        # 注文番号からshipmentを検索して更新
+        success_count = 0
+        updated_shipments: list[ShipmentResponse] = []
+
+        for order_number, (tracking_number, carrier_value, row_num) in parsed_entries.items():
+            # 注文を検索
+            order = await self._order_repo.find_by_order_number(order_number)
+            if not order:
+                errors.append(TrackingFileImportError(
+                    row=row_num,
+                    order_number=order_number,
+                    message="注文番号が見つかりません",
+                ))
+                continue
+
+            # shipmentを検索
+            order_shipment_map = await self._shipment_repo.find_by_order_ids([order.id])
+            shipment = order_shipment_map.get(order.id)
+            if not shipment:
+                errors.append(TrackingFileImportError(
+                    row=row_num,
+                    order_number=order_number,
+                    message="配送レコードが存在しません",
+                ))
+                continue
+
+            # 更新
+            shipment.tracking_number = tracking_number
+            if carrier_value is not None:
+                shipment.carrier = carrier_value
+            await self._shipment_repo.update(shipment)
+            success_count += 1
+
+        return TrackingFileImportResult(
+            total_count=valid_row_count,
+            success_count=success_count,
+            error_count=len(errors),
+            errors=errors,
+            updated_shipments=updated_shipments,
+        )
+
+    def _parse_csv(self, content: bytes) -> list[list[str]]:
+        """CSVバイトデータを解析する.
+
+        UTF-8 (BOM付き/なし) および Shift-JIS に対応。
+        chardet でエンコーディングを自動検出する。
+        """
+        # BOM付きUTF-8の場合はBOMを除去
+        if content.startswith(b"\xef\xbb\xbf"):
+            text = content[3:].decode("utf-8")
+        else:
+            # chardetでエンコーディングを検出
+            detected = chardet.detect(content)
+            encoding = detected.get("encoding", "utf-8") or "utf-8"
+            # chardetが "SHIFT_JIS" や "Windows-1252" 等を返す場合がある
+            # 日本語のCSVではShift-JIS系のエンコーディングを正しく扱う
+            if encoding.upper() in ("SHIFT_JIS", "SHIFT-JIS", "WINDOWS-31J", "CP932"):
+                encoding = "shift_jis"
+            try:
+                text = content.decode(encoding)
+            except (UnicodeDecodeError, LookupError):
+                text = content.decode("utf-8", errors="replace")
+
+        reader = csv.reader(io.StringIO(text))
+        return list(reader)
+
+    def _parse_xlsx(self, content: bytes) -> list[list[str]]:
+        """XLSXバイトデータを解析する."""
+        wb = openpyxl.load_workbook(io.BytesIO(content), read_only=True)
+        ws = wb.active
+        rows: list[list[str]] = []
+        for row in ws.iter_rows(values_only=True):
+            rows.append([str(cell) if cell is not None else "" for cell in row])
+        wb.close()
+        return rows
+
+    async def generate_import_template(self) -> tuple[bytes, str]:
+        """インポート用サンプルCSVテンプレートを生成.
+
+        Returns:
+            Tuple of (CSV content as bytes with UTF-8 BOM, filename).
+        """
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["注文番号", "伝票番号", "運送会社名"])
+        writer.writerow(["ORD-0001", "1234-5678-9012", "ヤマト運輸"])
+
+        csv_content = output.getvalue()
+        csv_bytes = b"\xef\xbb\xbf" + csv_content.encode("utf-8")
+
+        filename = "tracking_import_template.csv"
+        return csv_bytes, filename
 
     def _is_valid_transition(
         self, current: ShipmentStatus, target: ShipmentStatus

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "bcrypt>=4.0.1,<4.1.0",  # passlib互換性のためバージョン固定
     # File Processing
     "openpyxl>=3.1.0",
+    "chardet>=5.0.0",
     "python-multipart>=0.0.17",
     # Utilities
     "httpx>=0.28.0",

--- a/api/tests/integration/test_shipment_tracking_file_import.py
+++ b/api/tests/integration/test_shipment_tracking_file_import.py
@@ -1,0 +1,571 @@
+"""Integration tests for shipment tracking file import (CSV/XLSX).
+
+FEAT-0018: CSV/XLSXファイルによる伝票番号一括インポート機能
+
+Tests the full flow through API -> Service -> Repository -> Database,
+verifying that the imported tracking numbers are correctly persisted.
+
+AC-001: CSVファイル（UTF-8）アップロードで伝票番号・運送会社が更新される
+AC-002: XLSXファイルアップロードでも同様に更新される
+AC-003: 複数行のCSVで一括更新ができる
+AC-004: 存在しない注文番号の行はエラー、他の行は正常処理
+AC-005: shipmentが紐づいていない注文番号の行はエラー
+AC-012: GET /api/v1/shipments/import-templateでサンプルCSVテンプレートがダウンロードできる
+"""
+
+import csv
+import io
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---- Helpers ----
+
+
+def create_csv_bytes(
+    rows: list[list[str]],
+    encoding: str = "utf-8",
+    bom: bool = False,
+) -> bytes:
+    """Create CSV content as bytes."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    for row in rows:
+        writer.writerow(row)
+    csv_text = output.getvalue()
+
+    csv_bytes = csv_text.encode(encoding)
+    if bom:
+        csv_bytes = b"\xef\xbb\xbf" + csv_bytes
+    return csv_bytes
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture
+async def order_with_shipment(db_session: AsyncSession, test_order_source: dict):
+    """テスト用の注文 + 配送データ（shipment紐づき済み）
+
+    注文番号 "FEAT18-{uuid[:8]}" で作成し、shipmentと紐づけます。
+    """
+    order_id = str(uuid4())
+    order_number = f"FEAT18-{order_id[:8]}"
+    shipment_id = str(uuid4())
+    shipment_item_id = str(uuid4())
+
+    # Create order
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id,
+                product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at,
+                created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id,
+                :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(),
+                NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": order_number,
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product",
+            "quantity": 1,
+            "customer_name": "FEAT-0018 Customer",
+            "customer_email": "feat0018@example.com",
+            "customer_phone": "090-0018-0018",
+            "customer_postal_code": "100-0018",
+            "customer_address_prefecture": "東京都",
+            "customer_address_city": "千代田区テスト18-1",
+            "status": "delivered",
+        },
+    )
+
+    # Create shipment
+    await db_session.execute(
+        text("""
+            INSERT INTO shipments (id, status, created_at, updated_at)
+            VALUES (:id, :status, NOW(), NOW())
+        """),
+        {"id": shipment_id, "status": "pending"},
+    )
+
+    # Create shipment item linking shipment to order
+    await db_session.execute(
+        text("""
+            INSERT INTO shipment_items (id, shipment_id, order_id, created_at, updated_at)
+            VALUES (:id, :shipment_id, :order_id, NOW(), NOW())
+        """),
+        {
+            "id": shipment_item_id,
+            "shipment_id": shipment_id,
+            "order_id": order_id,
+        },
+    )
+
+    await db_session.commit()
+
+    yield {
+        "order_id": order_id,
+        "order_number": order_number,
+        "shipment_id": shipment_id,
+    }
+
+
+@pytest.fixture
+async def multiple_orders_with_shipments(
+    db_session: AsyncSession, test_order_source: dict
+):
+    """テスト用の3件の注文 + 配送データ"""
+    orders = []
+    for i in range(3):
+        order_id = str(uuid4())
+        order_number = f"FEAT18-MULTI-{i+1}-{order_id[:8]}"
+        shipment_id = str(uuid4())
+        shipment_item_id = str(uuid4())
+
+        await db_session.execute(
+            text("""
+                INSERT INTO orders (
+                    id, order_number, order_source_id,
+                    product_name, quantity,
+                    customer_name, customer_email, customer_phone,
+                    customer_postal_code, customer_address_prefecture,
+                    customer_address_city, status, ordered_at,
+                    created_at, updated_at
+                )
+                VALUES (
+                    :id, :order_number, :order_source_id,
+                    :product_name, :quantity,
+                    :customer_name, :customer_email, :customer_phone,
+                    :customer_postal_code, :customer_address_prefecture,
+                    :customer_address_city, :status, NOW(),
+                    NOW(), NOW()
+                )
+            """),
+            {
+                "id": order_id,
+                "order_number": order_number,
+                "order_source_id": test_order_source["id"],
+                "product_name": f"Test Product {i+1}",
+                "quantity": 1,
+                "customer_name": f"Customer {i+1}",
+                "customer_email": f"customer{i+1}@example.com",
+                "customer_phone": f"090-0000-{i+1:04d}",
+                "customer_postal_code": f"100-{i+1:04d}",
+                "customer_address_prefecture": "東京都",
+                "customer_address_city": f"千代田区テスト{i+1}",
+                "status": "delivered",
+            },
+        )
+
+        await db_session.execute(
+            text("""
+                INSERT INTO shipments (id, status, created_at, updated_at)
+                VALUES (:id, :status, NOW(), NOW())
+            """),
+            {"id": shipment_id, "status": "pending"},
+        )
+
+        await db_session.execute(
+            text("""
+                INSERT INTO shipment_items (id, shipment_id, order_id, created_at, updated_at)
+                VALUES (:id, :shipment_id, :order_id, NOW(), NOW())
+            """),
+            {
+                "id": shipment_item_id,
+                "shipment_id": shipment_id,
+                "order_id": order_id,
+            },
+        )
+
+        orders.append({
+            "order_id": order_id,
+            "order_number": order_number,
+            "shipment_id": shipment_id,
+        })
+
+    await db_session.commit()
+    yield orders
+
+
+@pytest.fixture
+async def order_without_shipment(db_session: AsyncSession, test_order_source: dict):
+    """テスト用の注文（shipment紐づきなし）"""
+    order_id = str(uuid4())
+    order_number = f"FEAT18-NOSHIP-{order_id[:8]}"
+
+    await db_session.execute(
+        text("""
+            INSERT INTO orders (
+                id, order_number, order_source_id,
+                product_name, quantity,
+                customer_name, customer_email, customer_phone,
+                customer_postal_code, customer_address_prefecture,
+                customer_address_city, status, ordered_at,
+                created_at, updated_at
+            )
+            VALUES (
+                :id, :order_number, :order_source_id,
+                :product_name, :quantity,
+                :customer_name, :customer_email, :customer_phone,
+                :customer_postal_code, :customer_address_prefecture,
+                :customer_address_city, :status, NOW(),
+                NOW(), NOW()
+            )
+        """),
+        {
+            "id": order_id,
+            "order_number": order_number,
+            "order_source_id": test_order_source["id"],
+            "product_name": "Test Product No Ship",
+            "quantity": 1,
+            "customer_name": "No Ship Customer",
+            "customer_email": "noship@example.com",
+            "customer_phone": "090-0000-9999",
+            "customer_postal_code": "100-9999",
+            "customer_address_prefecture": "東京都",
+            "customer_address_city": "千代田区テスト9999",
+            "status": "delivered",
+        },
+    )
+    await db_session.commit()
+
+    yield {
+        "order_id": order_id,
+        "order_number": order_number,
+    }
+
+
+class TestImportTrackingFileAPI:
+    """Integration tests for POST /api/v1/shipments/import."""
+
+    # ===========================================
+    # AC-001: CSVファイル（UTF-8）で伝票番号・運送会社が更新される
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac001_csv_upload_updates_tracking_and_carrier(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        order_with_shipment: dict,
+        db_session: AsyncSession,
+    ):
+        """AC-001: CSVファイルで伝票番号・運送会社が更新される.
+
+        Given: shipmentが存在し、注文番号に紐づいている
+        When: 注文番号、伝票番号"1234-5678-9012"、運送会社名"ヤマト運輸"のCSVをPOSTする
+        Then: 対応するshipmentのtracking_numberとcarrierが更新される
+        """
+        order_number = order_with_shipment["order_number"]
+        shipment_id = order_with_shipment["shipment_id"]
+
+        csv_bytes = create_csv_bytes([
+            ["注文番号", "伝票番号", "運送会社名"],
+            [order_number, "1234-5678-9012", "ヤマト運輸"],
+        ])
+
+        response = await client.post(
+            "/api/v1/shipments/import",
+            headers=auth_headers,
+            files={"file": ("tracking.csv", csv_bytes, "text/csv")},
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.text}"
+        )
+
+        data = response.json()
+        assert data["success_count"] == 1
+        assert data["error_count"] == 0
+
+        # Verify DB was updated
+        result = await db_session.execute(
+            text("SELECT tracking_number, carrier FROM shipments WHERE id = :id"),
+            {"id": shipment_id},
+        )
+        row = result.fetchone()
+        assert row is not None
+        assert row[0] == "1234-5678-9012"
+        assert row[1] == "ヤマト運輸"
+
+    # ===========================================
+    # AC-002: XLSXファイルで同様に更新される
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac002_xlsx_upload_updates_tracking_and_carrier(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        order_with_shipment: dict,
+        db_session: AsyncSession,
+    ):
+        """AC-002: XLSXファイルで伝票番号・運送会社が更新される.
+
+        Given: shipmentが存在し、注文番号に紐づいている
+        When: 同内容のXLSXファイルをPOST /api/v1/shipments/importにアップロードする
+        Then: CSVと同じ結果になる
+        """
+        import openpyxl
+
+        order_number = order_with_shipment["order_number"]
+        shipment_id = order_with_shipment["shipment_id"]
+
+        # Create XLSX in memory
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["注文番号", "伝票番号", "運送会社名"])
+        ws.append([order_number, "XLSX-TRACK-001", "佐川急便"])
+
+        xlsx_buffer = io.BytesIO()
+        wb.save(xlsx_buffer)
+        xlsx_bytes = xlsx_buffer.getvalue()
+
+        response = await client.post(
+            "/api/v1/shipments/import",
+            headers=auth_headers,
+            files={
+                "file": (
+                    "tracking.xlsx",
+                    xlsx_bytes,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.text}"
+        )
+
+        data = response.json()
+        assert data["success_count"] == 1
+        assert data["error_count"] == 0
+
+        # Verify DB was updated
+        result = await db_session.execute(
+            text("SELECT tracking_number, carrier FROM shipments WHERE id = :id"),
+            {"id": shipment_id},
+        )
+        row = result.fetchone()
+        assert row is not None
+        assert row[0] == "XLSX-TRACK-001"
+        assert row[1] == "佐川急便"
+
+    # ===========================================
+    # AC-003: 複数行のCSVで一括更新ができる
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac003_multiple_rows_bulk_update(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        multiple_orders_with_shipments: list[dict],
+        db_session: AsyncSession,
+    ):
+        """AC-003: 3行のCSVで3件すべてのshipmentが更新される.
+
+        Given: 3件のshipmentが存在する
+        When: 3行のCSVをアップロードする
+        Then: 3件すべてのshipmentが更新され、success_count=3が返される
+        """
+        orders = multiple_orders_with_shipments
+
+        csv_rows = [["注文番号", "伝票番号", "運送会社名"]]
+        for i, order in enumerate(orders):
+            csv_rows.append([
+                order["order_number"],
+                f"TRACK-{i+1:04d}",
+                "ヤマト運輸",
+            ])
+
+        csv_bytes = create_csv_bytes(csv_rows)
+
+        response = await client.post(
+            "/api/v1/shipments/import",
+            headers=auth_headers,
+            files={"file": ("tracking.csv", csv_bytes, "text/csv")},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success_count"] == 3
+        assert data["error_count"] == 0
+        assert data["total_count"] == 3
+
+        # Verify all 3 shipments were updated
+        for i, order in enumerate(orders):
+            result = await db_session.execute(
+                text("SELECT tracking_number FROM shipments WHERE id = :id"),
+                {"id": order["shipment_id"]},
+            )
+            row = result.fetchone()
+            assert row is not None
+            assert row[0] == f"TRACK-{i+1:04d}", (
+                f"Expected TRACK-{i+1:04d} for shipment {order['shipment_id']}, got {row[0]}"
+            )
+
+    # ===========================================
+    # AC-004: 存在しない注文番号の行はエラー、他は正常処理
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac004_nonexistent_order_number_partial_success(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        order_with_shipment: dict,
+    ):
+        """AC-004: 存在しない注文番号の行はエラー、他の行は正常処理.
+
+        Given: "ORD-001"は存在するが"ORD-999"は存在しない
+        When: 2行のCSV（ORD-001とORD-999）をアップロードする
+        Then: success_count=1、error_count=1、errorsにORD-999のエラーが含まれる
+        """
+        order_number = order_with_shipment["order_number"]
+        nonexistent_order = "NONEXISTENT-ORD-999"
+
+        csv_bytes = create_csv_bytes([
+            ["注文番号", "伝票番号", "運送会社名"],
+            [order_number, "VALID-TRACK-001", "ヤマト運輸"],
+            [nonexistent_order, "INVALID-TRACK-001", "佐川急便"],
+        ])
+
+        response = await client.post(
+            "/api/v1/shipments/import",
+            headers=auth_headers,
+            files={"file": ("tracking.csv", csv_bytes, "text/csv")},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success_count"] == 1
+        assert data["error_count"] == 1
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["order_number"] == nonexistent_order
+
+    # ===========================================
+    # AC-005: shipmentが紐づいていない注文番号の行はエラー
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac005_order_without_shipment_is_error(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        order_without_shipment: dict,
+    ):
+        """AC-005: shipmentが紐づいていない注文番号はエラー.
+
+        Given: 注文は存在するがshipmentが紐づいていない
+        When: その注文番号を含むCSVをアップロードする
+        Then: error_count=1、errorsに「配送レコードが存在しません」エラーが含まれる
+        """
+        order_number = order_without_shipment["order_number"]
+
+        csv_bytes = create_csv_bytes([
+            ["注文番号", "伝票番号", "運送会社名"],
+            [order_number, "TRACK-NOSHIP", "ヤマト運輸"],
+        ])
+
+        response = await client.post(
+            "/api/v1/shipments/import",
+            headers=auth_headers,
+            files={"file": ("tracking.csv", csv_bytes, "text/csv")},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error_count"] == 1
+        assert len(data["errors"]) == 1
+        # Error message should mention missing shipment
+        error_msg = data["errors"][0]["message"]
+        assert "配送" in error_msg or "shipment" in error_msg.lower()
+
+
+class TestImportTemplateAPI:
+    """Integration tests for GET /api/v1/shipments/import-template."""
+
+    # ===========================================
+    # AC-012: テンプレートCSVがダウンロードできる
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac012_import_template_download(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """AC-012: GET /api/v1/shipments/import-templateでテンプレートCSVがダウンロードできる.
+
+        Given: 認証済み管理者
+        When: GET /api/v1/shipments/import-templateにリクエストする
+        Then: UTF-8 BOM付きCSVファイルが返され、正しいヘッダーとサンプルデータが含まれる
+        """
+        response = await client.get(
+            "/api/v1/shipments/import-template",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.text}"
+        )
+
+        # Verify content type is CSV
+        content_type = response.headers.get("content-type", "")
+        assert "csv" in content_type.lower() or "text" in content_type.lower(), (
+            f"Expected CSV content type, got: {content_type}"
+        )
+
+        # Verify Content-Disposition header
+        content_disposition = response.headers.get("content-disposition", "")
+        assert "attachment" in content_disposition.lower(), (
+            f"Expected attachment disposition, got: {content_disposition}"
+        )
+
+        # Verify UTF-8 BOM
+        content = response.content
+        assert content[:3] == b"\xef\xbb\xbf", "Expected UTF-8 BOM"
+
+        # Parse CSV content
+        csv_text = content.decode("utf-8-sig")
+        reader = csv.reader(io.StringIO(csv_text))
+        rows = list(reader)
+
+        # Verify header row
+        assert len(rows) >= 2, f"Expected header + sample row, got {len(rows)} rows"
+        assert rows[0] == ["注文番号", "伝票番号", "運送会社名"], (
+            f"Expected correct header, got: {rows[0]}"
+        )
+
+        # Verify sample data row exists with 3 columns
+        assert len(rows[1]) == 3, (
+            f"Expected 3 columns in sample row, got {len(rows[1])}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ac012_import_template_requires_auth(
+        self,
+        client: AsyncClient,
+    ):
+        """テンプレートダウンロードには認証が必要."""
+        response = await client.get("/api/v1/shipments/import-template")
+
+        assert response.status_code == 401 or response.status_code == 403, (
+            f"Expected 401/403 without auth, got {response.status_code}"
+        )

--- a/api/tests/unit/test_shipment_tracking_file_import.py
+++ b/api/tests/unit/test_shipment_tracking_file_import.py
@@ -1,0 +1,611 @@
+"""Unit tests for shipment tracking file import (CSV/XLSX).
+
+FEAT-0018: CSV/XLSXファイルによる伝票番号一括インポート機能
+
+Tests verify file parsing logic, validation, and edge cases for the
+import_tracking_from_file() method and generate_import_template() method
+on ShipmentService.
+
+AC-006: 必須列（注文番号、伝票番号）がないCSVはバリデーションエラー
+AC-007: 空行はスキップされる
+AC-008: 伝票番号が空の行はエラーとして報告される
+AC-009: 運送会社名列が省略されている場合、carrierはnullのまま
+AC-010: CSV/XLSX以外のファイルはバリデーションエラー
+AC-011: 10MBを超えるファイルはバリデーションエラー
+AC-013: Shift-JISエンコードのCSVも正しく解析できる
+AC-017: 同一注文番号が複数行に存在する場合、最後の行の値で上書きされる
+"""
+
+import csv
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.order import Order
+from app.models.shipment import Shipment, ShipmentItem, ShipmentStatus
+from app.services.shipment_service import ShipmentService
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture
+def mock_shipment_repo():
+    """Mock shipment repository."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_order_repo():
+    """Mock order repository."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_file_storage():
+    """Mock file storage."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_order_source_repo():
+    """Mock order source repository."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def shipment_service(
+    mock_shipment_repo, mock_order_repo, mock_file_storage, mock_order_source_repo
+):
+    """Create ShipmentService with mocked dependencies."""
+    return ShipmentService(
+        shipment_repo=mock_shipment_repo,
+        order_repo=mock_order_repo,
+        file_storage=mock_file_storage,
+        order_source_repo=mock_order_source_repo,
+    )
+
+
+# ---- Helpers ----
+
+
+def create_csv_bytes(
+    rows: list[list[str]],
+    encoding: str = "utf-8",
+    bom: bool = False,
+) -> bytes:
+    """Create CSV content as bytes.
+
+    Args:
+        rows: List of rows (first row is header).
+        encoding: Encoding to use (utf-8, shift_jis, etc.).
+        bom: Whether to add UTF-8 BOM.
+
+    Returns:
+        CSV content as bytes.
+    """
+    output = io.StringIO()
+    writer = csv.writer(output)
+    for row in rows:
+        writer.writerow(row)
+    csv_text = output.getvalue()
+
+    csv_bytes = csv_text.encode(encoding)
+    if bom:
+        csv_bytes = b"\xef\xbb\xbf" + csv_bytes
+    return csv_bytes
+
+
+def create_mock_upload_file(
+    content: bytes,
+    filename: str = "tracking.csv",
+    content_type: str = "text/csv",
+) -> MagicMock:
+    """Create a mock UploadFile for testing.
+
+    Args:
+        content: File content as bytes.
+        filename: Filename.
+        content_type: MIME content type.
+
+    Returns:
+        Mock UploadFile object.
+    """
+    mock_file = MagicMock()
+    mock_file.filename = filename
+    mock_file.content_type = content_type
+    mock_file.size = len(content)
+    mock_file.read = AsyncMock(return_value=content)
+    mock_file.seek = AsyncMock()
+    return mock_file
+
+
+def create_mock_order(
+    order_id: str = "order-001",
+    order_number: str = "ORD-001",
+) -> MagicMock:
+    """Create a mock Order."""
+    order = MagicMock(spec=Order)
+    order.id = order_id
+    order.order_number = order_number
+    return order
+
+
+def create_mock_shipment(
+    shipment_id: str = "shipment-001",
+    tracking_number: str | None = None,
+    carrier: str | None = None,
+) -> MagicMock:
+    """Create a mock Shipment."""
+    shipment = MagicMock(spec=Shipment)
+    shipment.id = shipment_id
+    shipment.status = ShipmentStatus.PENDING.value
+    shipment.tracking_number = tracking_number
+    shipment.carrier = carrier
+    shipment.items = []
+    shipment.first_order = None
+    return shipment
+
+
+# ---- Tests ----
+
+
+class TestImportTrackingFromFile:
+    """Test ShipmentService.import_tracking_from_file()."""
+
+    # ===========================================
+    # AC-006: 必須列（注文番号、伝票番号）がないCSVはバリデーションエラー
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac006_missing_tracking_number_column_raises_validation_error(
+        self, shipment_service
+    ):
+        """AC-006: 「伝票番号」列がないCSVはバリデーションエラーになる.
+
+        Given: ヘッダーが「注文番号」列のみのCSV
+        When: ファイルを解析する
+        Then: 「伝票番号」列が見つかりませんというバリデーションエラーが返される
+        """
+        csv_bytes = create_csv_bytes([
+            ["注文番号"],
+            ["ORD-001"],
+        ])
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        with pytest.raises(Exception) as exc_info:
+            await shipment_service.import_tracking_from_file(mock_file)
+
+        assert "伝票番号" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_ac006_missing_order_number_column_raises_validation_error(
+        self, shipment_service
+    ):
+        """AC-006: 「注文番号」列がないCSVはバリデーションエラーになる.
+
+        Given: ヘッダーが「伝票番号」列のみのCSV
+        When: ファイルを解析する
+        Then: 「注文番号」列が見つかりませんというバリデーションエラーが返される
+        """
+        csv_bytes = create_csv_bytes([
+            ["伝票番号"],
+            ["1234-5678-9012"],
+        ])
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        with pytest.raises(Exception) as exc_info:
+            await shipment_service.import_tracking_from_file(mock_file)
+
+        assert "注文番号" in str(exc_info.value)
+
+    # ===========================================
+    # AC-007: 空行はスキップされる
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac007_empty_rows_are_skipped(
+        self, shipment_service, mock_order_repo, mock_shipment_repo
+    ):
+        """AC-007: データ行の間に空行が含まれるCSVで空行は無視される.
+
+        Given: データ行の間に空行が含まれるCSV
+        When: ファイルを解析する
+        Then: 空行は無視され、有効な行のみが処理される
+        """
+        # CSV with blank lines interspersed
+        csv_text = "注文番号,伝票番号,運送会社名\nORD-001,1234-5678-9012,ヤマト運輸\n\n\nORD-002,2345-6789-0123,佐川急便\n"
+        csv_bytes = csv_text.encode("utf-8")
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        # Set up mocks for the two valid orders
+        order1 = create_mock_order("order-001", "ORD-001")
+        order2 = create_mock_order("order-002", "ORD-002")
+        mock_order_repo.find_by_order_number = AsyncMock(
+            side_effect=lambda n: order1 if n == "ORD-001" else order2
+        )
+
+        shipment1 = create_mock_shipment("shipment-001")
+        shipment2 = create_mock_shipment("shipment-002")
+        mock_shipment_repo.find_by_order_ids = AsyncMock(
+            return_value={"order-001": shipment1, "order-002": shipment2}
+        )
+        mock_shipment_repo.update = AsyncMock()
+
+        result = await shipment_service.import_tracking_from_file(mock_file)
+
+        # Only 2 valid rows should be processed (not 4 including blanks)
+        assert result.total_count == 2
+        assert result.success_count == 2
+        assert result.error_count == 0
+
+    # ===========================================
+    # AC-008: 伝票番号が空の行はエラーとして報告される
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac008_empty_tracking_number_is_error(
+        self, shipment_service, mock_order_repo, mock_shipment_repo
+    ):
+        """AC-008: 伝票番号が空の行はエラーとして報告される.
+
+        Given: 注文番号は入力されているが伝票番号が空の行
+        When: ファイルを解析する
+        Then: error_count=1、errorsに「伝票番号が空です」エラーが含まれる
+        """
+        csv_bytes = create_csv_bytes([
+            ["注文番号", "伝票番号", "運送会社名"],
+            ["ORD-001", "", "ヤマト運輸"],
+        ])
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        result = await shipment_service.import_tracking_from_file(mock_file)
+
+        assert result.error_count == 1
+        assert len(result.errors) == 1
+        assert "伝票番号" in result.errors[0].message
+        assert result.errors[0].order_number == "ORD-001"
+
+    # ===========================================
+    # AC-009: 運送会社名列が省略されている場合、carrierはnullのまま
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac009_missing_carrier_column_sets_carrier_null(
+        self, shipment_service, mock_order_repo, mock_shipment_repo
+    ):
+        """AC-009: ヘッダーが「注文番号,伝票番号」のみのCSVで正常処理される.
+
+        Given: ヘッダーが「注文番号,伝票番号」のみのCSV
+        When: ファイルを解析する
+        Then: 正常に処理され、carrierは更新されない（nullのまま）
+        """
+        csv_bytes = create_csv_bytes([
+            ["注文番号", "伝票番号"],
+            ["ORD-001", "1234-5678-9012"],
+        ])
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        order = create_mock_order("order-001", "ORD-001")
+        mock_order_repo.find_by_order_number = AsyncMock(return_value=order)
+
+        shipment = create_mock_shipment("shipment-001")
+        mock_shipment_repo.find_by_order_ids = AsyncMock(
+            return_value={"order-001": shipment}
+        )
+        mock_shipment_repo.update = AsyncMock()
+
+        result = await shipment_service.import_tracking_from_file(mock_file)
+
+        assert result.success_count == 1
+        assert result.error_count == 0
+        # Verify carrier was not set (no carrier column)
+        assert shipment.carrier is None
+
+    # ===========================================
+    # AC-010: CSV/XLSX以外のファイルはバリデーションエラー
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac010_unsupported_file_extension_raises_error(
+        self, shipment_service
+    ):
+        """AC-010: .txtファイルはバリデーションエラーになる.
+
+        Given: .txtファイル
+        When: POST /api/v1/shipments/importにアップロードする
+        Then: 422エラー「対応していないファイル形式です。CSVまたはXLSXファイルをアップロードしてください」が返される
+        """
+        mock_file = create_mock_upload_file(
+            b"some text data",
+            filename="tracking.txt",
+            content_type="text/plain",
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            await shipment_service.import_tracking_from_file(mock_file)
+
+        error_msg = str(exc_info.value)
+        assert "対応していないファイル形式" in error_msg or "CSV" in error_msg
+
+    @pytest.mark.asyncio
+    async def test_ac010_pdf_file_raises_error(
+        self, shipment_service
+    ):
+        """AC-010: .pdfファイルはバリデーションエラーになる."""
+        mock_file = create_mock_upload_file(
+            b"%PDF-1.4",
+            filename="tracking.pdf",
+            content_type="application/pdf",
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            await shipment_service.import_tracking_from_file(mock_file)
+
+        error_msg = str(exc_info.value)
+        assert "対応していないファイル形式" in error_msg or "CSV" in error_msg
+
+    # ===========================================
+    # AC-011: 10MBを超えるファイルはバリデーションエラー
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac011_file_over_10mb_raises_error(
+        self, shipment_service
+    ):
+        """AC-011: 11MBのCSVファイルはバリデーションエラーになる.
+
+        Given: 11MBのCSVファイル
+        When: POST /api/v1/shipments/importにアップロードする
+        Then: 422エラー「ファイルサイズが上限（10MB）を超えています」が返される
+        """
+        # Create a file that reports 11MB
+        large_content = b"x" * (11 * 1024 * 1024)
+        mock_file = create_mock_upload_file(
+            large_content,
+            filename="tracking.csv",
+            content_type="text/csv",
+        )
+        # Ensure mock reports the correct size
+        mock_file.size = len(large_content)
+
+        with pytest.raises(Exception) as exc_info:
+            await shipment_service.import_tracking_from_file(mock_file)
+
+        error_msg = str(exc_info.value)
+        assert "ファイルサイズ" in error_msg or "10MB" in error_msg
+
+    @pytest.mark.asyncio
+    async def test_ac011_file_exactly_10mb_is_accepted(
+        self, shipment_service, mock_order_repo, mock_shipment_repo
+    ):
+        """AC-011: 10MB以下のファイルはサイズバリデーションを通過する."""
+        csv_bytes = create_csv_bytes([
+            ["注文番号", "伝票番号"],
+            ["ORD-001", "1234-5678-9012"],
+        ])
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+        # Exactly 10MB
+        mock_file.size = 10 * 1024 * 1024
+
+        order = create_mock_order("order-001", "ORD-001")
+        mock_order_repo.find_by_order_number = AsyncMock(return_value=order)
+
+        shipment = create_mock_shipment("shipment-001")
+        mock_shipment_repo.find_by_order_ids = AsyncMock(
+            return_value={"order-001": shipment}
+        )
+        mock_shipment_repo.update = AsyncMock()
+
+        # Should succeed (not raise file size error)
+        result = await shipment_service.import_tracking_from_file(mock_file)
+
+        # The method should exist and return a result
+        assert result.success_count == 1
+
+    # ===========================================
+    # AC-013: Shift-JISエンコードのCSVも正しく解析できる
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac013_shift_jis_csv_is_parsed_correctly(
+        self, shipment_service, mock_order_repo, mock_shipment_repo
+    ):
+        """AC-013: Shift-JISでエンコードされたCSVが正しく解析される.
+
+        Given: Shift-JISでエンコードされたCSV
+        When: ファイルを解析する
+        Then: 日本語の注文番号・運送会社名が正しく読み取れる
+        """
+        csv_bytes = create_csv_bytes(
+            [
+                ["注文番号", "伝票番号", "運送会社名"],
+                ["ORD-001", "1234-5678-9012", "ヤマト運輸"],
+            ],
+            encoding="shift_jis",
+        )
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        order = create_mock_order("order-001", "ORD-001")
+        mock_order_repo.find_by_order_number = AsyncMock(return_value=order)
+
+        shipment = create_mock_shipment("shipment-001")
+        mock_shipment_repo.find_by_order_ids = AsyncMock(
+            return_value={"order-001": shipment}
+        )
+        mock_shipment_repo.update = AsyncMock()
+
+        result = await shipment_service.import_tracking_from_file(mock_file)
+
+        assert result.success_count == 1
+        assert result.error_count == 0
+        # Verify the tracking number was correctly parsed from Shift-JIS
+        assert shipment.tracking_number == "1234-5678-9012"
+        assert shipment.carrier == "ヤマト運輸"
+
+    @pytest.mark.asyncio
+    async def test_ac013_utf8_bom_csv_is_parsed_correctly(
+        self, shipment_service, mock_order_repo, mock_shipment_repo
+    ):
+        """AC-013: UTF-8 BOM付きCSVが正しく解析される."""
+        csv_bytes = create_csv_bytes(
+            [
+                ["注文番号", "伝票番号", "運送会社名"],
+                ["ORD-001", "1234-5678-9012", "佐川急便"],
+            ],
+            encoding="utf-8",
+            bom=True,
+        )
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        order = create_mock_order("order-001", "ORD-001")
+        mock_order_repo.find_by_order_number = AsyncMock(return_value=order)
+
+        shipment = create_mock_shipment("shipment-001")
+        mock_shipment_repo.find_by_order_ids = AsyncMock(
+            return_value={"order-001": shipment}
+        )
+        mock_shipment_repo.update = AsyncMock()
+
+        result = await shipment_service.import_tracking_from_file(mock_file)
+
+        assert result.success_count == 1
+        assert shipment.tracking_number == "1234-5678-9012"
+        assert shipment.carrier == "佐川急便"
+
+    # ===========================================
+    # AC-017: 同一注文番号が複数行に存在する場合、最後の行の値で上書きされる
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_ac017_duplicate_order_number_last_write_wins(
+        self, shipment_service, mock_order_repo, mock_shipment_repo
+    ):
+        """AC-017: 同じ注文番号が2行あると最後の行の伝票番号で更新される.
+
+        Given: 同じ注文番号"ORD-001"が2行存在し、伝票番号がそれぞれ異なる
+        When: ファイルを解析・処理する
+        Then: 最後の行の伝票番号で更新される（警告なし）
+        """
+        csv_bytes = create_csv_bytes([
+            ["注文番号", "伝票番号", "運送会社名"],
+            ["ORD-001", "FIRST-TRACKING", "ヤマト運輸"],
+            ["ORD-001", "LAST-TRACKING", "佐川急便"],
+        ])
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        order = create_mock_order("order-001", "ORD-001")
+        mock_order_repo.find_by_order_number = AsyncMock(return_value=order)
+
+        shipment = create_mock_shipment("shipment-001")
+        mock_shipment_repo.find_by_order_ids = AsyncMock(
+            return_value={"order-001": shipment}
+        )
+        mock_shipment_repo.update = AsyncMock()
+
+        result = await shipment_service.import_tracking_from_file(mock_file)
+
+        # Both rows count as processed for the same order
+        assert result.total_count == 2
+        # The shipment should have the LAST tracking number
+        assert shipment.tracking_number == "LAST-TRACKING"
+        assert shipment.carrier == "佐川急便"
+
+    # ===========================================
+    # Additional: 「運送会社」ヘッダー名のバリエーション
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_carrier_column_alternative_name_accepted(
+        self, shipment_service, mock_order_repo, mock_shipment_repo
+    ):
+        """運送会社名列のヘッダーが「運送会社」でも許容される.
+
+        Spec assumption: 運送会社名の列ヘッダーは「運送会社名」「運送会社」のいずれも許容する
+        """
+        csv_bytes = create_csv_bytes([
+            ["注文番号", "伝票番号", "運送会社"],
+            ["ORD-001", "1234-5678-9012", "日本郵便"],
+        ])
+        mock_file = create_mock_upload_file(csv_bytes, filename="tracking.csv")
+
+        order = create_mock_order("order-001", "ORD-001")
+        mock_order_repo.find_by_order_number = AsyncMock(return_value=order)
+
+        shipment = create_mock_shipment("shipment-001")
+        mock_shipment_repo.find_by_order_ids = AsyncMock(
+            return_value={"order-001": shipment}
+        )
+        mock_shipment_repo.update = AsyncMock()
+
+        result = await shipment_service.import_tracking_from_file(mock_file)
+
+        assert result.success_count == 1
+        assert shipment.carrier == "日本郵便"
+
+
+class TestGenerateImportTemplate:
+    """Test ShipmentService.generate_import_template()."""
+
+    # ===========================================
+    # AC-012 (partial): テンプレートCSV生成
+    # ===========================================
+
+    @pytest.mark.asyncio
+    async def test_template_has_correct_headers(self, shipment_service):
+        """テンプレートCSVのヘッダー行が正しい.
+
+        Given: ShipmentService.generate_import_template() が呼び出される
+        When: テンプレートCSVを生成する
+        Then: ヘッダー行「注文番号,伝票番号,運送会社名」が含まれる
+        """
+        csv_bytes, filename = await shipment_service.generate_import_template()
+
+        # Parse the CSV
+        csv_text = csv_bytes.decode("utf-8-sig")
+        reader = csv.reader(io.StringIO(csv_text))
+        rows = list(reader)
+
+        # Verify header
+        assert len(rows) >= 1
+        assert rows[0] == ["注文番号", "伝票番号", "運送会社名"]
+
+    @pytest.mark.asyncio
+    async def test_template_has_sample_data_row(self, shipment_service):
+        """テンプレートCSVにサンプルデータ行が含まれる.
+
+        Given: ShipmentService.generate_import_template() が呼び出される
+        When: テンプレートCSVを生成する
+        Then: ヘッダー行に加えてサンプルデータ行が1行含まれる
+        """
+        csv_bytes, filename = await shipment_service.generate_import_template()
+
+        csv_text = csv_bytes.decode("utf-8-sig")
+        reader = csv.reader(io.StringIO(csv_text))
+        rows = list(reader)
+
+        # Header + at least 1 sample data row
+        assert len(rows) >= 2, f"Expected at least 2 rows (header + sample), got {len(rows)}"
+        # Sample row should have 3 columns
+        assert len(rows[1]) == 3, f"Expected 3 columns in sample row, got {len(rows[1])}"
+
+    @pytest.mark.asyncio
+    async def test_template_is_utf8_bom(self, shipment_service):
+        """テンプレートCSVがUTF-8 BOM付きである.
+
+        Given: ShipmentService.generate_import_template() が呼び出される
+        When: テンプレートCSVを生成する
+        Then: UTF-8 BOM付きCSVファイルが返される
+        """
+        csv_bytes, filename = await shipment_service.generate_import_template()
+
+        # Check for UTF-8 BOM
+        assert csv_bytes[:3] == b"\xef\xbb\xbf", "Expected UTF-8 BOM at start of file"
+
+    @pytest.mark.asyncio
+    async def test_template_filename_is_csv(self, shipment_service):
+        """テンプレートのファイル名が.csv拡張子である."""
+        csv_bytes, filename = await shipment_service.generate_import_template()
+
+        assert filename.endswith(".csv"), f"Expected .csv extension, got '{filename}'"

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -237,6 +237,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "6.0.0.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/42/fb9436c103a881a377e34b9f58d77b5f503461c702ff654ebe86151bcfe9/chardet-6.0.0.post1.tar.gz", hash = "sha256:6b78048c3c97c7b2ed1fbad7a18f76f5a6547f7d34dbab536cc13887c9a92fa4", size = 12521798, upload-time = "2026-02-22T15:09:17.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/42/5de54f632c2de53cd3415b3703383d5fff43a94cbc0567ef362515261a21/chardet-6.0.0.post1-py3-none-any.whl", hash = "sha256:c894a36800549adf7bb5f2af47033281b75fdfcd2aa0f0243be0ad22a52e2dcb", size = 627245, upload-time = "2026-02-22T15:09:15.876Z" },
 ]
 
 [[package]]
@@ -944,6 +953,7 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "bcrypt" },
+    { name = "chardet" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -986,6 +996,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "bcrypt", specifier = ">=4.0.1,<4.1.0" },
+    { name = "chardet", specifier = ">=5.0.0" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },

--- a/web/src/features/shipments/components/tracking-import.tsx
+++ b/web/src/features/shipments/components/tracking-import.tsx
@@ -1,74 +1,57 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { FileUp, Package } from "lucide-react";
+import { Package, Upload } from "lucide-react";
 import { apiClient } from "@/lib/api/client";
+import type { TrackingFileImportResult } from "@/types/api";
 
 interface TrackingImportProps {
   onImportComplete?: () => void;
 }
 
-const carriers = [
-  { value: "yamato", label: "ヤマト運輸" },
-  { value: "sagawa", label: "佐川急便" },
-  { value: "japan_post", label: "日本郵便" },
-  { value: "other", label: "その他" },
-];
-
 export function TrackingImport({ onImportComplete }: TrackingImportProps) {
-  const [csvData, setCsvData] = useState("");
-  const [carrier, setCarrier] = useState("yamato");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isImporting, setIsImporting] = useState(false);
+  const [result, setResult] = useState<TrackingFileImportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<{ success: number; failed: number } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    setSelectedFile(file);
+    setResult(null);
+    setError(null);
+  };
 
   const handleImport = async () => {
-    if (!csvData.trim()) {
-      setError("CSVデータを入力してください");
+    if (!selectedFile) {
+      setError("ファイルを選択してください");
       return;
     }
 
     setIsImporting(true);
-    setError(null);
     setResult(null);
+    setError(null);
 
     try {
-      // Parse CSV: expected format is "shipment_id,tracking_number" per line
-      const lines = csvData.trim().split("\n");
-      const trackingData = lines
-        .filter((line) => line.trim())
-        .map((line) => {
-          const [shipment_id, tracking_number] = line.split(",").map((s) => s.trim());
-          return { shipment_id, tracking_number, carrier };
-        })
-        .filter((item) => item.shipment_id && item.tracking_number);
+      const formData = new FormData();
+      formData.append("file", selectedFile);
 
-      if (trackingData.length === 0) {
-        setError("有効なデータがありません。形式: 配送ID,伝票番号");
-        return;
+      const response = await apiClient<TrackingFileImportResult>(
+        "/shipments/import",
+        {
+          method: "POST",
+          body: formData,
+        }
+      );
+
+      setResult(response);
+
+      if (response.success_count > 0) {
+        onImportComplete?.();
       }
-
-      const response = await apiClient<unknown[]>("/shipments/import-tracking", {
-        method: "POST",
-        body: { items: trackingData },
-      });
-
-      setResult({
-        success: response.length,
-        failed: trackingData.length - response.length,
-      });
-      setCsvData("");
-      onImportComplete?.();
     } catch (err) {
       console.error("Import failed:", err);
       setError("インポートに失敗しました");
@@ -77,61 +60,81 @@ export function TrackingImport({ onImportComplete }: TrackingImportProps) {
     }
   };
 
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
+
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Package className="h-5 w-5" />
-          伝票番号インポート
+          伝票番号ファイルインポート
         </CardTitle>
         <CardDescription>
-          CSVデータを貼り付けて、複数の配送に伝票番号を一括登録します。
-          形式: 配送ID,伝票番号（1行1件）
+          CSV/XLSXファイルをアップロードして、伝票番号を一括登録します。
+          ファイルには「注文番号」「伝票番号」列が必要です。「運送会社名」列はオプションです。
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        {/* テンプレートダウンロード */}
+        <div>
+          <a
+            href={`${apiBaseUrl}/shipments/import-template`}
+            className="text-sm text-blue-600 hover:underline"
+          >
+            サンプルテンプレートをダウンロード
+          </a>
+        </div>
+
+        {/* ファイル選択 */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium">ファイル選択</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="file"
+              ref={fileInputRef}
+              accept=".csv,.xlsx"
+              onChange={handleFileChange}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+            />
+          </div>
+          {selectedFile && (
+            <p className="text-sm text-gray-600">
+              選択中: {selectedFile.name}
+            </p>
+          )}
+        </div>
+
+        {/* エラー表示 */}
         {error && (
           <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md">
             {error}
           </div>
         )}
 
+        {/* インポート結果表示 */}
         {result && (
-          <div className="p-3 text-sm text-green-600 bg-green-50 border border-green-200 rounded-md">
-            インポート完了: {result.success}件成功
-            {result.failed > 0 && `、${result.failed}件失敗`}
+          <div className="space-y-2">
+            <div className={`p-3 text-sm rounded-md border ${result.error_count > 0 ? "bg-yellow-50 border-yellow-200 text-yellow-800" : "bg-green-50 border-green-200 text-green-600"}`}>
+              インポート完了: {result.success_count}件成功
+              {result.error_count > 0 && `、${result.error_count}件失敗`}
+            </div>
+
+            {result.errors.length > 0 && (
+              <div className="p-3 text-sm bg-red-50 border border-red-200 rounded-md space-y-1">
+                <p className="font-medium text-red-700">エラー詳細:</p>
+                {result.errors.map((error, index) => (
+                  <div key={index} className="text-red-600">
+                    行{error.row}: {error.order_number && <span>{error.order_number} - </span>}{error.message}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
 
-        <div className="space-y-2">
-          <label className="text-sm font-medium">運送会社</label>
-          <Select value={carrier} onValueChange={setCarrier}>
-            <SelectTrigger>
-              <SelectValue placeholder="運送会社を選択" />
-            </SelectTrigger>
-            <SelectContent>
-              {carriers.map((c) => (
-                <SelectItem key={c.value} value={c.value}>
-                  {c.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="space-y-2">
-          <label className="text-sm font-medium">CSVデータ</label>
-          <Textarea
-            placeholder="例:&#10;abc12345,1234-5678-9012&#10;def67890,2345-6789-0123"
-            value={csvData}
-            onChange={(e) => setCsvData(e.target.value)}
-            rows={6}
-            className="font-mono text-sm"
-          />
-        </div>
-
-        <Button onClick={handleImport} disabled={isImporting} className="w-full">
-          <FileUp className="h-4 w-4 mr-2" />
+        {/* インポートボタン */}
+        <Button onClick={handleImport} disabled={isImporting || !selectedFile} className="w-full">
+          <Upload className="h-4 w-4 mr-2" />
           {isImporting ? "インポート中..." : "インポート"}
         </Button>
       </CardContent>

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -163,6 +163,20 @@ export interface ShipmentListResponse {
   limit: number;
 }
 
+export interface TrackingFileImportError {
+  row: number;
+  order_number: string | null;
+  message: string;
+}
+
+export interface TrackingFileImportResult {
+  total_count: number;
+  success_count: number;
+  error_count: number;
+  errors: TrackingFileImportError[];
+  updated_shipments: Shipment[];
+}
+
 // Manufacturer types
 export interface Manufacturer {
   id: string;

--- a/web/tests/unit/feat-0018-tracking-file-import.test.tsx
+++ b/web/tests/unit/feat-0018-tracking-file-import.test.tsx
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for FEAT-0018: CSV/XLSXファイルによる伝票番号一括インポート
+ *
+ * Covers:
+ * - AC-014: ファイル選択してインポート実行 -> API呼び出し -> 結果表示
+ * - AC-015: インポート成功後に配送一覧が自動リフレッシュされる
+ * - AC-016: サンプルテンプレートダウンロードリンクが表示される
+ *
+ * NOTE: TDD Red phase - tests will fail until implementation is completed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock API client
+const mockApiClient = vi.fn()
+vi.mock('@/lib/api/client', () => ({
+  apiClient: (...args: unknown[]) => mockApiClient(...args),
+  downloadFile: vi.fn(),
+}))
+
+// Mock sonner
+const mockToast = {
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+}
+vi.mock('sonner', () => ({
+  toast: mockToast,
+}))
+
+// Import the component AFTER mocks are set up
+// The component will be renamed from TrackingImport to a file-upload-based dialog
+import { TrackingImport } from '@/features/shipments/components/tracking-import'
+import type { TrackingFileImportResult } from '@/types/api'
+
+// ======================================
+// Helper: Create a mock File
+// ======================================
+
+function createMockFile(
+  name: string,
+  content: string = 'test',
+  type: string = 'text/csv'
+): File {
+  return new File([content], name, { type })
+}
+
+function createMockCSVFile(
+  rows: string[][] = [
+    ['注文番号', '伝票番号', '運送会社名'],
+    ['ORD-001', '1234-5678-9012', 'ヤマト運輸'],
+  ]
+): File {
+  const csvContent = rows.map((row) => row.join(',')).join('\n')
+  return new File([csvContent], 'tracking.csv', { type: 'text/csv' })
+}
+
+// ======================================
+// Helper: Mock successful import response
+// ======================================
+
+function createMockImportResult(
+  overrides: Partial<TrackingFileImportResult> = {}
+): TrackingFileImportResult {
+  return {
+    total_count: 1,
+    success_count: 1,
+    error_count: 0,
+    errors: [],
+    updated_shipments: [],
+    ...overrides,
+  }
+}
+
+// ======================================
+// AC-014: ファイル選択してインポート実行 -> API呼び出し -> 結果表示
+// ======================================
+
+describe('AC-014: File upload import dialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the file upload area', () => {
+    render(<TrackingImport />)
+
+    // ファイルアップロード UI が存在すること
+    // ファイル選択用のinput[type="file"]またはドロップゾーンが存在
+    const fileInput = document.querySelector('input[type="file"]')
+    expect(fileInput).toBeInTheDocument()
+  })
+
+  it('renders the import button', () => {
+    render(<TrackingImport />)
+
+    // インポートボタンが存在すること
+    const importButton = screen.getByRole('button', { name: /インポート/ })
+    expect(importButton).toBeInTheDocument()
+  })
+
+  it('accepts CSV files', () => {
+    render(<TrackingImport />)
+
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    expect(fileInput).toBeInTheDocument()
+
+    // accept属性でCSV/XLSXが許可されていること
+    const accept = fileInput?.getAttribute('accept') ?? ''
+    expect(accept).toContain('.csv')
+  })
+
+  it('accepts XLSX files', () => {
+    render(<TrackingImport />)
+
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    expect(fileInput).toBeInTheDocument()
+
+    const accept = fileInput?.getAttribute('accept') ?? ''
+    expect(accept).toContain('.xlsx')
+  })
+
+  it('calls API with FormData when file is selected and import is clicked', async () => {
+    const user = userEvent.setup()
+    mockApiClient.mockResolvedValueOnce(createMockImportResult())
+
+    render(<TrackingImport />)
+
+    // ファイルを選択
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const csvFile = createMockCSVFile()
+    await user.upload(fileInput, csvFile)
+
+    // インポートボタンをクリック
+    const importButton = screen.getByRole('button', { name: /インポート/ })
+    await user.click(importButton)
+
+    // API が呼ばれたことを確認
+    await waitFor(() => {
+      expect(mockApiClient).toHaveBeenCalledWith(
+        '/shipments/import',
+        expect.objectContaining({
+          method: 'POST',
+        })
+      )
+    })
+  })
+
+  it('displays success count after successful import', async () => {
+    const user = userEvent.setup()
+    mockApiClient.mockResolvedValueOnce(
+      createMockImportResult({
+        total_count: 3,
+        success_count: 3,
+        error_count: 0,
+      })
+    )
+
+    render(<TrackingImport />)
+
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const csvFile = createMockCSVFile()
+    await user.upload(fileInput, csvFile)
+
+    const importButton = screen.getByRole('button', { name: /インポート/ })
+    await user.click(importButton)
+
+    // 成功件数が表示されること
+    await waitFor(() => {
+      expect(screen.getByText(/3件/)).toBeInTheDocument()
+    })
+  })
+
+  it('displays error details when some rows fail', async () => {
+    const user = userEvent.setup()
+    mockApiClient.mockResolvedValueOnce(
+      createMockImportResult({
+        total_count: 2,
+        success_count: 1,
+        error_count: 1,
+        errors: [
+          {
+            row: 2,
+            order_number: 'ORD-999',
+            message: '注文番号が見つかりません',
+          },
+        ],
+      })
+    )
+
+    render(<TrackingImport />)
+
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const csvFile = createMockCSVFile()
+    await user.upload(fileInput, csvFile)
+
+    const importButton = screen.getByRole('button', { name: /インポート/ })
+    await user.click(importButton)
+
+    // エラー詳細が表示されること
+    await waitFor(() => {
+      expect(screen.getByText(/ORD-999/)).toBeInTheDocument()
+      expect(screen.getByText(/注文番号が見つかりません/)).toBeInTheDocument()
+    })
+  })
+
+  it('displays error count in the result', async () => {
+    const user = userEvent.setup()
+    mockApiClient.mockResolvedValueOnce(
+      createMockImportResult({
+        total_count: 2,
+        success_count: 1,
+        error_count: 1,
+        errors: [
+          {
+            row: 2,
+            order_number: 'ORD-999',
+            message: '注文番号が見つかりません',
+          },
+        ],
+      })
+    )
+
+    render(<TrackingImport />)
+
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const csvFile = createMockCSVFile()
+    await user.upload(fileInput, csvFile)
+
+    const importButton = screen.getByRole('button', { name: /インポート/ })
+    await user.click(importButton)
+
+    // 失敗件数が表示されること
+    await waitFor(() => {
+      expect(screen.getByText(/1件.*失敗|失敗.*1/)).toBeInTheDocument()
+    })
+  })
+})
+
+// ======================================
+// AC-015: インポート成功後に配送一覧が自動リフレッシュされる
+// ======================================
+
+describe('AC-015: Auto-refresh shipment list after successful import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls onImportComplete callback after successful import', async () => {
+    const user = userEvent.setup()
+    const onImportComplete = vi.fn()
+    mockApiClient.mockResolvedValueOnce(createMockImportResult())
+
+    render(<TrackingImport onImportComplete={onImportComplete} />)
+
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const csvFile = createMockCSVFile()
+    await user.upload(fileInput, csvFile)
+
+    const importButton = screen.getByRole('button', { name: /インポート/ })
+    await user.click(importButton)
+
+    // onImportComplete が呼ばれたことを確認（リフレッシュのトリガー）
+    await waitFor(() => {
+      expect(onImportComplete).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not call onImportComplete when import fails completely', async () => {
+    const user = userEvent.setup()
+    const onImportComplete = vi.fn()
+    mockApiClient.mockRejectedValueOnce(new Error('API Error'))
+
+    render(<TrackingImport onImportComplete={onImportComplete} />)
+
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const csvFile = createMockCSVFile()
+    await user.upload(fileInput, csvFile)
+
+    const importButton = screen.getByRole('button', { name: /インポート/ })
+    await user.click(importButton)
+
+    // API エラー時は onImportComplete が呼ばれないこと
+    await waitFor(() => {
+      expect(onImportComplete).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ======================================
+// AC-016: サンプルテンプレートダウンロードリンクが表示される
+// ======================================
+
+describe('AC-016: Sample template download link is displayed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a template download link', () => {
+    render(<TrackingImport />)
+
+    // テンプレートダウンロードリンクが存在すること
+    const downloadLink = screen.getByText(/テンプレート/)
+    expect(downloadLink).toBeInTheDocument()
+  })
+
+  it('template download link points to the import-template endpoint', () => {
+    render(<TrackingImport />)
+
+    // テンプレートダウンロードリンクがimport-templateエンドポイントを参照していること
+    const downloadLink = screen.getByText(/テンプレート/)
+    // リンクまたはボタンとして存在
+    expect(downloadLink).toBeInTheDocument()
+
+    // href属性またはonClickでimport-templateを参照
+    const linkElement = downloadLink.closest('a')
+    if (linkElement) {
+      expect(linkElement.getAttribute('href')).toContain('import-template')
+    }
+    // If it's a button, it should trigger a download via API
+  })
+})


### PR DESCRIPTION
## 概要

**Intent Spec:** `.claude/specs/FEAT-0018-shipment-tracking-import.yaml`

### なぜこの変更が必要か

現在の伝票番号登録はテキストエリアに「配送ID,伝票番号」形式で手入力する方式であり、配送業者から受け取ったCSV/XLSXファイルを直接インポートできない。注文番号ベースでファイルアップロードによる一括登録を実現し、運用効率を大幅に改善する。

**主な変更:**
- `POST /api/v1/shipments/import` — CSV/XLSXファイルアップロードで伝票番号・運送会社を一括更新
- `GET /api/v1/shipments/import-template` — サンプルCSVテンプレートダウンロード
- フロントエンドのインポートUIをファイルアップロード方式に刷新
- Shift-JIS/UTF-8 BOM対応、部分成功方式、10MBサイズ上限

Closes #30

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | TypeScript/Pythonエラーなし |
| リンター | ✅ | FEAT-0018に重大エラーなし（軽微な警告のみ） |
| ユニットテスト | ✅ | BE: 207 passed, FE: 170 passed |
| 統合テスト | ✅ | 89 passed（FEAT-0018: 7テスト） |
| Playwright E2E | ⏭️ | ポリシーによりスキップ |
| 仕様適合 | ✅ | AC: 17/17 カバー |
| AI意味レビュー | ✅ | 軽微指摘のみ（ブロッキングなし） |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| AC-001: CSV UTF-8でtracking/carrier更新 | `tests/integration/test_shipment_tracking_file_import.py` | ✅ |
| AC-002: XLSXでも同様に更新 | `tests/integration/test_shipment_tracking_file_import.py` | ✅ |
| AC-003: 複数行一括更新 | `tests/integration/test_shipment_tracking_file_import.py` | ✅ |
| AC-004: 存在しない注文番号→エラー+部分成功 | `tests/integration/test_shipment_tracking_file_import.py` | ✅ |
| AC-005: shipment未紐づけ→エラー | `tests/integration/test_shipment_tracking_file_import.py` | ✅ |
| AC-006: 必須列不足→バリデーションエラー | `tests/unit/test_shipment_tracking_file_import.py` | ✅ |
| AC-007: 空行スキップ | `tests/unit/test_shipment_tracking_file_import.py` | ✅ |
| AC-008: 伝票番号空→エラー | `tests/unit/test_shipment_tracking_file_import.py` | ✅ |
| AC-009: 運送会社名列省略→carrier=null | `tests/unit/test_shipment_tracking_file_import.py` | ✅ |
| AC-010: 非対応ファイル形式→エラー | `tests/unit/test_shipment_tracking_file_import.py` | ✅ |
| AC-011: 10MB超→エラー | `tests/unit/test_shipment_tracking_file_import.py` | ✅ |
| AC-012: テンプレートCSVダウンロード | `tests/integration/test_shipment_tracking_file_import.py` | ✅ |
| AC-013: Shift-JIS/UTF-8 BOM対応 | `tests/unit/test_shipment_tracking_file_import.py` | ✅ |
| AC-014: フロントエンドインポートUI | `web/tests/unit/feat-0018-tracking-file-import.test.tsx` | ✅ |
| AC-015: インポート成功後の自動リフレッシュ | `web/tests/unit/feat-0018-tracking-file-import.test.tsx` | ✅ |
| AC-016: テンプレートダウンロードリンク | `web/tests/unit/feat-0018-tracking-file-import.test.tsx` | ✅ |
| AC-017: 同一注文番号last-write-wins | `tests/unit/test_shipment_tracking_file_import.py` | ✅ |

## レビューのポイント

- **部分成功方式**: エラー行はスキップし、他の行は正常に処理する（all-or-nothingではない）。既存の`bulk_update_status()`と同じパターン
- **エンコーディング対応**: UTF-8→UTF-8 BOM→chardetフォールバックの段階的検出。日本語CSV（Shift-JIS）に対応
- **ルート定義順序**: `POST /import`と`GET /import-template`は`/{shipment_id}`の前に定義し、パス衝突を回避
- **既存エンドポイント保持**: `POST /shipments/import-tracking`（JSON形式）は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)