### PR TITLE
feat: 受注一覧から商品イメージ画像をZIPダウンロードする機能を追加 (FEAT-0018)

### DIFF
--- a/.claude/specs/FEAT-0018-order-image-zip-download.yaml
+++ b/.claude/specs/FEAT-0018-order-image-zip-download.yaml
@@ -1,0 +1,147 @@
+id: FEAT-0018
+summary: 管理者が受注一覧で選択した受注に紐づく商品イメージ画像をZIPファイルとしてまとめてダウンロードできる
+
+background:
+  why: |
+    受注処理において、各受注に紐づく商品のデザイン画像（design_image_url）を個別にダウンロードするのは
+    非効率であり、一括でまとめてダウンロードしたいという運用上のニーズがある。
+    ZIPファイルとして一括ダウンロードすることで、製造データの準備や確認作業を効率化する。
+  who: 管理者（admin/staff）
+  when: |
+    - 受注一覧画面で対象の受注を選択し、まとめてイメージ画像をダウンロードしたいとき
+    - 製造用のデザインデータを一括取得したいとき
+
+scope:
+  includes:
+    - 受注一覧画面（/orders）に「イメージ画像ダウンロード」ボタンを追加
+    - 選択された受注IDリストを受け取り、紐づくOrderItemのdesign_image_urlを収集してZIP化するAPIエンドポイントを実装
+    - 画像URLから画像を非同期で取得（httpx等）し、ZIPに格納
+    - 画像が存在しない（URLがnull、または取得失敗）場合はスキップしてログに記録
+    - ZIPファイルのダウンロードレスポンス（StreamingResponse）
+  excludes:
+    - thumbnail_image_urlのダウンロード（design_image_urlのみ対象）
+    - 画像のリサイズ・変換処理（元画像をそのままZIPに格納）
+    - 受注詳細画面からの個別ダウンロード機能（対象外、将来拡張として検討）
+    - CSVインポート画面からのダウンロード機能（受注一覧画面のみ対象）
+  prerequisites:
+    - OrderItemモデルにdesign_image_urlフィールドが存在すること
+    - 受注一覧画面にチェックボックスによる複数選択機能が存在すること
+    - ZipBuilderユーティリティ（api/app/utils/zip_builder.py）が存在すること
+
+input_output:
+  inputs:
+    - name: order_ids
+      type: list[string]
+      required: true
+      validation: 1件以上のUUID文字列リスト
+  outputs:
+    - name: ZIPファイル
+      type: application/zip
+      description: |
+        選択された受注のOrderItemに紐づくdesign_image_urlから取得した画像ファイルを格納したZIPファイル。
+        ファイル名は「受注画像_{YYYYMMDD_HHMMSS}.zip」形式。
+        ZIP内のファイル構成: {注文番号}/{商品名}_{連番}.{拡張子}
+  state_changes:
+    - なし（読み取り専用の操作）
+
+acceptance_criteria:
+  - id: AC-001
+    description: 受注を1件以上選択した状態で「イメージ画像ダウンロード」ボタンが表示される
+    test_type: unit
+    given: 受注一覧画面を開いている
+    when: 1件以上の受注にチェックを入れる
+    then: 「イメージ画像ダウンロード」ボタンが表示される
+
+  - id: AC-002
+    description: 受注が未選択の場合は「イメージ画像ダウンロード」ボタンが表示されない
+    test_type: unit
+    given: 受注一覧画面を開いている
+    when: 受注を1件も選択していない
+    then: 「イメージ画像ダウンロード」ボタンは表示されない
+
+  - id: AC-003
+    description: APIエンドポイントが選択された受注IDに紐づくdesign_image_urlを収集してZIPを返す
+    test_type: integration
+    given: design_image_urlを持つOrderItemが紐づく受注が存在する
+    when: POST /api/v1/orders/download-images に対象のorder_idsを送信する
+    then: 対象画像を含むZIPファイルがレスポンスとして返される
+
+  - id: AC-004
+    description: design_image_urlがnullのOrderItemはスキップされる
+    test_type: unit
+    given: design_image_urlがnullのOrderItemが含まれる受注を選択する
+    when: 画像ZIPダウンロードAPIを呼び出す
+    then: nullのアイテムはスキップされ、画像を持つアイテムのみがZIPに含まれる
+
+  - id: AC-005
+    description: 画像URLからの取得に失敗した場合はスキップしてログに記録する
+    test_type: unit
+    given: 無効な画像URL（404やタイムアウト）を持つOrderItemが含まれる受注を選択する
+    when: 画像ZIPダウンロードAPIを呼び出す
+    then: 取得失敗した画像はスキップされ、ログに警告が記録され、取得できた画像のみがZIPに含まれる
+
+  - id: AC-006
+    description: 全ての画像取得に失敗した場合、またはdesign_image_urlを持つアイテムが0件の場合はエラーを返す
+    test_type: unit
+    given: 選択された受注のOrderItemに有効なdesign_image_urlが存在しない
+    when: 画像ZIPダウンロードAPIを呼び出す
+    then: 404エラー（ダウンロード可能な画像がありません）が返される
+
+  - id: AC-007
+    description: 存在しない受注IDが含まれている場合、存在する受注のみ処理される
+    test_type: unit
+    given: 存在しない受注IDが1件含まれるorder_idsリストを送信する
+    when: 画像ZIPダウンロードAPIを呼び出す
+    then: 存在する受注に紐づく画像のみがZIPに含まれ、存在しない受注はスキップされる
+
+  - id: AC-008
+    description: ZIPファイル内のファイル名が注文番号と商品名で構成される
+    test_type: unit
+    given: 注文番号「ORD-001」、商品名「Tシャツ Mサイズ 白」のOrderItemがある受注を選択する
+    when: 画像ZIPダウンロードAPIを呼び出す
+    then: ZIP内のファイルパスが「ORD-001/Tシャツ Mサイズ 白_1.png」のような形式になっている
+
+  - id: AC-009
+    description: order_idsが空の場合は422エラーを返す
+    test_type: unit
+    given: 空のorder_idsリストを送信する
+    when: POST /api/v1/orders/download-images を呼び出す
+    then: 422バリデーションエラーが返される
+
+  - id: AC-010
+    description: 管理者認証が必要
+    test_type: integration
+    given: 認証されていないユーザー
+    when: POST /api/v1/orders/download-images を呼び出す
+    then: 401 Unauthorizedエラーが返される
+
+  - id: AC-011
+    description: ボタンクリック時にダウンロードが開始される
+    test_type: unit
+    given: 受注一覧画面で1件以上の受注を選択している
+    when: 「イメージ画像ダウンロード」ボタンをクリックする
+    then: ZIPファイルのダウンロードが開始される（ブラウザのダウンロードダイアログまたは自動保存）
+
+constraints:
+  performance:
+    - 画像取得は並列で行い、1画像あたりのタイムアウトは10秒
+    - 全体のリクエストタイムアウトは120秒（大量画像対応）
+    - 同時取得数は最大10並列（外部サーバー負荷軽減のため）
+  security:
+    - 管理者（admin/staff）のみアクセス可能（get_current_admin依存関係使用）
+    - 画像URLはOrderItemのdesign_image_urlフィールドに保存されたもののみ取得（任意URLの指定不可）
+  compatibility:
+    - 既存の受注一覧画面のUI・機能を壊さない
+    - 既存の一括ステータス更新機能と共存する（ボタンが両方表示される）
+
+assumptions:
+  - design_image_urlは外部URL（HTTPS）であり、認証なしでアクセス可能と想定
+  - 画像の拡張子はURLのパスから推定する。推定できない場合はContent-Typeヘッダーから判定し、それでも不明な場合は.pngとする
+  - 同一注文番号内で同名ファイルが発生する場合は連番で区別する（_1, _2, ...）
+  - ZIPファイルのサイズ上限は特に設けない（実運用上、数十件程度の受注を想定）
+  - フロントエンドのボタンは既存の「選択したN件を更新」ボタンの横に配置する
+
+success_metrics:
+  - 受注一覧画面から選択した受注のイメージ画像をZIPで一括ダウンロードできる
+  - 画像がない受注や取得失敗したURLがあっても、エラーにならず取得できた画像のみがダウンロードされる
+  - 既存の受注一覧・ステータス更新機能に影響がない

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -25,6 +25,7 @@ from app.services.invoice_service import InvoiceService
 from app.services.manufacturer_service import ManufacturerService
 from app.services.manufacturer_order_service import ManufacturerOrderService
 from app.services.manufacturer_portal_service import ManufacturerPortalService
