### PR TITLE
feat: リフレッシュトークン有効期限を30日に延長 (FEAT-0030)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -10,7 +10,7 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/pod_admin
 # Security
 SECRET_KEY=your-secret-key-here
 ACCESS_TOKEN_EXPIRE_MINUTES=30
-REFRESH_TOKEN_EXPIRE_DAYS=7
+REFRESH_TOKEN_EXPIRE_DAYS=30
 API_KEY_HEADER=X-API-Key
 
 # CORS

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
     # Security
     SECRET_KEY: str
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
-    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 30
     API_KEY_HEADER: str = "X-API-Key"
 
     # CORS

--- a/api/tests/integration/test_auth_token_expiry.py
+++ b/api/tests/integration/test_auth_token_expiry.py
@@ -1,0 +1,197 @@
+"""Integration tests for authentication token expiry.
+
+FEAT-0030: リフレッシュトークンの有効期限を7日から30日に変更。
+管理者・製造者の両方でログインAPIから返されるリフレッシュトークンの
+有効期限が30日であることを検証する。
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from jose import jwt
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid import uuid4
+
+from app.config import settings
+from app.utils.security import ALGORITHM, create_refresh_token, hash_password
+
+
+@pytest.fixture
+async def test_admin_for_auth(db_session: AsyncSession):
+    """認証テスト用の管理者ユーザーを作成"""
+    user_id = str(uuid4())
+
+    await db_session.execute(
+        text("""
+            INSERT INTO users (id, email, name, password_hash, role, is_active, created_at, updated_at)
+            VALUES (:id, :email, :name, :password_hash, :role, :is_active, NOW(), NOW())
+        """),
+        {
+            "id": user_id,
+            "email": f"auth-test-admin-{user_id[:8]}@example.com",
+            "name": "Auth Test Admin",
+            "password_hash": hash_password("test-password-123"),
+            "role": "admin",
+            "is_active": True,
+        },
+    )
+    await db_session.commit()
+
+    yield {
+        "id": user_id,
+        "email": f"auth-test-admin-{user_id[:8]}@example.com",
+        "password": "test-password-123",
+    }
+
+
+@pytest.fixture
+async def test_manufacturer_for_auth(db_session: AsyncSession):
+    """認証テスト用の製造者を作成"""
+    manufacturer_id = str(uuid4())
+
+    await db_session.execute(
+        text("""
+            INSERT INTO manufacturers (
+                id, name, email, supported_products, unit_prices,
+                lead_time_days, daily_order_limit, sharing_method,
+                password_hash, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :name, :email, :supported_products, :unit_prices,
+                :lead_time_days, :daily_order_limit, :sharing_method,
+                :password_hash, :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": manufacturer_id,
+            "name": f"Auth Test Manufacturer {manufacturer_id[:8]}",
+            "email": f"auth-test-mfr-{manufacturer_id[:8]}@example.com",
+            "supported_products": ["seal"],
+            "unit_prices": "{}",
+            "lead_time_days": 3,
+            "daily_order_limit": 100,
+            "sharing_method": "portal",
+            "password_hash": hash_password("test-password-123"),
+            "is_active": True,
+        },
+    )
+    await db_session.commit()
+
+    yield {
+        "id": manufacturer_id,
+        "email": f"auth-test-mfr-{manufacturer_id[:8]}@example.com",
+        "password": "test-password-123",
+    }
+
+
+@pytest.mark.asyncio
+async def test_admin_login_returns_30_day_refresh_token(
+    client: AsyncClient,
+    test_admin_for_auth: dict,
+):
+    """AC-002: 管理者ログインで30日有効のリフレッシュトークンが返される"""
+    before = datetime.now(timezone.utc)
+
+    response = await client.post(
+        f"{settings.API_V1_PREFIX}/auth/login",
+        json={
+            "email": test_admin_for_auth["email"],
+            "password": test_admin_for_auth["password"],
+        },
+    )
+
+    assert response.status_code == 200, f"Login failed: {response.text}"
+    data = response.json()
+    assert "refresh_token" in data
+
+    # リフレッシュトークンのexpを検証
+    decoded = jwt.decode(
+        data["refresh_token"], settings.SECRET_KEY, algorithms=[ALGORITHM]
+    )
+    exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
+
+    expected_min = before + timedelta(days=30) - timedelta(seconds=60)
+    expected_max = before + timedelta(days=30) + timedelta(seconds=60)
+
+    assert expected_min <= exp <= expected_max, (
+        f"Admin refresh token exp should be ~30 days. Got {exp}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_manufacturer_login_returns_30_day_refresh_token(
+    client: AsyncClient,
+    test_manufacturer_for_auth: dict,
+):
+    """AC-003: 製造者ログインで30日有効のリフレッシュトークンが返される"""
+    before = datetime.now(timezone.utc)
+
+    response = await client.post(
+        f"{settings.API_V1_PREFIX}/manufacturer-portal/login",
+        json={
+            "email": test_manufacturer_for_auth["email"],
+            "password": test_manufacturer_for_auth["password"],
+        },
+    )
+
+    assert response.status_code == 200, f"Login failed: {response.text}"
+    data = response.json()
+    assert "refresh_token" in data
+
+    # リフレッシュトークンのexpを検証
+    decoded = jwt.decode(
+        data["refresh_token"], settings.SECRET_KEY, algorithms=[ALGORITHM]
+    )
+    exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
+
+    expected_min = before + timedelta(days=30) - timedelta(seconds=60)
+    expected_max = before + timedelta(days=30) + timedelta(seconds=60)
+
+    assert expected_min <= exp <= expected_max, (
+        f"Manufacturer refresh token exp should be ~30 days. Got {exp}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_endpoint_returns_new_30_day_token(
+    client: AsyncClient,
+    test_admin_for_auth: dict,
+):
+    """AC-004: リフレッシュトークンが有効な間、アクセストークンの再発行が可能"""
+    # まずログインしてリフレッシュトークンを取得
+    login_response = await client.post(
+        f"{settings.API_V1_PREFIX}/auth/login",
+        json={
+            "email": test_admin_for_auth["email"],
+            "password": test_admin_for_auth["password"],
+        },
+    )
+    assert login_response.status_code == 200
+    refresh_token = login_response.json()["refresh_token"]
+
+    # リフレッシュエンドポイントを呼び出し
+    before = datetime.now(timezone.utc)
+    refresh_response = await client.post(
+        f"{settings.API_V1_PREFIX}/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+
+    assert refresh_response.status_code == 200, f"Refresh failed: {refresh_response.text}"
+    data = refresh_response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+
+    # 新しいリフレッシュトークンも30日の有効期限を持つこと
+    decoded = jwt.decode(
+        data["refresh_token"], settings.SECRET_KEY, algorithms=[ALGORITHM]
+    )
+    exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
+
+    expected_min = before + timedelta(days=30) - timedelta(seconds=60)
+    expected_max = before + timedelta(days=30) + timedelta(seconds=60)
+
+    assert expected_min <= exp <= expected_max, (
+        f"Refreshed token exp should be ~30 days. Got {exp}"
+    )

--- a/api/tests/unit/test_config.py
+++ b/api/tests/unit/test_config.py
@@ -56,3 +56,55 @@ def test_settings_cors_origins():
 
     assert "http://localhost:3000" in settings.CORS_ORIGINS
     assert "http://localhost:8080" in settings.CORS_ORIGINS
+
+
+# === FEAT-0030: リフレッシュトークン有効期限デフォルト値テスト ===
+
+
+def test_refresh_token_expire_days_default_is_30():
+    """REFRESH_TOKEN_EXPIRE_DAYSのデフォルト値が30日であること"""
+    from app.config import Settings
+
+    settings = Settings(
+        DATABASE_URL="postgresql+asyncpg://test:test@localhost:5432/testdb",
+        SECRET_KEY="test-secret-key-for-testing-only",
+        _env_file=None,
+    )
+
+    assert settings.REFRESH_TOKEN_EXPIRE_DAYS == 30, (
+        f"Expected REFRESH_TOKEN_EXPIRE_DAYS default to be 30, "
+        f"got {settings.REFRESH_TOKEN_EXPIRE_DAYS}"
+    )
+
+
+def test_refresh_token_expire_days_can_be_overridden():
+    """REFRESH_TOKEN_EXPIRE_DAYSが環境変数で上書き可能であること"""
+    os.environ["REFRESH_TOKEN_EXPIRE_DAYS"] = "60"
+    os.environ["DATABASE_URL"] = "postgresql+asyncpg://test:test@localhost:5432/testdb"
+    os.environ["SECRET_KEY"] = "test-secret-key"
+
+    from app.config import Settings
+
+    settings = Settings(_env_file=None)
+    assert settings.REFRESH_TOKEN_EXPIRE_DAYS == 60
+
+    # Cleanup
+    del os.environ["REFRESH_TOKEN_EXPIRE_DAYS"]
+    del os.environ["DATABASE_URL"]
+    del os.environ["SECRET_KEY"]
+
+
+def test_access_token_expire_minutes_unchanged():
+    """ACCESS_TOKEN_EXPIRE_MINUTESのデフォルト値が30分のままであること"""
+    from app.config import Settings
+
+    settings = Settings(
+        DATABASE_URL="postgresql+asyncpg://test:test@localhost:5432/testdb",
+        SECRET_KEY="test-secret-key-for-testing-only",
+        _env_file=None,
+    )
+
+    assert settings.ACCESS_TOKEN_EXPIRE_MINUTES == 30, (
+        f"Expected ACCESS_TOKEN_EXPIRE_MINUTES default to be 30, "
+        f"got {settings.ACCESS_TOKEN_EXPIRE_MINUTES}"
+    )

--- a/api/tests/unit/test_security.py
+++ b/api/tests/unit/test_security.py
@@ -1,15 +1,17 @@
 """Test security utilities."""
 
 import pytest
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from app.utils.security import (
+    ALGORITHM,
     create_access_token,
     create_refresh_token,
     decode_token,
     hash_password,
     verify_password,
 )
+from app.config import settings
 
 
 def test_hash_password():
@@ -96,3 +98,68 @@ def test_access_and_refresh_tokens_different():
 
     assert access_decoded["type"] == "access"
     assert refresh_decoded["type"] == "refresh"
+
+
+# === FEAT-0030: リフレッシュトークン有効期限30日テスト ===
+
+
+def test_refresh_token_expiry_is_30_days():
+    """AC-001: リフレッシュトークンが30日の有効期限で発行される"""
+    from jose import jwt
+
+    data = {"sub": "user_id_123"}
+    before = datetime.now(timezone.utc)
+    token = create_refresh_token(data)
+    after = datetime.now(timezone.utc)
+
+    decoded = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+    exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
+
+    # expが発行時刻から30日後（±60秒の許容範囲）であること
+    expected_min = before + timedelta(days=30) - timedelta(seconds=60)
+    expected_max = after + timedelta(days=30) + timedelta(seconds=60)
+
+    assert expected_min <= exp <= expected_max, (
+        f"Refresh token exp should be ~30 days from now. "
+        f"Got {exp}, expected between {expected_min} and {expected_max}"
+    )
+
+
+def test_refresh_token_default_expiry_uses_settings():
+    """設定値REFRESH_TOKEN_EXPIRE_DAYSがリフレッシュトークンに反映されること"""
+    assert settings.REFRESH_TOKEN_EXPIRE_DAYS == 30, (
+        f"REFRESH_TOKEN_EXPIRE_DAYS should be 30, got {settings.REFRESH_TOKEN_EXPIRE_DAYS}"
+    )
+
+
+def test_refresh_token_expired_after_30_days():
+    """AC-005: 30日超過のリフレッシュトークンは無効と判定される"""
+    data = {"sub": "user_id_123"}
+    # 31日前に発行されたトークンをシミュレート（負のtimedelta）
+    expired_token = create_refresh_token(
+        data, expires_delta=timedelta(days=-1)
+    )
+    decoded = decode_token(expired_token)
+
+    assert decoded is None, "Expired refresh token should be decoded as None"
+
+
+def test_access_token_expiry_unchanged():
+    """アクセストークンの有効期限が30分のままであること（変更なし）"""
+    from jose import jwt
+
+    data = {"sub": "user_id_123", "role": "admin"}
+    before = datetime.now(timezone.utc)
+    token = create_access_token(data)
+
+    decoded = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+    exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
+
+    # expが発行時刻から30分後（±60秒の許容範囲）であること
+    expected_min = before + timedelta(minutes=30) - timedelta(seconds=60)
+    expected_max = before + timedelta(minutes=30) + timedelta(seconds=60)
+
+    assert expected_min <= exp <= expected_max, (
+        f"Access token exp should be ~30 minutes from now. "
+        f"Got {exp}, expected between {expected_min} and {expected_max}"
+    )


### PR DESCRIPTION
## 概要

**Intent Spec:** `.claude/specs/FEAT-0030-extend-login-session.yaml`

### なぜこの変更が必要か

現在リフレッシュトークンの有効期限が7日間であり、週次で再ログインが必要になるため利便性が低い。管理者・製造者ともにログイン状態を1ヶ月間保持し、再ログインを不要にする。

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | mypy (pre-existing errors のみ) |
| リンター | ✅ | ruff check パス |
| ユニットテスト | ✅ | 349件パス、カバレッジ: 85% (config.py) |
| 統合テスト | ✅ | 128件パス、2件スキップ |
| 仕様適合 | ✅ | AC: 5/5 カバー |
| AI意味レビュー | ✅ | /simplify 実行済み |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| AC-001: リフレッシュトークンが30日の有効期限で発行される | `tests/unit/test_security.py::test_refresh_token_expiry_is_30_days` | ✅ |
| AC-002: 管理者ログインで30日有効のリフレッシュトークンが返される | `tests/integration/test_auth_token_expiry.py::test_admin_login_returns_30_day_refresh_token` | ✅ |
| AC-003: 製造者ログインで30日有効のリフレッシュトークンが返される | `tests/integration/test_auth_token_expiry.py::test_manufacturer_login_returns_30_day_refresh_token` | ✅ |
| AC-004: リフレッシュトークンが有効な間、アクセストークンの再発行が可能 | `tests/integration/test_auth_token_expiry.py::test_refresh_endpoint_returns_new_30_day_token` | ✅ |
| AC-005: リフレッシュトークンが期限切れの場合、再ログインが必要 | `tests/unit/test_security.py::test_refresh_token_expired_after_30_days` | ✅ |

## レビューのポイント

- 変更は `REFRESH_TOKEN_EXPIRE_DAYS` のデフォルト値を `7` → `30` に変更するのみ
- `create_refresh_token()` は既に `settings.REFRESH_TOKEN_EXPIRE_DAYS` を参照しているため、管理者・製造者の両方に自動適用される
- 本番環境の `.env` で `REFRESH_TOKEN_EXPIRE_DAYS=7` が明示設定されている場合はデプロイ時に確認が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)