+from app.services.order_image_service import OrderImageService
 from app.services.order_list_service import OrderListService
 from app.services.order_service import OrderService
 from app.services.product_service import ProductService
@@ -179,6 +180,13 @@ def get_external_service(
 ) -> ExternalService:
     """Get external service for external sales site APIs."""
     return ExternalService(product_repo, order_repo)
+
+
+def get_order_image_service(
+    order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
+) -> OrderImageService:
+    """Get order image service."""
+    return OrderImageService(order_repo)
 
 
 def get_invoice_service(

--- a/api/app/routers/orders.py
+++ b/api/app/routers/orders.py
@@ -9,6 +9,7 @@ from fastapi.responses import StreamingResponse
 from app.dependencies import (
     get_current_admin,
     get_file_storage,
+    get_order_image_service,
     get_order_service,
     verify_api_key,
 )
@@ -19,10 +20,12 @@ from app.schemas.order import (
     OrderBulkStatusUpdate,
     OrderBulkStatusUpdateResponse,
     OrderCreate,
+    OrderImageDownloadRequest,
     OrderListResponse,
     OrderResponse,
     OrderStatusUpdate,
 )
+from app.services.order_image_service import OrderImageService
 from app.services.order_service import OrderService
 from app.utils.exceptions import OrderNotFoundError, ValidationError
 from app.utils.file_storage import FileStorage
@@ -90,6 +93,33 @@ async def list_orders(
         ordered_from=ordered_from,
         ordered_to=ordered_to,
         search=search,
+    )
+
+
+@router.post("/download-images")
+async def download_order_images(
+    data: OrderImageDownloadRequest,
+    image_service: Annotated[OrderImageService, Depends(get_order_image_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> StreamingResponse:
+    """受注イメージ画像をZIPファイルとしてダウンロード."""
+    from urllib.parse import quote
+
+    zip_bytes = await image_service.collect_and_build_zip(data.order_ids)
+    filename = image_service.generate_zip_filename()
+
+    # RFC 5987: Use filename* for non-ASCII filenames
+    encoded_filename = quote(filename)
+    content_disposition = (
+        f"attachment; filename*=UTF-8''{encoded_filename}"
+    )
+
+    return StreamingResponse(
+        iter([zip_bytes]),
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": content_disposition,
+        },
     )
 
 

--- a/api/app/schemas/order.py
+++ b/api/app/schemas/order.py
@@ -164,3 +164,9 @@ class OrderBulkStatusUpdateResponse(BaseModel):
     updated_count: int
     failed_count: int
     failed_ids: list[str]
+
+
+class OrderImageDownloadRequest(BaseModel):
+    """受注イメージ画像ZIPダウンロードリクエスト"""
+
+    order_ids: list[str] = Field(..., min_length=1)

--- a/api/app/services/order_image_service.py
+++ b/api/app/services/order_image_service.py
@@ -1,0 +1,179 @@
+"""Order image download service.
+
+FEAT-0018: 受注イメージ画像ZIPダウンロード
+"""
+
+import asyncio
+import logging
+import mimetypes
+from datetime import datetime
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import HTTPException
+
+from app.repositories.order_repository import OrderRepository
+from app.utils.zip_builder import ZipBuilder
+
+logger = logging.getLogger(__name__)
+
+
+class OrderImageService:
+    """Service for downloading order images and building ZIP files."""
+
+    def __init__(self, order_repo: OrderRepository):
+        self._order_repo = order_repo
+
+    async def collect_and_build_zip(
+        self, order_ids: list[str]
+    ) -> bytes:
+        """Collect design images from orders and build a ZIP file.
+
+        Args:
+            order_ids: List of order IDs to collect images from.
+
+        Returns:
+            ZIP file content as bytes.
+
+        Raises:
+            HTTPException: 404 if no images could be collected.
+        """
+        # Collect image URLs with metadata from orders
+        image_tasks: list[dict] = []
+
+        for order_id in order_ids:
+            order = await self._order_repo.find_by_id(order_id)
+            if order is None:
+                logger.warning(f"Order not found: {order_id}")
+                continue
+
+            item_counter = 0
+            for item in order.items:
+                if item.design_image_url is None:
+                    continue
+                item_counter += 1
+                image_tasks.append({
+                    "order_number": order.order_number,
+                    "product_name": item.product_name,
+                    "design_image_url": item.design_image_url,
+                    "index": item_counter,
+                })
+
+        if not image_tasks:
+            raise HTTPException(
+                status_code=404,
+                detail="ダウンロード対象の画像がありません",
+            )
+
+        # Fetch images in parallel with semaphore
+        semaphore = asyncio.Semaphore(10)
+        fetched_images: list[dict | None] = []
+
+        async with httpx.AsyncClient() as client:
+
+            async def fetch_image(task: dict) -> dict | None:
+                async with semaphore:
+                    try:
+                        response = await client.get(task["design_image_url"])
+                        if response.status_code != 200:
+                            logger.warning(
+                                f"Failed to fetch image: {task['design_image_url']} "
+                                f"(status={response.status_code})"
+                            )
+                            return None
+
+                        # Determine file extension
+                        ext = self._get_extension_from_url(task["design_image_url"])
+                        if not ext:
+                            ext = self._get_extension_from_content_type(
+                                response.headers.get("content-type", "")
+                            )
+                        if not ext:
+                            ext = ".png"
+
+                        return {
+                            "order_number": task["order_number"],
+                            "product_name": task["product_name"],
+                            "index": task["index"],
+                            "content": response.content,
+                            "extension": ext,
+                        }
+                    except Exception as e:
+                        logger.warning(
+                            f"Error fetching image {task['design_image_url']}: {e}"
+                        )
+                        return None
+
+            results = await asyncio.gather(
+                *[fetch_image(task) for task in image_tasks]
+            )
+            fetched_images = [r for r in results if r is not None]
+
+        if not fetched_images:
+            raise HTTPException(
+                status_code=404,
+                detail="全ての画像の取得に失敗しました",
+            )
+
+        # Build ZIP
+        builder = ZipBuilder()
+        for img in fetched_images:
+            file_path = (
+                f"{img['order_number']}/"
+                f"{img['product_name']}_{img['index']}{img['extension']}"
+            )
+            builder.add_file(file_path, img["content"])
+
+        return builder.build()
+
+    def generate_zip_filename(self) -> str:
+        """Generate ZIP filename with timestamp.
+
+        Returns:
+            Filename in format: 受注画像_{YYYYMMDD_HHMMSS}.zip
+        """
+        now = datetime.now()
+        timestamp = now.strftime("%Y%m%d_%H%M%S")
+        return f"受注画像_{timestamp}.zip"
+
+    @staticmethod
+    def _get_extension_from_url(url: str) -> str | None:
+        """Extract file extension from URL path."""
+        parsed = urlparse(url)
+        path = parsed.path
+        if "." in path:
+            ext = path.rsplit(".", 1)[-1].lower()
+            if ext in ("png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "tiff"):
+                return f".{ext}"
+        return None
+
+    @staticmethod
+    def _get_extension_from_content_type(content_type: str) -> str | None:
+        """Get file extension from Content-Type header."""
+        if not content_type:
+            return None
+        # Remove parameters (e.g., "image/jpeg; charset=utf-8")
+        mime_type = content_type.split(";")[0].strip().lower()
+
+        # Map common image MIME types to extensions
+        mime_map = {
+            "image/png": ".png",
+            "image/jpeg": ".jpg",
+            "image/jpg": ".jpg",
+            "image/gif": ".gif",
+            "image/webp": ".webp",
+            "image/bmp": ".bmp",
+            "image/svg+xml": ".svg",
+            "image/tiff": ".tiff",
+        }
+
+        ext = mime_map.get(mime_type)
+        if ext:
+            return ext
+
+        # Fallback to mimetypes module
+        guessed_ext = mimetypes.guess_extension(mime_type)
+        if guessed_ext and guessed_ext != ".bin":
+            return guessed_ext
+
+        return None

--- a/api/tests/integration/test_order_image_download.py
+++ b/api/tests/integration/test_order_image_download.py
@@ -1,0 +1,277 @@
+"""統合テスト: 受注イメージ画像ZIPダウンロードAPI
+
+FEAT-0018: 受注イメージ画像ZIPダウンロード
+
+受け入れ基準:
+- AC-003: APIエンドポイントが選択された受注IDに紐づくdesign_image_urlを収集してZIPを返す
+- AC-010: 管理者認証が必要
+
+NOTE: These tests are written in TDD Red phase - the implementation does not exist yet.
+Tests will fail until the implementation is completed.
+"""
+
+import io
+import json
+import zipfile
+from unittest.mock import AsyncMock, patch, MagicMock
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class TestOrderImageDownloadAPI:
+    """受注イメージ画像ZIPダウンロードAPIの統合テスト."""
+
+    @pytest.fixture
+    async def test_product(self, db_session: AsyncSession, test_order_source: dict):
+        """テスト用商品（メーカーに紐づく）."""
+        manufacturer_id = str(uuid4())
+        manufacturer_name = f"テストメーカー_{manufacturer_id[:8]}"
+
+        await db_session.execute(
+            text("""
+                INSERT INTO manufacturers (id, name, email, phone, supported_products, unit_prices, lead_time_days, daily_order_limit, sharing_method, is_active, created_at, updated_at)
+                VALUES (:id, :name, :email, :phone, :supported_products, :unit_prices, :lead_time_days, :daily_order_limit, :sharing_method, :is_active, NOW(), NOW())
+            """),
+            {
+                "id": manufacturer_id,
+                "name": manufacturer_name,
+                "email": "test-mfr@example.com",
+                "phone": "03-0000-0000",
+                "supported_products": ["tshirt"],
+                "unit_prices": json.dumps({}),
+                "lead_time_days": 7,
+                "daily_order_limit": 100,
+                "sharing_method": "portal",
+                "is_active": True,
+            }
+        )
+
+        product_id = str(uuid4())
+        unique_size = f"IMG-{product_id[:8]}"
+
+        await db_session.execute(
+            text("""
+                INSERT INTO products (id, product_type, size, position, color, manufacturer_id, cost, lead_time_days, order_limit, is_active, created_at, updated_at)
+                VALUES (:id, :product_type, :size, :position, :color, :manufacturer_id, :cost, :lead_time_days, :order_limit, :is_active, NOW(), NOW())
+            """),
+            {
+                "id": product_id,
+                "product_type": "tshirt",
+                "size": unique_size,
+                "position": "正面",
+                "color": "白",
+                "manufacturer_id": manufacturer_id,
+                "cost": 1000,
+                "lead_time_days": 7,
+                "order_limit": 100,
+                "is_active": True,
+            }
+        )
+        await db_session.commit()
+
+        yield {"id": product_id, "product_type": "tshirt"}
+
+    @pytest.fixture
+    async def orders_with_images(
+        self,
+        db_session: AsyncSession,
+        test_order_source: dict,
+        test_product: dict,
+    ):
+        """design_image_urlを持つOrderItemが紐づく受注を2件作成."""
+        orders = []
+        for i in range(2):
+            order_id = str(uuid4())
+            order_item_id = str(uuid4())
+
+            await db_session.execute(
+                text("""
+                    INSERT INTO orders (id, order_number, order_source_id, product_name, quantity, customer_name, customer_email, customer_phone, customer_postal_code, customer_address_prefecture, customer_address_city, status, total_price, ordered_at, created_at, updated_at)
+                    VALUES (:id, :order_number, :order_source_id, :product_name, :quantity, :customer_name, :customer_email, :customer_phone, :customer_postal_code, :customer_address_prefecture, :customer_address_city, :status, :total_price, NOW(), NOW(), NOW())
+                """),
+                {
+                    "id": order_id,
+                    "order_number": f"IMG-{i+1}-{order_id[:8]}",
+                    "order_source_id": test_order_source["id"],
+                    "product_name": f"テスト商品{i+1}",
+                    "quantity": 1,
+                    "customer_name": f"テスト顧客{i+1}",
+                    "customer_email": f"img-customer{i+1}@example.com",
+                    "customer_phone": f"090-8888-000{i}",
+                    "customer_postal_code": "100-0001",
+                    "customer_address_prefecture": "東京都",
+                    "customer_address_city": "千代田区",
+                    "status": "ordered",
+                    "total_price": 3000,
+                }
+            )
+
+            await db_session.execute(
+                text("""
+                    INSERT INTO order_items (id, order_id, uid, product_id, product_name, product_type, price, quantity, size, position, color, design_image_url, created_at, updated_at)
+                    VALUES (:id, :order_id, :uid, :product_id, :product_name, :product_type, :price, :quantity, :size, :position, :color, :design_image_url, NOW(), NOW())
+                """),
+                {
+                    "id": order_item_id,
+                    "order_id": order_id,
+                    "uid": f"IMG-UID-{i+1}",
+                    "product_id": test_product["id"],
+                    "product_name": f"テスト商品{i+1}",
+                    "product_type": "tshirt",
+                    "price": 3000,
+                    "quantity": 1,
+                    "size": "M",
+                    "position": "正面",
+                    "color": "白",
+                    "design_image_url": f"https://example.com/designs/design{i+1}.png",
+                }
+            )
+
+            orders.append({"order_id": order_id, "order_item_id": order_item_id})
+
+        await db_session.commit()
+        yield orders
+
+    # ======================================
+    # AC-003: APIがZIPを返す
+    # ======================================
+
+    @pytest.mark.asyncio
+    async def test_download_images_returns_zip(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        orders_with_images: list[dict],
+    ):
+        """AC-003: POST /api/v1/orders/download-images が対象画像を含むZIPファイルを返す.
+
+        given: design_image_urlを持つOrderItemが紐づく受注が存在する
+        when: POST /api/v1/orders/download-images に対象のorder_idsを送信する
+        then: 対象画像を含むZIPファイルがレスポンスとして返される
+        """
+        order_ids = [item["order_id"] for item in orders_with_images]
+
+        # Mock httpx image fetch (外部URL取得をモック)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"fake-image-data-for-integration-test"
+        mock_response.headers = {"content-type": "image/png"}
+
+        with patch("httpx.AsyncClient") as MockHttpxClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockHttpxClient.return_value = mock_client_instance
+
+            response = await client.post(
+                "/api/v1/orders/download-images",
+                json={"order_ids": order_ids},
+                headers=auth_headers,
+            )
+
+        # ZIPファイルが正常にダウンロードされることを確認
+        assert response.status_code == 200, (
+            f"Expected 200 OK, but got {response.status_code}: {response.text}"
+        )
+
+        content_type = response.headers.get("content-type", "")
+        assert "application/zip" in content_type or "application/x-zip" in content_type, (
+            f"Expected Content-Type to be application/zip, but got '{content_type}'"
+        )
+
+        # ZIPの内容を検証
+        zip_bytes = response.content
+        assert len(zip_bytes) > 0, "Expected non-empty ZIP content"
+
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = zf.namelist()
+            # 2件の受注 x 各1アイテム = 2ファイル
+            assert len(file_list) == 2, (
+                f"Expected 2 files in ZIP, but got {len(file_list)}: {file_list}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_download_images_zip_filename_header(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        orders_with_images: list[dict],
+    ):
+        """ZIPファイル名が「受注画像_{YYYYMMDD_HHMMSS}.zip」形式であること."""
+        order_ids = [item["order_id"] for item in orders_with_images]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"fake-image-data"
+        mock_response.headers = {"content-type": "image/png"}
+
+        with patch("httpx.AsyncClient") as MockHttpxClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockHttpxClient.return_value = mock_client_instance
+
+            response = await client.post(
+                "/api/v1/orders/download-images",
+                json={"order_ids": order_ids},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+
+        # Content-Disposition ヘッダーにファイル名が含まれること
+        content_disposition = response.headers.get("content-disposition", "")
+        assert "受注画像_" in content_disposition or "attachment" in content_disposition, (
+            f"Expected Content-Disposition with filename, but got '{content_disposition}'"
+        )
+
+    # ======================================
+    # AC-010: 管理者認証が必要
+    # ======================================
+
+    @pytest.mark.asyncio
+    async def test_download_images_returns_401_without_auth(
+        self,
+        client: AsyncClient,
+        orders_with_images: list[dict],
+    ):
+        """AC-010: 認証されていないユーザーは401エラーが返される.
+
+        given: 認証されていないユーザー
+        when: POST /api/v1/orders/download-images を呼び出す
+        then: 401 Unauthorizedエラーが返される
+        """
+        order_ids = [item["order_id"] for item in orders_with_images]
+
+        response = await client.post(
+            "/api/v1/orders/download-images",
+            json={"order_ids": order_ids},
+            # headers なし（認証トークンなし）
+        )
+
+        assert response.status_code == 401, (
+            f"Expected 401 Unauthorized, but got {response.status_code}: {response.text}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_download_images_empty_order_ids_returns_422(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        """空のorder_idsリストで422バリデーションエラーが返される."""
+        response = await client.post(
+            "/api/v1/orders/download-images",
+            json={"order_ids": []},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 422, (
+            f"Expected 422 Validation Error, but got {response.status_code}: {response.text}"
+        )

--- a/api/tests/unit/conftest.py
+++ b/api/tests/unit/conftest.py
@@ -1,0 +1,20 @@
+"""Unit test conftest.
+
+Re-define the async HTTP client fixture locally so that the parent
+conftest.py does not interfere with pytest-asyncio fixture scoping.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.fixture
+async def client():
+    """Async HTTP client for testing."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac

--- a/api/tests/unit/test_order_image_service.py
+++ b/api/tests/unit/test_order_image_service.py
@@ -1,0 +1,671 @@
+"""Unit tests for OrderImageService.
+
+FEAT-0018: 受注イメージ画像ZIPダウンロード
+Tests cover:
+- AC-004: design_image_urlがnullのOrderItemはスキップされる
+- AC-005: 画像取得失敗時はスキップ+ログ記録
+- AC-006: 全件失敗時は404エラー
+- AC-007: 存在しない受注IDはスキップ
+- AC-008: ZIP内ファイル名の形式
+- AC-009: 空のorder_idsで422エラー
+
+NOTE: These tests are written in TDD Red phase - the implementation does not exist yet.
+Tests will fail until the implementation is completed.
+"""
+
+import io
+import logging
+import zipfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.order import Order, OrderItem, OrderStatus
+
+# Direct import - will cause ImportError (test failure) until implementation exists
+from app.services.order_image_service import OrderImageService
+from app.schemas.order import OrderImageDownloadRequest
+
+
+# ======================================
+# Fixtures
+# ======================================
+
+
+@pytest.fixture
+def mock_order_repo():
+    """Mock order repository."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def order_image_service(mock_order_repo):
+    """Create OrderImageService with mocked dependencies."""
+    return OrderImageService(order_repo=mock_order_repo)
+
+
+# ======================================
+# Helpers
+# ======================================
+
+
+def create_mock_order(
+    order_id: str = "order-123",
+    order_number: str = "ORD-001",
+    status: str = OrderStatus.ORDERED.value,
+    items: list | None = None,
+) -> MagicMock:
+    """Create a mock Order with OrderItems."""
+    order = MagicMock(spec=Order)
+    order.id = order_id
+    order.order_number = order_number
+    order.status = status
+    order.items = items or []
+    return order
+
+
+def create_mock_order_item(
+    item_id: str = "item-123",
+    product_name: str = "Tshirt M White",
+    design_image_url: str | None = "https://example.com/designs/design1.png",
+    thumbnail_image_url: str | None = None,
+) -> MagicMock:
+    """Create a mock OrderItem."""
+    item = MagicMock(spec=OrderItem)
+    item.id = item_id
+    item.product_name = product_name
+    item.design_image_url = design_image_url
+    item.thumbnail_image_url = thumbnail_image_url
+    return item
+
+
+# ======================================
+# AC-004: design_image_urlがnullのOrderItemはスキップされる
+# ======================================
+
+
+class TestSkipNullDesignImageUrl:
+    """AC-004: design_image_urlがnullのOrderItemはスキップされる."""
+
+    async def test_null_design_image_url_items_are_skipped(
+        self, order_image_service, mock_order_repo
+    ):
+        """design_image_urlがnullのアイテムはスキップされ、画像を持つアイテムのみがZIPに含まれる."""
+        # Arrange
+        item_with_image = create_mock_order_item(
+            item_id="item-1",
+            product_name="Tshirt M White",
+            design_image_url="https://example.com/design1.png",
+        )
+        item_without_image = create_mock_order_item(
+            item_id="item-2",
+            product_name="Tshirt L Black",
+            design_image_url=None,
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item_with_image, item_without_image],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        # Mock httpx image fetch
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"fake-image-data"
+        mock_response.headers = {"content-type": "image/png"}
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            zip_bytes = await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+
+        # Assert: ZIP should only contain one file (the item with image)
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = zf.namelist()
+            assert len(file_list) == 1
+
+    async def test_all_items_null_design_image_url_raises_error(
+        self, order_image_service, mock_order_repo
+    ):
+        """全てのアイテムのdesign_image_urlがnullの場合、エラーが発生する."""
+        # Arrange
+        item_null_1 = create_mock_order_item(
+            item_id="item-1", design_image_url=None
+        )
+        item_null_2 = create_mock_order_item(
+            item_id="item-2", design_image_url=None
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item_null_1, item_null_2],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        # Act & Assert
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ======================================
+# AC-005: 画像取得失敗時はスキップ+ログ記録
+# ======================================
+
+
+class TestImageFetchFailureSkipAndLog:
+    """AC-005: 画像URLからの取得に失敗した場合はスキップしてログに記録する."""
+
+    async def test_failed_image_fetch_is_skipped_and_logged(
+        self, order_image_service, mock_order_repo, caplog
+    ):
+        """取得失敗した画像はスキップされ、ログに警告が記録される."""
+        # Arrange
+        item_good = create_mock_order_item(
+            item_id="item-1",
+            product_name="Good Product",
+            design_image_url="https://example.com/good.png",
+        )
+        item_bad = create_mock_order_item(
+            item_id="item-2",
+            product_name="Bad Product",
+            design_image_url="https://example.com/bad.png",
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item_good, item_bad],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        # Mock: first request succeeds, second returns 404
+        mock_response_good = MagicMock()
+        mock_response_good.status_code = 200
+        mock_response_good.content = b"good-image-data"
+        mock_response_good.headers = {"content-type": "image/png"}
+
+        mock_response_bad = MagicMock()
+        mock_response_bad.status_code = 404
+        mock_response_bad.content = b""
+
+        async def side_effect_get(url, **kwargs):
+            if "good" in url:
+                return mock_response_good
+            return mock_response_bad
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.side_effect = side_effect_get
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            with caplog.at_level(logging.WARNING):
+                zip_bytes = await order_image_service.collect_and_build_zip(
+                    order_ids=["order-1"]
+                )
+
+        # Assert: Only one file in ZIP (the good one)
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = zf.namelist()
+            assert len(file_list) == 1
+
+        # Assert: Warning logged for failed fetch
+        assert any("bad.png" in record.message or "bad" in record.message.lower()
+                    for record in caplog.records
+                    if record.levelno >= logging.WARNING)
+
+    async def test_timeout_on_image_fetch_is_skipped(
+        self, order_image_service, mock_order_repo
+    ):
+        """タイムアウトした画像取得はスキップされる."""
+        import httpx
+
+        # Arrange
+        item_timeout = create_mock_order_item(
+            item_id="item-1",
+            product_name="Timeout Product",
+            design_image_url="https://example.com/timeout.png",
+        )
+        item_good = create_mock_order_item(
+            item_id="item-2",
+            product_name="Good Product",
+            design_image_url="https://example.com/good.png",
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item_timeout, item_good],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        mock_response_good = MagicMock()
+        mock_response_good.status_code = 200
+        mock_response_good.content = b"good-image-data"
+        mock_response_good.headers = {"content-type": "image/png"}
+
+        async def side_effect_get(url, **kwargs):
+            if "timeout" in url:
+                raise httpx.TimeoutException("Connection timed out")
+            return mock_response_good
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.side_effect = side_effect_get
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            zip_bytes = await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+
+        # Assert: Only the good image is in ZIP
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            assert len(zf.namelist()) == 1
+
+
+# ======================================
+# AC-006: 全件失敗時は404エラー
+# ======================================
+
+
+class TestAllFetchFailuresReturn404:
+    """AC-006: 全ての画像取得に失敗した場合は404エラーを返す."""
+
+    async def test_all_images_fetch_failed_returns_404(
+        self, order_image_service, mock_order_repo
+    ):
+        """全ての画像URLからの取得に失敗した場合、404エラーが返される."""
+        # Arrange
+        item_bad_1 = create_mock_order_item(
+            item_id="item-1",
+            design_image_url="https://example.com/bad1.png",
+        )
+        item_bad_2 = create_mock_order_item(
+            item_id="item-2",
+            design_image_url="https://example.com/bad2.png",
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item_bad_1, item_bad_2],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        mock_response_bad = MagicMock()
+        mock_response_bad.status_code = 500
+        mock_response_bad.content = b""
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response_bad
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act & Assert
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException) as exc_info:
+                await order_image_service.collect_and_build_zip(
+                    order_ids=["order-1"]
+                )
+            assert exc_info.value.status_code == 404
+
+    async def test_no_design_image_urls_at_all_returns_404(
+        self, order_image_service, mock_order_repo
+    ):
+        """design_image_urlを持つアイテムが0件の場合は404エラーが返される."""
+        # Arrange
+        item_null = create_mock_order_item(
+            item_id="item-1",
+            design_image_url=None,
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item_null],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        # Act & Assert
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ======================================
+# AC-007: 存在しない受注IDはスキップ
+# ======================================
+
+
+class TestNonExistentOrderIdsSkipped:
+    """AC-007: 存在しない受注IDが含まれている場合、存在する受注のみ処理される."""
+
+    async def test_nonexistent_order_ids_are_skipped(
+        self, order_image_service, mock_order_repo
+    ):
+        """存在しない受注IDはスキップされ、存在する受注の画像のみがZIPに含まれる."""
+        # Arrange
+        item = create_mock_order_item(
+            item_id="item-1",
+            product_name="Valid Product",
+            design_image_url="https://example.com/valid.png",
+        )
+        valid_order = create_mock_order(
+            order_id="order-valid",
+            order_number="ORD-VALID",
+            items=[item],
+        )
+
+        async def find_by_id(order_id):
+            if order_id == "order-valid":
+                return valid_order
+            return None  # Not found
+
+        mock_order_repo.find_by_id.side_effect = find_by_id
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"image-data"
+        mock_response.headers = {"content-type": "image/png"}
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            zip_bytes = await order_image_service.collect_and_build_zip(
+                order_ids=["order-valid", "order-nonexistent"]
+            )
+
+        # Assert: ZIP contains files only from the valid order
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = zf.namelist()
+            assert len(file_list) == 1
+            # File should be under the valid order's directory
+            assert any("ORD-VALID" in f for f in file_list)
+
+    async def test_all_nonexistent_order_ids_returns_404(
+        self, order_image_service, mock_order_repo
+    ):
+        """全ての受注IDが存在しない場合は404エラーが返される."""
+        # Arrange
+        mock_order_repo.find_by_id.return_value = None
+
+        # Act & Assert
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await order_image_service.collect_and_build_zip(
+                order_ids=["nonexistent-1", "nonexistent-2"]
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ======================================
+# AC-008: ZIP内ファイル名の形式
+# ======================================
+
+
+class TestZipFileNameFormat:
+    """AC-008: ZIPファイル内のファイル名が注文番号と商品名で構成される."""
+
+    async def test_zip_file_path_format(
+        self, order_image_service, mock_order_repo
+    ):
+        """ZIP内のファイルパスが「{注文番号}/{商品名}_{連番}.{拡張子}」形式になっている."""
+        # Arrange
+        item = create_mock_order_item(
+            item_id="item-1",
+            product_name="Tシャツ Mサイズ 白",
+            design_image_url="https://example.com/design1.png",
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"image-data"
+        mock_response.headers = {"content-type": "image/png"}
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            zip_bytes = await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+
+        # Assert
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = zf.namelist()
+            assert len(file_list) == 1
+            # Format: ORD-001/Tシャツ Mサイズ 白_1.png
+            file_path = file_list[0]
+            assert file_path.startswith("ORD-001/")
+            assert "Tシャツ Mサイズ 白" in file_path
+            assert "_1." in file_path
+            assert file_path.endswith(".png")
+
+    async def test_zip_file_path_with_multiple_items_has_sequential_numbers(
+        self, order_image_service, mock_order_repo
+    ):
+        """同一注文の複数アイテムには連番が振られる."""
+        # Arrange
+        item_1 = create_mock_order_item(
+            item_id="item-1",
+            product_name="Tシャツ",
+            design_image_url="https://example.com/design1.png",
+        )
+        item_2 = create_mock_order_item(
+            item_id="item-2",
+            product_name="Tシャツ",
+            design_image_url="https://example.com/design2.png",
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item_1, item_2],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"image-data"
+        mock_response.headers = {"content-type": "image/png"}
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            zip_bytes = await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+
+        # Assert: Two files with sequential numbers
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = sorted(zf.namelist())
+            assert len(file_list) == 2
+            assert "_1." in file_list[0]
+            assert "_2." in file_list[1]
+
+    async def test_zip_file_extension_from_url(
+        self, order_image_service, mock_order_repo
+    ):
+        """拡張子はURLのパスから推定される."""
+        # Arrange
+        item = create_mock_order_item(
+            item_id="item-1",
+            product_name="Product",
+            design_image_url="https://example.com/images/photo.jpg",
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"image-data"
+        mock_response.headers = {"content-type": "image/jpeg"}
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            zip_bytes = await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+
+        # Assert: Extension should be .jpg from URL
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = zf.namelist()
+            assert len(file_list) == 1
+            assert file_list[0].endswith(".jpg")
+
+    async def test_zip_file_extension_fallback_to_content_type(
+        self, order_image_service, mock_order_repo
+    ):
+        """URLから拡張子が推定できない場合はContent-Typeから判定する."""
+        # Arrange
+        item = create_mock_order_item(
+            item_id="item-1",
+            product_name="Product",
+            design_image_url="https://example.com/image?id=123",  # No extension in URL
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"image-data"
+        mock_response.headers = {"content-type": "image/jpeg"}
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            zip_bytes = await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+
+        # Assert: Extension from Content-Type
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = zf.namelist()
+            assert len(file_list) == 1
+            assert file_list[0].endswith(".jpg") or file_list[0].endswith(".jpeg")
+
+    async def test_zip_file_extension_fallback_to_png(
+        self, order_image_service, mock_order_repo
+    ):
+        """URLからもContent-Typeからも拡張子が推定できない場合は.pngとする."""
+        # Arrange
+        item = create_mock_order_item(
+            item_id="item-1",
+            product_name="Product",
+            design_image_url="https://example.com/image?id=123",  # No extension
+        )
+        order = create_mock_order(
+            order_id="order-1",
+            order_number="ORD-001",
+            items=[item],
+        )
+        mock_order_repo.find_by_id.return_value = order
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"image-data"
+        mock_response.headers = {"content-type": "application/octet-stream"}  # Unknown type
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            # Act
+            zip_bytes = await order_image_service.collect_and_build_zip(
+                order_ids=["order-1"]
+            )
+
+        # Assert: Fallback to .png
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            file_list = zf.namelist()
+            assert len(file_list) == 1
+            assert file_list[0].endswith(".png")
+
+
+# ======================================
+# AC-009: 空のorder_idsで422エラー
+# ======================================
+
+
+class TestEmptyOrderIdsValidation:
+    """AC-009: order_idsが空の場合は422エラーを返す."""
+
+    def test_empty_order_ids_validation_error(self):
+        """空のorder_idsリストはバリデーションエラーになる."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        with pytest.raises(PydanticValidationError):
+            OrderImageDownloadRequest(order_ids=[])
+
+    def test_valid_order_ids_accepted(self):
+        """1件以上のorder_idsは受け入れられる."""
+        request = OrderImageDownloadRequest(order_ids=["order-1"])
+        assert request.order_ids == ["order-1"]
+
+    def test_multiple_order_ids_accepted(self):
+        """複数のorder_idsも受け入れられる."""
+        request = OrderImageDownloadRequest(order_ids=["order-1", "order-2", "order-3"])
+        assert len(request.order_ids) == 3

--- a/web/src/app/(dashboard)/orders/page.tsx
+++ b/web/src/app/(dashboard)/orders/page.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { RefreshCw } from "lucide-react";
+import { Download, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { downloadFileByPost } from "@/lib/api/client";
 import { Button } from "@/components/ui/button";
 import { PageContainer } from "@/components/layout/page-container";
 import { Pagination } from "@/components/common/pagination";
@@ -52,16 +54,43 @@ export default function OrdersPage() {
     mutate();
   };
 
+  const handleImageDownload = async () => {
+    try {
+      const now = new Date();
+      const timestamp = now.getFullYear().toString()
+        + (now.getMonth() + 1).toString().padStart(2, "0")
+        + now.getDate().toString().padStart(2, "0")
+        + "_"
+        + now.getHours().toString().padStart(2, "0")
+        + now.getMinutes().toString().padStart(2, "0")
+        + now.getSeconds().toString().padStart(2, "0");
+      const filename = `受注画像_${timestamp}.zip`;
+      await downloadFileByPost(
+        "/orders/download-images",
+        { order_ids: selectedIds },
+        filename
+      );
+    } catch {
+      toast.error("画像のダウンロードに失敗しました");
+    }
+  };
+
   return (
     <PageContainer
       title="受注一覧"
       description="外部販売サイトからの受注情報"
       actions={
         selectedIds.length > 0 ? (
-          <Button onClick={() => setIsBulkStatusDialogOpen(true)}>
-            <RefreshCw className="h-4 w-4 mr-2" />
-            選択した{selectedIds.length}件を更新
-          </Button>
+          <>
+            <Button variant="outline" onClick={handleImageDownload}>
+              <Download className="h-4 w-4 mr-2" />
+              イメージ画像ダウンロード
+            </Button>
+            <Button onClick={() => setIsBulkStatusDialogOpen(true)}>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              選択した{selectedIds.length}件を更新
+            </Button>
+          </>
         ) : undefined
       }
     >

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -96,4 +96,39 @@ export async function downloadFile(endpoint: string, filename: string): Promise<
   document.body.removeChild(a);
 }
 
+export async function downloadFileByPost(
+  endpoint: string,
+  body: unknown,
+  filename: string
+): Promise<void> {
+  const token = await getAuthToken();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error("Download failed");
+  }
+
+  const blob = await response.blob();
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(a);
+}
+
 export { ApiError };

--- a/web/tests/unit/feat-0018-order-image-download.test.tsx
+++ b/web/tests/unit/feat-0018-order-image-download.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Unit tests for FEAT-0018: 受注イメージ画像ZIPダウンロード
+ *
+ * Covers:
+ * - AC-001: 受注を1件以上選択した状態で「イメージ画像ダウンロード」ボタンが表示される
+ * - AC-002: 受注が未選択の場合は「イメージ画像ダウンロード」ボタンが表示されない
+ * - AC-011: ボタンクリック時にダウンロードが開始される
+ *
+ * NOTE: These tests are written in TDD Red phase - the implementation does not exist yet.
+ * Tests will fail until the implementation is completed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock the API client
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+  downloadFile: vi.fn(),
+  downloadFileByPost: vi.fn(),
+}))
+
+// Mock toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+// Mock SWR
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({
+    data: undefined,
+    error: undefined,
+    isLoading: false,
+    mutate: vi.fn(),
+  })),
+}))
+
+// Mock next/navigation
+const mockPush = vi.fn()
+const mockReplace = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: mockReplace,
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/orders',
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}))
+
+import { downloadFileByPost } from '@/lib/api/client'
+import { toast } from 'sonner'
+import type { Order, OrderStatus } from '@/types/api'
+
+const mockDownloadFileByPost = vi.mocked(downloadFileByPost)
+const mockToast = vi.mocked(toast)
+
+// Import the page component - will fail until implementation exists
+import OrdersPage from '@/app/(dashboard)/orders/page'
+
+// ======================================
+// Helper: Create mock order data
+// ======================================
+
+const createMockOrder = (overrides: Partial<Order> = {}): Order => ({
+  id: 'order-123',
+  order_number: 'TEST-001',
+  status: 'ordered' as OrderStatus,
+  source: 'test-source',
+  order_source_id: 'source-123',
+  customer_name: 'Test Customer',
+  customer_postal_code: '100-0001',
+  customer_address_prefecture: 'Tokyo',
+  customer_address_city: 'Chiyoda',
+  customer_address_building: null,
+  customer_full_address: 'Tokyo Chiyoda',
+  customer_phone: '090-1234-5678',
+  customer_email: 'test@example.com',
+  ordered_at: '2024-01-01T00:00:00Z',
+  total_price: 1000,
+  items: [],
+  shipment: null,
+  product_id: null,
+  product_name: null,
+  price: null,
+  quantity: null,
+  manufacturing_data: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  ...overrides,
+})
+
+// ======================================
+// Setup: Mock SWR to return orders
+// ======================================
+
+function setupOrdersMock(orders: Order[]) {
+  const useSWR = vi.mocked(
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('swr').default
+  )
+  useSWR.mockReturnValue({
+    data: {
+      items: orders,
+      total: orders.length,
+      page: 1,
+      limit: 20,
+    },
+    error: undefined,
+    isLoading: false,
+    mutate: vi.fn(),
+    isValidating: false,
+  })
+}
+
+// ======================================
+// AC-001: 受注を1件以上選択した状態で「イメージ画像ダウンロード」ボタンが表示される
+// ======================================
+
+describe('AC-001: Image download button shown when orders selected', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows "イメージ画像ダウンロード" button when one or more orders are selected', async () => {
+    const user = userEvent.setup()
+    const orders = [
+      createMockOrder({ id: 'order-1', order_number: 'ORD-001' }),
+      createMockOrder({ id: 'order-2', order_number: 'ORD-002' }),
+    ]
+    setupOrdersMock(orders)
+
+    render(<OrdersPage />)
+
+    // Select the first order by clicking its checkbox
+    const checkboxes = screen.getAllByRole('checkbox').filter(
+      cb => !cb.getAttribute('aria-label')?.includes('全選択')
+    )
+    await user.click(checkboxes[0])
+
+    // "イメージ画像ダウンロード" button should appear
+    await waitFor(() => {
+      const downloadButton = screen.getByRole('button', { name: /イメージ画像ダウンロード/ })
+      expect(downloadButton).toBeInTheDocument()
+    })
+  })
+
+  it('shows image download button when multiple orders are selected', async () => {
+    const user = userEvent.setup()
+    const orders = [
+      createMockOrder({ id: 'order-1', order_number: 'ORD-001' }),
+      createMockOrder({ id: 'order-2', order_number: 'ORD-002' }),
+      createMockOrder({ id: 'order-3', order_number: 'ORD-003' }),
+    ]
+    setupOrdersMock(orders)
+
+    render(<OrdersPage />)
+
+    // Select all by clicking header checkbox
+    const selectAllCheckbox = screen.getByRole('checkbox', { name: /全選択/ })
+    await user.click(selectAllCheckbox)
+
+    // "イメージ画像ダウンロード" button should appear
+    await waitFor(() => {
+      const downloadButton = screen.getByRole('button', { name: /イメージ画像ダウンロード/ })
+      expect(downloadButton).toBeInTheDocument()
+    })
+  })
+})
+
+// ======================================
+// AC-002: 受注が未選択の場合は「イメージ画像ダウンロード」ボタンが表示されない
+// ======================================
+
+describe('AC-002: Image download button hidden when no orders selected', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not show "イメージ画像ダウンロード" button when no orders are selected', () => {
+    const orders = [
+      createMockOrder({ id: 'order-1', order_number: 'ORD-001' }),
+      createMockOrder({ id: 'order-2', order_number: 'ORD-002' }),
+    ]
+    setupOrdersMock(orders)
+
+    render(<OrdersPage />)
+
+    // "イメージ画像ダウンロード" button should NOT be visible
+    const downloadButton = screen.queryByRole('button', { name: /イメージ画像ダウンロード/ })
+    expect(downloadButton).not.toBeInTheDocument()
+  })
+
+  it('hides image download button when orders are deselected', async () => {
+    const user = userEvent.setup()
+    const orders = [
+      createMockOrder({ id: 'order-1', order_number: 'ORD-001' }),
+    ]
+    setupOrdersMock(orders)
+
+    render(<OrdersPage />)
+
+    // Select the first order
+    const checkboxes = screen.getAllByRole('checkbox').filter(
+      cb => !cb.getAttribute('aria-label')?.includes('全選択')
+    )
+    await user.click(checkboxes[0])
+
+    // Button should appear
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /イメージ画像ダウンロード/ })).toBeInTheDocument()
+    })
+
+    // Deselect the order
+    await user.click(checkboxes[0])
+
+    // Button should disappear
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /イメージ画像ダウンロード/ })).not.toBeInTheDocument()
+    })
+  })
+})
+
+// ======================================
+// AC-011: ボタンクリック時にダウンロードが開始される
+// ======================================
+
+describe('AC-011: Download starts when button is clicked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls downloadFileByPost with correct order_ids when button is clicked', async () => {
+    const user = userEvent.setup()
+    const orders = [
+      createMockOrder({ id: 'order-1', order_number: 'ORD-001' }),
+      createMockOrder({ id: 'order-2', order_number: 'ORD-002' }),
+    ]
+    setupOrdersMock(orders)
+
+    mockDownloadFileByPost.mockResolvedValueOnce(undefined)
+
+    render(<OrdersPage />)
+
+    // Select both orders
+    const selectAllCheckbox = screen.getByRole('checkbox', { name: /全選択/ })
+    await user.click(selectAllCheckbox)
+
+    // Click the download button
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /イメージ画像ダウンロード/ })).toBeInTheDocument()
+    })
+    const downloadButton = screen.getByRole('button', { name: /イメージ画像ダウンロード/ })
+    await user.click(downloadButton)
+
+    // downloadFileByPost should be called with the selected order IDs
+    await waitFor(() => {
+      expect(mockDownloadFileByPost).toHaveBeenCalledWith(
+        '/orders/download-images',
+        { order_ids: ['order-1', 'order-2'] },
+        expect.stringContaining('受注画像_')
+      )
+    })
+  })
+
+  it('shows error toast when download fails', async () => {
+    const user = userEvent.setup()
+    const orders = [
+      createMockOrder({ id: 'order-1', order_number: 'ORD-001' }),
+    ]
+    setupOrdersMock(orders)
+
+    mockDownloadFileByPost.mockRejectedValueOnce(new Error('Download failed'))
+
+    render(<OrdersPage />)
+
+    // Select the order
+    const checkboxes = screen.getAllByRole('checkbox').filter(
+      cb => !cb.getAttribute('aria-label')?.includes('全選択')
+    )
+    await user.click(checkboxes[0])
+
+    // Click the download button
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /イメージ画像ダウンロード/ })).toBeInTheDocument()
+    })
+    const downloadButton = screen.getByRole('button', { name: /イメージ画像ダウンロード/ })
+    await user.click(downloadButton)
+
+    // Error toast should be shown
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 受注一覧画面に「イメージ画像ダウンロード」ボタンを追加（1件以上選択時に表示）
- `POST /api/v1/orders/download-images` エンドポイントを新設し、選択された受注に紐づく商品の `design_image_url` を収集して並列取得し、ZIPファイルとしてダウンロード
- `OrderImageService` を新規作成（httpx + asyncio.Semaphore で最大10並列画像取得、既存 ZipBuilder でZIP構築）

Closes #26

## Changes
### Backend
- `api/app/schemas/order.py` — `OrderImageDownloadRequest` スキーマ追加
- `api/app/services/order_image_service.py` — 新規。画像収集・取得・ZIP構築のビジネスロジック
- `api/app/dependencies.py` — `get_order_image_service` 依存関数追加
- `api/app/routers/orders.py` — `POST /download-images` エンドポイント追加

### Frontend
- `web/src/lib/api/client.ts` — `downloadFileByPost` 関数追加（POSTでファイルダウンロード）
- `web/src/app/(dashboard)/orders/page.tsx` — 「イメージ画像ダウンロード」ボタン追加

### Tests
- `api/tests/unit/test_order_image_service.py` — ユニットテスト16件
- `api/tests/integration/test_order_image_download.py` — 統合テスト4件
- `web/tests/unit/feat-0018-order-image-download.test.tsx` — フロントエンドテスト6件

## Test plan
- [x] バックエンドユニットテスト 206件パス
- [x] バックエンド統合テスト 86件パス
- [x] フロントエンドテスト 164件パス
- [x] design_image_url が null のアイテムはスキップされる
- [x] 画像取得失敗時はスキップ+ログ記録
- [x] 全件失敗時は 404 エラー
- [x] 空の order_ids で 422 バリデーションエラー
- [x] 認証なしで 401 エラー
- [x] ZIP内ファイル名が `{注文番号}/{商品名}_{連番}.{拡張子}` 形式

🤖 Generated with [Claude Code](https://claude.com/claude-code)