### PR TITLE
配送一覧に配送予定日を表示する

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -18,6 +18,8 @@ from app.models.order import Order, OrderItem  # noqa: F401
 from app.models.product import Product  # noqa: F401
 from app.models.shipment import Shipment, ShipmentItem  # noqa: F401
 from app.models.user import User  # noqa: F401
+from app.models.system_setting import SystemSetting  # noqa: F401
+from app.models.company_holiday import CompanyHoliday  # noqa: F401
 
 # Alembic Config object
 config = context.config

--- a/api/alembic/versions/add_estimated_shipping_date.py
+++ b/api/alembic/versions/add_estimated_shipping_date.py
@@ -1,0 +1,28 @@
+"""Add estimated_shipping_date column to shipments table.
+
+Revision ID: add_est_ship_date_001
+Revises: add_sys_settings_001
+Create Date: 2026-04-07
+
+Shipment作成時に計算した納品予定日を永続化する。
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "add_est_ship_date_001"
+down_revision = "add_sys_settings_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "shipments",
+        sa.Column("estimated_shipping_date", sa.Date(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("shipments", "estimated_shipping_date")

--- a/api/alembic/versions/add_expected_delivery_date.py
+++ b/api/alembic/versions/add_expected_delivery_date.py
@@ -1,0 +1,28 @@
+"""Add expected_delivery_date column to order_items table.
+
+Revision ID: add_exp_deliv_date_001
+Revises: add_est_ship_date_001
+Create Date: 2026-04-08
+
+注文明細ごとの納品予定日を永続化する。
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "add_exp_deliv_date_001"
+down_revision = "add_est_ship_date_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "order_items",
+        sa.Column("expected_delivery_date", sa.Date(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("order_items", "expected_delivery_date")

--- a/api/alembic/versions/add_expected_delivery_date.py
+++ b/api/alembic/versions/add_expected_delivery_date.py
@@ -22,6 +22,19 @@ def upgrade() -> None:
         "order_items",
         sa.Column("expected_delivery_date", sa.Date(), nullable=True),
     )
+    # 既存データのバックフィル: ordered_at + Product.lead_time_days
+    op.execute(
+        """
+        UPDATE order_items
+        SET expected_delivery_date = (
+            SELECT DATE(orders.ordered_at) + products.lead_time_days
+            FROM orders
+            JOIN products ON products.id = order_items.product_id
+            WHERE orders.id = order_items.order_id
+        )
+        WHERE expected_delivery_date IS NULL
+        """
+    )
 
 
 def downgrade() -> None:

--- a/api/alembic/versions/add_system_settings_and_company_holidays.py
+++ b/api/alembic/versions/add_system_settings_and_company_holidays.py
@@ -1,0 +1,55 @@
+"""Add system_settings and company_holidays tables.
+
+Revision ID: add_sys_settings_001
+Revises: cleanup_dev_transaction_data
+Create Date: 2026-03-27
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "add_sys_settings_001"
+down_revision = "cleanup_dev_transaction_data"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "system_settings",
+        sa.Column("id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("key", sa.String(100), nullable=False),
+        sa.Column("value", sa.Text(), nullable=False),
+        sa.Column("description", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("key"),
+    )
+    op.create_index(op.f("ix_system_settings_key"), "system_settings", ["key"], unique=True)
+
+    op.create_table(
+        "company_holidays",
+        sa.Column("id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("date"),
+    )
+    op.create_index(op.f("ix_company_holidays_date"), "company_holidays", ["date"], unique=True)
+
+    # Insert default shipping preparation days
+    op.execute(
+        "INSERT INTO system_settings (id, key, value, description, created_at, updated_at) "
+        "VALUES (gen_random_uuid(), 'shipping_preparation_days', '5', '発送準備日数', now(), now())"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_company_holidays_date"), table_name="company_holidays")
+    op.drop_table("company_holidays")
+    op.drop_index(op.f("ix_system_settings_key"), table_name="system_settings")
+    op.drop_table("system_settings")

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -11,11 +11,13 @@ from app.database import get_db
 from app.models.manufacturer import Manufacturer
 from app.models.user import User, UserRole
 from app.repositories.chat_repository import ChatRepository
+from app.repositories.company_holiday_repository import CompanyHolidayRepository
 from app.repositories.manufacturer_repository import ManufacturerRepository
 from app.repositories.order_repository import OrderRepository
 from app.repositories.order_source_repository import OrderSourceRepository
 from app.repositories.product_repository import ProductRepository
 from app.repositories.shipment_repository import ShipmentRepository
+from app.repositories.system_setting_repository import SystemSettingRepository
 from app.repositories.user_repository import UserRepository
 from app.services.auth_service import AuthService
 from app.services.chat_service import ChatService
@@ -30,6 +32,7 @@ from app.services.order_list_service import OrderListService
 from app.services.order_service import OrderService
 from app.services.product_service import ProductService
 from app.services.email_service import EmailService
+from app.services.settings_service import SettingsService
 from app.services.shipment_service import ShipmentService
 from app.utils.exceptions import ForbiddenError, UnauthorizedError
 from app.utils.file_storage import FileStorage, LocalFileStorage
@@ -91,6 +94,20 @@ def get_order_source_repository(
 ) -> OrderSourceRepository:
     """Get order source repository."""
     return OrderSourceRepository(db)
+
+
+def get_system_setting_repository(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SystemSettingRepository:
+    """Get system setting repository."""
+    return SystemSettingRepository(db)
+
+
+def get_company_holiday_repository(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> CompanyHolidayRepository:
+    """Get company holiday repository."""
+    return CompanyHolidayRepository(db)
 
 
 # Service dependencies
@@ -211,6 +228,14 @@ def get_invoice_service(
 ) -> InvoiceService:
     """Get invoice service."""
     return InvoiceService(manufacturer_repo, order_repo)
+
+
+def get_settings_service(
+    system_setting_repo: Annotated[SystemSettingRepository, Depends(get_system_setting_repository)],
+    company_holiday_repo: Annotated[CompanyHolidayRepository, Depends(get_company_holiday_repository)],
+) -> SettingsService:
+    """Get settings service."""
+    return SettingsService(system_setting_repo, company_holiday_repo)
 
 
 # File storage dependency

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -160,10 +160,11 @@ def get_shipment_service(
     file_storage: Annotated[FileStorage, Depends(lambda: LocalFileStorage(settings.UPLOAD_DIR))],
     order_source_repo: Annotated[OrderSourceRepository, Depends(get_order_source_repository)],
     email_service: Annotated[EmailService | None, Depends(get_email_service)],
+    settings_service: Annotated[SettingsService, Depends(get_settings_service)],
 ) -> ShipmentService:
     """Get shipment service."""
     return ShipmentService(
-        shipment_repo, order_repo, file_storage, order_source_repo, email_service
+        shipment_repo, order_repo, file_storage, order_source_repo, email_service, settings_service
     )
 
 

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -154,6 +154,14 @@ def get_email_service() -> EmailService | None:
     )
 
 
+def get_settings_service(
+    system_setting_repo: Annotated[SystemSettingRepository, Depends(get_system_setting_repository)],
+    company_holiday_repo: Annotated[CompanyHolidayRepository, Depends(get_company_holiday_repository)],
+) -> SettingsService:
+    """Get settings service."""
+    return SettingsService(system_setting_repo, company_holiday_repo)
+
+
 def get_shipment_service(
     shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
     order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
@@ -229,14 +237,6 @@ def get_invoice_service(
 ) -> InvoiceService:
     """Get invoice service."""
     return InvoiceService(manufacturer_repo, order_repo)
-
-
-def get_settings_service(
-    system_setting_repo: Annotated[SystemSettingRepository, Depends(get_system_setting_repository)],
-    company_holiday_repo: Annotated[CompanyHolidayRepository, Depends(get_company_holiday_repository)],
-) -> SettingsService:
-    """Get settings service."""
-    return SettingsService(system_setting_repo, company_holiday_repo)
 
 
 # File storage dependency

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -133,16 +133,6 @@ def get_manufacturer_service(
     return ManufacturerService(manufacturer_repo)
 
 
-def get_order_service(
-    order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
-    product_repo: Annotated[ProductRepository, Depends(get_product_repository)],
-    shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
-    order_source_repo: Annotated[OrderSourceRepository, Depends(get_order_source_repository)],
-) -> OrderService:
-    """Get order service."""
-    return OrderService(order_repo, product_repo, shipment_repo, order_source_repo)
-
-
 def get_email_service() -> EmailService | None:
     """Get email service (None if SendGrid not configured)."""
     if not settings.SENDGRID_API_KEY:
@@ -160,6 +150,17 @@ def get_settings_service(
 ) -> SettingsService:
     """Get settings service."""
     return SettingsService(system_setting_repo, company_holiday_repo)
+
+
+def get_order_service(
+    order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
+    product_repo: Annotated[ProductRepository, Depends(get_product_repository)],
+    shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
+    order_source_repo: Annotated[OrderSourceRepository, Depends(get_order_source_repository)],
+    settings_service: Annotated[SettingsService, Depends(get_settings_service)],
+) -> OrderService:
+    """Get order service."""
+    return OrderService(order_repo, product_repo, shipment_repo, order_source_repo, settings_service)
 
 
 def get_shipment_service(
@@ -204,9 +205,10 @@ def get_manufacturer_order_service(
     order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
     manufacturer_repo: Annotated[ManufacturerRepository, Depends(get_manufacturer_repository)],
     shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
+    settings_service: Annotated[SettingsService, Depends(get_settings_service)],
 ) -> ManufacturerOrderService:
     """Get manufacturer order service."""
-    return ManufacturerOrderService(order_repo, manufacturer_repo, shipment_repo)
+    return ManufacturerOrderService(order_repo, manufacturer_repo, shipment_repo, settings_service)
 
 
 def get_manufacturer_portal_service(

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -14,6 +14,7 @@ from app.routers import (
     manufacturers,
     orders,
     products,
+    settings as settings_router,
     shipments,
 )
 from app.utils.exceptions import AppException
@@ -76,6 +77,7 @@ app.include_router(shipments.router, prefix=settings.API_V1_PREFIX)
 app.include_router(chat.router, prefix=settings.API_V1_PREFIX)
 app.include_router(dashboard.router, prefix=settings.API_V1_PREFIX)
 app.include_router(external.router, prefix=settings.API_V1_PREFIX)
+app.include_router(settings_router.router, prefix=settings.API_V1_PREFIX)
 
 
 # Test endpoints for exception handling (only in debug mode)

--- a/api/app/models/company_holiday.py
+++ b/api/app/models/company_holiday.py
@@ -1,0 +1,20 @@
+"""Company holiday model."""
+
+from datetime import date as date_type
+
+from sqlalchemy import Date, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class CompanyHoliday(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    """Company holiday model - TOSYO独自休日."""
+
+    __tablename__ = "company_holidays"
+
+    date: Mapped[date_type] = mapped_column(Date, unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(100))
+
+    def __repr__(self) -> str:
+        return f"<CompanyHoliday(date={self.date}, name={self.name})>"

--- a/api/app/models/order.py
+++ b/api/app/models/order.py
@@ -1,10 +1,10 @@
 """Order model."""
 
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, CustomerAddressMixin, TimestampMixin, UUIDPrimaryKeyMixin
@@ -194,6 +194,7 @@ class OrderItem(Base, UUIDPrimaryKeyMixin, TimestampMixin):
     color: Mapped[str | None] = mapped_column(String(50), nullable=True)
     design_image_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     thumbnail_image_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    expected_delivery_date: Mapped[date | None] = mapped_column(Date, nullable=True)
 
     # Relationships
     order: Mapped["Order"] = relationship(back_populates="items")

--- a/api/app/models/shipment.py
+++ b/api/app/models/shipment.py
@@ -1,10 +1,10 @@
 """Shipment models."""
 
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
@@ -38,6 +38,7 @@ class Shipment(Base, UUIDPrimaryKeyMixin, TimestampMixin):
     shipped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    estimated_shipping_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     shipping_email_sent: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false"
     )

--- a/api/app/models/system_setting.py
+++ b/api/app/models/system_setting.py
@@ -1,0 +1,19 @@
+"""System setting model."""
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class SystemSetting(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    """System setting model - key/value store for application settings."""
+
+    __tablename__ = "system_settings"
+
+    key: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    value: Mapped[str] = mapped_column(Text)
+    description: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<SystemSetting(key={self.key}, value={self.value})>"

--- a/api/app/repositories/company_holiday_repository.py
+++ b/api/app/repositories/company_holiday_repository.py
@@ -35,9 +35,16 @@ class CompanyHolidayRepository:
 
     async def create(self, holiday_date: date, name: str) -> CompanyHoliday:
         """Create a new company holiday."""
+        from sqlalchemy.exc import IntegrityError
+        from app.utils.exceptions import ValidationError
+
         holiday = CompanyHoliday(date=holiday_date, name=name)
         self._db.add(holiday)
-        await self._db.flush()
+        try:
+            await self._db.flush()
+        except IntegrityError:
+            await self._db.rollback()
+            raise ValidationError(f"休日 {holiday_date} は既に登録されています")
         await self._db.refresh(holiday)
         return holiday
 

--- a/api/app/repositories/company_holiday_repository.py
+++ b/api/app/repositories/company_holiday_repository.py
@@ -1,0 +1,51 @@
+"""Company holiday repository for database operations."""
+
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.company_holiday import CompanyHoliday
+
+
+class CompanyHolidayRepository:
+    """Repository for CompanyHoliday model."""
+
+    def __init__(self, db: AsyncSession):
+        self._db = db
+
+    async def find_all(self) -> list[CompanyHoliday]:
+        """Get all company holidays ordered by date."""
+        result = await self._db.execute(
+            select(CompanyHoliday).order_by(CompanyHoliday.date.asc())
+        )
+        return list(result.scalars().all())
+
+    async def find_all_dates(self) -> set[date]:
+        """Get all company holiday dates as a set (for business day calculation)."""
+        holidays = await self.find_all()
+        return {h.date for h in holidays}
+
+    async def find_by_id(self, holiday_id: str) -> CompanyHoliday | None:
+        """Find a company holiday by ID."""
+        result = await self._db.execute(
+            select(CompanyHoliday).where(CompanyHoliday.id == holiday_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def create(self, holiday_date: date, name: str) -> CompanyHoliday:
+        """Create a new company holiday."""
+        holiday = CompanyHoliday(date=holiday_date, name=name)
+        self._db.add(holiday)
+        await self._db.flush()
+        await self._db.refresh(holiday)
+        return holiday
+
+    async def delete(self, holiday_id: str) -> bool:
+        """Delete a company holiday. Returns True if deleted."""
+        holiday = await self.find_by_id(holiday_id)
+        if not holiday:
+            return False
+        await self._db.delete(holiday)
+        await self._db.flush()
+        return True

--- a/api/app/repositories/order_repository.py
+++ b/api/app/repositories/order_repository.py
@@ -257,7 +257,6 @@ class OrderRepository:
             受注明細のタプルリスト（OrderItem, order_number, ordered_at, customer_name, cost, item_status, order_status, lead_time_days）
         """
         from app.models.product import Product
-        from app.models.manufacturer import Manufacturer
 
         query = (
             select(
@@ -268,11 +267,10 @@ class OrderRepository:
                 Product.cost,
                 OrderItem.status,  # item_status
                 Order.status,  # order_status（後方互換性のため）
-                Manufacturer.lead_time_days,
+                Product.lead_time_days,
             )
             .join(Order, OrderItem.order_id == Order.id)
             .join(Product, OrderItem.product_id == Product.id)
-            .join(Manufacturer, Product.manufacturer_id == Manufacturer.id)
             .where(Product.manufacturer_id == manufacturer_id)
         )
 
@@ -299,15 +297,15 @@ class OrderRepository:
             )
             query = query.where(search_filter)
 
-        # 納品予定日フィルター（ordered_at + lead_time_days）
+        # 納品予定日フィルター
         if expected_delivery_from:
             query = query.where(
-                func.date(Order.ordered_at) + Manufacturer.lead_time_days >= expected_delivery_from
+                OrderItem.expected_delivery_date >= expected_delivery_from
             )
 
         if expected_delivery_to:
             query = query.where(
-                func.date(Order.ordered_at) + Manufacturer.lead_time_days <= expected_delivery_to
+                OrderItem.expected_delivery_date <= expected_delivery_to
             )
 
         query = query.order_by(Order.ordered_at.desc())
@@ -354,7 +352,7 @@ class OrderRepository:
                 Order.status,
                 Manufacturer.id.label("manufacturer_id"),
                 Manufacturer.name.label("manufacturer_name"),
-                Manufacturer.lead_time_days,
+                Product.lead_time_days,
             )
             .join(Order, OrderItem.order_id == Order.id)
             .join(Product, OrderItem.product_id == Product.id)
@@ -391,15 +389,15 @@ class OrderRepository:
             )
             query = query.where(search_filter)
 
-        # 納品予定日フィルター（ordered_at + lead_time_days）
+        # 納品予定日フィルター
         if expected_delivery_from:
             query = query.where(
-                func.date(Order.ordered_at) + Manufacturer.lead_time_days >= expected_delivery_from
+                OrderItem.expected_delivery_date >= expected_delivery_from
             )
 
         if expected_delivery_to:
             query = query.where(
-                func.date(Order.ordered_at) + Manufacturer.lead_time_days <= expected_delivery_to
+                OrderItem.expected_delivery_date <= expected_delivery_to
             )
 
         query = query.order_by(Order.ordered_at.desc())

--- a/api/app/repositories/order_repository.py
+++ b/api/app/repositories/order_repository.py
@@ -585,7 +585,7 @@ class OrderRepository:
         query = (
             select(Order)
             .options(
-                selectinload(Order.items),
+                selectinload(Order.items).selectinload(OrderItem.product),
                 selectinload(Order.order_source),
             )
             .where(*base_conditions)

--- a/api/app/repositories/shipment_repository.py
+++ b/api/app/repositories/shipment_repository.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.order import Order, OrderItem
+from app.models.product import Product
 from app.models.shipment import Shipment, ShipmentItem, ShipmentStatus
 
 
@@ -23,7 +24,8 @@ class ShipmentRepository:
             .options(
                 selectinload(Shipment.items)
                 .selectinload(ShipmentItem.order)
-                .selectinload(Order.items),
+                .selectinload(Order.items)
+                .selectinload(OrderItem.product),
                 selectinload(Shipment.items)
                 .selectinload(ShipmentItem.order)
                 .selectinload(Order.order_source),
@@ -39,7 +41,8 @@ class ShipmentRepository:
             .options(
                 selectinload(Shipment.items)
                 .selectinload(ShipmentItem.order)
-                .selectinload(Order.items),
+                .selectinload(Order.items)
+                .selectinload(OrderItem.product),
                 selectinload(Shipment.items)
                 .selectinload(ShipmentItem.order)
                 .selectinload(Order.order_source),
@@ -70,6 +73,7 @@ class ShipmentRepository:
             selectinload(Shipment.items)
             .selectinload(ShipmentItem.order)
             .selectinload(Order.items)
+            .selectinload(OrderItem.product),
         )
         count_query = select(func.count(Shipment.id))
 

--- a/api/app/repositories/shipment_repository.py
+++ b/api/app/repositories/shipment_repository.py
@@ -150,12 +150,16 @@ class ShipmentRepository:
 
         return shipments, total
 
-    async def create(self, order_ids: list[str]) -> Shipment:
+    async def create(
+        self,
+        order_ids: list[str],
+        estimated_shipping_date: date | None = None,
+    ) -> Shipment:
         """Create a new shipment.
 
         顧客情報は order_ids の最初の注文から参照します。
         """
-        shipment = Shipment()
+        shipment = Shipment(estimated_shipping_date=estimated_shipping_date)
         self._db.add(shipment)
         await self._db.flush()
 

--- a/api/app/repositories/system_setting_repository.py
+++ b/api/app/repositories/system_setting_repository.py
@@ -1,0 +1,34 @@
+"""System setting repository for database operations."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.system_setting import SystemSetting
+
+
+class SystemSettingRepository:
+    """Repository for SystemSetting model."""
+
+    def __init__(self, db: AsyncSession):
+        self._db = db
+
+    async def get_by_key(self, key: str) -> SystemSetting | None:
+        """Get a setting by key."""
+        result = await self._db.execute(
+            select(SystemSetting).where(SystemSetting.key == key)
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert(self, key: str, value: str, description: str | None = None) -> SystemSetting:
+        """Create or update a setting."""
+        setting = await self.get_by_key(key)
+        if setting:
+            setting.value = value
+            if description is not None:
+                setting.description = description
+        else:
+            setting = SystemSetting(key=key, value=value, description=description)
+            self._db.add(setting)
+        await self._db.flush()
+        await self._db.refresh(setting)
+        return setting

--- a/api/app/routers/settings.py
+++ b/api/app/routers/settings.py
@@ -1,0 +1,66 @@
+"""Settings router."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from app.dependencies import get_current_admin, get_settings_service
+from app.models.user import User
+from app.schemas.settings import (
+    CompanyHolidayCreate,
+    CompanyHolidayListResponse,
+    CompanyHolidayResponse,
+    ShippingPreparationDaysResponse,
+    ShippingPreparationDaysUpdate,
+)
+from app.services.settings_service import SettingsService
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+@router.get("/shipping-preparation-days", response_model=ShippingPreparationDaysResponse)
+async def get_shipping_preparation_days(
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ShippingPreparationDaysResponse:
+    """発送準備日数を取得."""
+    return await service.get_shipping_preparation_days()
+
+
+@router.put("/shipping-preparation-days", response_model=ShippingPreparationDaysResponse)
+async def update_shipping_preparation_days(
+    data: ShippingPreparationDaysUpdate,
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ShippingPreparationDaysResponse:
+    """発送準備日数を更新."""
+    return await service.update_shipping_preparation_days(data)
+
+
+@router.get("/company-holidays", response_model=CompanyHolidayListResponse)
+async def get_company_holidays(
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> CompanyHolidayListResponse:
+    """独自休日一覧を取得."""
+    return await service.get_company_holidays()
+
+
+@router.post("/company-holidays", response_model=CompanyHolidayResponse, status_code=201)
+async def create_company_holiday(
+    data: CompanyHolidayCreate,
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> CompanyHolidayResponse:
+    """独自休日を追加."""
+    return await service.create_company_holiday(data)
+
+
+@router.delete("/company-holidays/{holiday_id}", status_code=204)
+async def delete_company_holiday(
+    holiday_id: str,
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> None:
+    """独自休日を削除."""
+    await service.delete_company_holiday(holiday_id)

--- a/api/app/schemas/order.py
+++ b/api/app/schemas/order.py
@@ -1,6 +1,6 @@
 """Order schemas."""
 
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, computed_field
 
@@ -66,6 +66,7 @@ class OrderItemResponse(BaseModel):
     color: str | None = None
     design_image_url: str | None = None
     thumbnail_image_url: str | None = None
+    expected_delivery_date: date | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/api/app/schemas/settings.py
+++ b/api/app/schemas/settings.py
@@ -1,0 +1,41 @@
+"""Settings schemas."""
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ShippingPreparationDaysResponse(BaseModel):
+    """Response for shipping preparation days setting."""
+
+    value: int
+    description: str | None = None
+
+
+class ShippingPreparationDaysUpdate(BaseModel):
+    """Request to update shipping preparation days."""
+
+    value: int = Field(..., ge=0, le=30, description="発送準備日数（0〜30日）")
+
+
+class CompanyHolidayResponse(BaseModel):
+    """Response for a company holiday."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    date: date
+    name: str
+
+
+class CompanyHolidayCreate(BaseModel):
+    """Request to create a company holiday."""
+
+    date: date
+    name: str = Field(..., min_length=1, max_length=100)
+
+
+class CompanyHolidayListResponse(BaseModel):
+    """Response for company holiday list."""
+
+    items: list[CompanyHolidayResponse]

--- a/api/app/schemas/shipment.py
+++ b/api/app/schemas/shipment.py
@@ -1,6 +1,6 @@
 """Shipment schemas."""
 
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import Literal, Union
 
@@ -47,6 +47,7 @@ class PendingOrderResponse(BaseModel):
     status: PendingOrderStatus
     created_at: datetime
     order_items: list[OrderItemSummary] = []
+    estimated_shipping_date: date | None = None
 
 
 class ShipmentCreate(BaseModel):
@@ -117,6 +118,7 @@ class ShipmentResponse(BaseModel):
     items: list[ShipmentItemResponse]
     created_at: datetime
     updated_at: datetime
+    estimated_shipping_date: date | None = None
 
     @computed_field
     @property

--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -19,6 +19,7 @@ from app.schemas.manufacturer import (
     AllManufacturerOrderItemResponse,
     AllManufacturerOrderItemListResponse,
 )
+from app.utils.business_day_calculator import add_business_days
 from app.utils.exceptions import NotFoundError, NoOrderedItemsError
 from app.utils.order_list_generator import OrderListGenerator, get_product_type_name
 from app.utils.stand_file_config import get_stand_file_path
@@ -277,7 +278,7 @@ class ManufacturerOrderService:
 
         return len(updated_items), shipments_created
 
-    async def _create_shipment_for_order(self, order) -> bool:
+    async def _create_shipment_for_order(self, order: Order) -> bool:
         """Create a shipment for the delivered order.
 
         This method is idempotent - if a shipment already exists for the order,
@@ -296,13 +297,10 @@ class ManufacturerOrderService:
         )
         return True
 
-    async def _calculate_estimated_shipping_date(self, order) -> "date | None":
+    async def _calculate_estimated_shipping_date(self, order: Order) -> date | None:
         """注文の納品予定日を計算する."""
         if not self._settings_service:
             return None
-
-        from datetime import date, timedelta
-        from app.utils.business_day_calculator import add_business_days
 
         prep_days = await self._settings_service.get_shipping_preparation_days_value()
         company_holidays = await self._settings_service.get_company_holiday_dates()

--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -1,7 +1,7 @@
 """Manufacturer order service for managing orders by manufacturer."""
 
 import os
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from urllib.parse import urlparse
 
 import httpx
@@ -119,9 +119,6 @@ class ManufacturerOrderService:
         total_amount = 0
 
         for order_item, order_number, ordered_at, customer_name, cost, item_status, order_status, lead_time_days in rows:
-            # 納品予定日を計算
-            expected_delivery_date = ordered_at.date() + timedelta(days=lead_time_days)
-
             items.append(
                 ManufacturerOrderItemResponse(
                     id=order_item.id,
@@ -143,7 +140,7 @@ class ManufacturerOrderService:
                     status=item_status,  # OrderItem.statusを使用
                     item_status=item_status,  # 新フィールド
                     lead_time_days=lead_time_days,
-                    expected_delivery_date=expected_delivery_date,
+                    expected_delivery_date=order_item.expected_delivery_date,
                 )
             )
             total_quantity += order_item.quantity
@@ -197,9 +194,6 @@ class ManufacturerOrderService:
         total_amount = 0
 
         for order_item, order_number, ordered_at, customer_name, cost, order_status, mfr_id, mfr_name, lead_time_days in rows:
-            # 納品予定日を計算
-            expected_delivery_date = ordered_at.date() + timedelta(days=lead_time_days)
-
             items.append(
                 AllManufacturerOrderItemResponse(
                     id=order_item.id,
@@ -222,7 +216,7 @@ class ManufacturerOrderService:
                     manufacturer_id=mfr_id,
                     manufacturer_name=mfr_name,
                     lead_time_days=lead_time_days,
-                    expected_delivery_date=expected_delivery_date,
+                    expected_delivery_date=order_item.expected_delivery_date,
                 )
             )
             total_quantity += order_item.quantity
@@ -298,7 +292,7 @@ class ManufacturerOrderService:
         return True
 
     async def _calculate_estimated_shipping_date(self, order: Order) -> date | None:
-        """注文の納品予定日を計算する."""
+        """配送予定日を計算する。OrderItemの納品予定日から算出."""
         if not self._settings_service:
             return None
 
@@ -308,10 +302,8 @@ class ManufacturerOrderService:
         delivery_dates: list[date] = []
         if order.items:
             for order_item in order.items:
-                product = order_item.product if order_item.product else None
-                if product and product.lead_time_days is not None:
-                    d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
-                    delivery_dates.append(d)
+                if order_item.expected_delivery_date is not None:
+                    delivery_dates.append(order_item.expected_delivery_date)
 
         if not delivery_dates:
             return None

--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -33,10 +33,12 @@ class ManufacturerOrderService:
         order_repo: OrderRepository,
         manufacturer_repo: ManufacturerRepository,
         shipment_repo: ShipmentRepository,
+        settings_service: "SettingsService | None" = None,
     ):
         self._order_repo = order_repo
         self._manufacturer_repo = manufacturer_repo
         self._shipment_repo = shipment_repo
+        self._settings_service = settings_service
         self._order_list_gen = OrderListGenerator()
 
     async def get_order_summary_list(
@@ -275,7 +277,7 @@ class ManufacturerOrderService:
 
         return len(updated_items), shipments_created
 
-    async def _create_shipment_for_order(self, order: Order) -> bool:
+    async def _create_shipment_for_order(self, order) -> bool:
         """Create a shipment for the delivered order.
 
         This method is idempotent - if a shipment already exists for the order,
@@ -284,13 +286,40 @@ class ManufacturerOrderService:
         Returns:
             bool: True if a shipment was created, False if it already existed
         """
-        # Check if shipment already exists (prevent duplicates)
         if await self._shipment_repo.exists_for_order(order.id):
             return False
 
-        # Customer info is now accessed via shipment.first_order relationship
-        await self._shipment_repo.create(order_ids=[order.id])
+        estimated_date = await self._calculate_estimated_shipping_date(order)
+        await self._shipment_repo.create(
+            order_ids=[order.id],
+            estimated_shipping_date=estimated_date,
+        )
         return True
+
+    async def _calculate_estimated_shipping_date(self, order) -> "date | None":
+        """注文の納品予定日を計算する."""
+        if not self._settings_service:
+            return None
+
+        from datetime import date, timedelta
+        from app.utils.business_day_calculator import add_business_days
+
+        prep_days = await self._settings_service.get_shipping_preparation_days_value()
+        company_holidays = await self._settings_service.get_company_holiday_dates()
+
+        delivery_dates: list[date] = []
+        if order.items:
+            for order_item in order.items:
+                product = order_item.product if order_item.product else None
+                if product and product.lead_time_days is not None:
+                    d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
+                    delivery_dates.append(d)
+
+        if not delivery_dates:
+            return None
+
+        latest_delivery = max(delivery_dates)
+        return add_business_days(latest_delivery, prep_days, company_holidays)
 
     # Product type -> manufacturing data extension mapping
     _MANUFACTURING_EXT: dict[str, str] = {

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -7,7 +7,7 @@ import csv
 import io
 import logging
 import mimetypes
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from urllib.parse import urlparse
 
 import httpx
@@ -120,10 +120,17 @@ class OrderService:
             total_price=total_price,
         )
 
+        # Fetch company holidays for business day calculation
+        company_holidays: set[date] = set()
+        if self._settings_service:
+            company_holidays = await self._settings_service.get_company_holiday_dates()
+
         # Create order items
         for idx, item_data in enumerate(data.items):
             product = products[idx]
-            expected_delivery_date = data.ordered_at.date() + timedelta(days=product.lead_time_days)
+            expected_delivery_date = add_business_days(
+                data.ordered_at.date(), product.lead_time_days, company_holidays
+            )
             order_item = OrderItem(
                 uid=item_data.uid,
                 product_id=product.id,

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -88,7 +88,7 @@ class OrderService:
             raise DuplicateError("Order", "order_number", data.order_number)
 
         # Validate items and find product_ids
-        product_ids: dict[int, str] = {}  # index -> product_id
+        products: dict[int, "Product"] = {}  # index -> product
         for idx, item_data in enumerate(data.items):
             # Validate attributes based on product_type
             self._validate_item_attributes(item_data)
@@ -99,7 +99,7 @@ class OrderService:
             )
             if not product:
                 raise ProductNotFoundError(item_data.product_type.value)
-            product_ids[idx] = product.id
+            products[idx] = product
 
         # Calculate total price
         total_price = sum(item.price * item.quantity for item in data.items)
@@ -122,9 +122,11 @@ class OrderService:
 
         # Create order items
         for idx, item_data in enumerate(data.items):
+            product = products[idx]
+            expected_delivery_date = data.ordered_at.date() + timedelta(days=product.lead_time_days)
             order_item = OrderItem(
                 uid=item_data.uid,
-                product_id=product_ids[idx],
+                product_id=product.id,
                 product_name=item_data.product_name,
                 product_type=item_data.product_type.value,
                 price=item_data.price,
@@ -134,6 +136,7 @@ class OrderService:
                 color=item_data.color,
                 design_image_url=item_data.design_image_url,
                 thumbnail_image_url=item_data.thumbnail_image_url,
+                expected_delivery_date=expected_delivery_date,
             )
             order.items.append(order_item)
 
@@ -324,6 +327,7 @@ class OrderService:
                 color=item.color,
                 design_image_url=item.design_image_url,
                 thumbnail_image_url=item.thumbnail_image_url,
+                expected_delivery_date=item.expected_delivery_date,
                 created_at=item.created_at,
                 updated_at=item.updated_at,
             )

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -272,7 +272,7 @@ class OrderService:
         )
 
     async def _calculate_estimated_shipping_date(self, order: Order) -> date | None:
-        """注文の納品予定日を計算する."""
+        """配送予定日を計算する。OrderItemの納品予定日から算出."""
         if not self._settings_service:
             return None
 
@@ -282,10 +282,8 @@ class OrderService:
         delivery_dates: list[date] = []
         if order.items:
             for order_item in order.items:
-                product = order_item.product if order_item.product else None
-                if product and product.lead_time_days is not None:
-                    d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
-                    delivery_dates.append(d)
+                if order_item.expected_delivery_date is not None:
+                    delivery_dates.append(order_item.expected_delivery_date)
 
         if not delivery_dates:
             return None

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -7,7 +7,7 @@ import csv
 import io
 import logging
 import mimetypes
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from urllib.parse import urlparse
 
 import httpx
@@ -33,6 +33,7 @@ from app.repositories.order_repository import OrderRepository
 from app.repositories.order_source_repository import OrderSourceRepository
 from app.repositories.product_repository import ProductRepository
 from app.repositories.shipment_repository import ShipmentRepository
+from app.utils.business_day_calculator import add_business_days
 from app.utils.zip_builder import ZipBuilder
 from app.models.shipment import Shipment
 from app.schemas.order import (
@@ -267,13 +268,10 @@ class OrderService:
             estimated_shipping_date=estimated_date,
         )
 
-    async def _calculate_estimated_shipping_date(self, order) -> "date | None":
+    async def _calculate_estimated_shipping_date(self, order: Order) -> date | None:
         """注文の納品予定日を計算する."""
         if not self._settings_service:
             return None
-
-        from datetime import date, timedelta
-        from app.utils.business_day_calculator import add_business_days
 
         prep_days = await self._settings_service.get_shipping_preparation_days_value()
         company_holidays = await self._settings_service.get_company_holiday_dates()

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -67,11 +67,13 @@ class OrderService:
         product_repo: ProductRepository,
         shipment_repo: ShipmentRepository,
         order_source_repo: OrderSourceRepository | None = None,
+        settings_service: "SettingsService | None" = None,
     ):
         self._order_repo = order_repo
         self._product_repo = product_repo
         self._shipment_repo = shipment_repo
         self._order_source_repo = order_source_repo
+        self._settings_service = settings_service
 
     async def create(
         self,
@@ -255,19 +257,40 @@ class OrderService:
         the same transaction as the order status update, ensuring atomicity.
 
         顧客情報は Shipment から Order のリレーションを経由して取得します。
-
-        Args:
-            order: The order that was just marked as delivered.
-
-        Raises:
-            Exception: If shipment creation fails, the entire transaction
-                       (including order status update) will be rolled back.
         """
-        # Check if shipment already exists (prevent duplicates)
         if await self._shipment_repo.exists_for_order(order.id):
             return
 
-        await self._shipment_repo.create(order_ids=[order.id])
+        estimated_date = await self._calculate_estimated_shipping_date(order)
+        await self._shipment_repo.create(
+            order_ids=[order.id],
+            estimated_shipping_date=estimated_date,
+        )
+
+    async def _calculate_estimated_shipping_date(self, order) -> "date | None":
+        """注文の納品予定日を計算する."""
+        if not self._settings_service:
+            return None
+
+        from datetime import date, timedelta
+        from app.utils.business_day_calculator import add_business_days
+
+        prep_days = await self._settings_service.get_shipping_preparation_days_value()
+        company_holidays = await self._settings_service.get_company_holiday_dates()
+
+        delivery_dates: list[date] = []
+        if order.items:
+            for order_item in order.items:
+                product = order_item.product if order_item.product else None
+                if product and product.lead_time_days is not None:
+                    d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
+                    delivery_dates.append(d)
+
+        if not delivery_dates:
+            return None
+
+        latest_delivery = max(delivery_dates)
+        return add_business_days(latest_delivery, prep_days, company_holidays)
 
     async def _to_response(
         self, order: Order, shipment: Shipment | None = None

--- a/api/app/services/settings_service.py
+++ b/api/app/services/settings_service.py
@@ -32,8 +32,12 @@ class SettingsService:
         """Get shipping preparation days setting."""
         setting = await self._system_setting_repo.get_by_key(SHIPPING_PREPARATION_DAYS_KEY)
         if setting:
+            try:
+                value = int(setting.value)
+            except (ValueError, TypeError):
+                value = SHIPPING_PREPARATION_DAYS_DEFAULT
             return ShippingPreparationDaysResponse(
-                value=int(setting.value),
+                value=value,
                 description=setting.description,
             )
         return ShippingPreparationDaysResponse(
@@ -59,7 +63,11 @@ class SettingsService:
         """Get shipping preparation days as integer (for internal use)."""
         setting = await self._system_setting_repo.get_by_key(SHIPPING_PREPARATION_DAYS_KEY)
         if setting:
-            return int(setting.value)
+            try:
+                value = int(setting.value)
+            except (ValueError, TypeError):
+                value = SHIPPING_PREPARATION_DAYS_DEFAULT
+            return value
         return SHIPPING_PREPARATION_DAYS_DEFAULT
 
     async def get_company_holidays(self) -> CompanyHolidayListResponse:

--- a/api/app/services/settings_service.py
+++ b/api/app/services/settings_service.py
@@ -1,0 +1,92 @@
+"""Settings service."""
+
+from datetime import date
+
+from app.repositories.company_holiday_repository import CompanyHolidayRepository
+from app.repositories.system_setting_repository import SystemSettingRepository
+from app.schemas.settings import (
+    CompanyHolidayCreate,
+    CompanyHolidayListResponse,
+    CompanyHolidayResponse,
+    ShippingPreparationDaysResponse,
+    ShippingPreparationDaysUpdate,
+)
+from app.utils.exceptions import NotFoundError
+
+SHIPPING_PREPARATION_DAYS_KEY = "shipping_preparation_days"
+SHIPPING_PREPARATION_DAYS_DEFAULT = 5
+
+
+class SettingsService:
+    """Service for settings operations."""
+
+    def __init__(
+        self,
+        system_setting_repo: SystemSettingRepository,
+        company_holiday_repo: CompanyHolidayRepository,
+    ):
+        self._system_setting_repo = system_setting_repo
+        self._company_holiday_repo = company_holiday_repo
+
+    async def get_shipping_preparation_days(self) -> ShippingPreparationDaysResponse:
+        """Get shipping preparation days setting."""
+        setting = await self._system_setting_repo.get_by_key(SHIPPING_PREPARATION_DAYS_KEY)
+        if setting:
+            return ShippingPreparationDaysResponse(
+                value=int(setting.value),
+                description=setting.description,
+            )
+        return ShippingPreparationDaysResponse(
+            value=SHIPPING_PREPARATION_DAYS_DEFAULT,
+            description="発送準備日数",
+        )
+
+    async def update_shipping_preparation_days(
+        self, data: ShippingPreparationDaysUpdate
+    ) -> ShippingPreparationDaysResponse:
+        """Update shipping preparation days setting."""
+        setting = await self._system_setting_repo.upsert(
+            key=SHIPPING_PREPARATION_DAYS_KEY,
+            value=str(data.value),
+            description="発送準備日数",
+        )
+        return ShippingPreparationDaysResponse(
+            value=int(setting.value),
+            description=setting.description,
+        )
+
+    async def get_shipping_preparation_days_value(self) -> int:
+        """Get shipping preparation days as integer (for internal use)."""
+        setting = await self._system_setting_repo.get_by_key(SHIPPING_PREPARATION_DAYS_KEY)
+        if setting:
+            return int(setting.value)
+        return SHIPPING_PREPARATION_DAYS_DEFAULT
+
+    async def get_company_holidays(self) -> CompanyHolidayListResponse:
+        """Get all company holidays."""
+        holidays = await self._company_holiday_repo.find_all()
+        return CompanyHolidayListResponse(
+            items=[
+                CompanyHolidayResponse(id=h.id, date=h.date, name=h.name)
+                for h in holidays
+            ]
+        )
+
+    async def get_company_holiday_dates(self) -> set[date]:
+        """Get all company holiday dates as set (for business day calculation)."""
+        return await self._company_holiday_repo.find_all_dates()
+
+    async def create_company_holiday(
+        self, data: CompanyHolidayCreate
+    ) -> CompanyHolidayResponse:
+        """Create a new company holiday."""
+        holiday = await self._company_holiday_repo.create(
+            holiday_date=data.date, name=data.name
+        )
+        return CompanyHolidayResponse(id=holiday.id, date=holiday.date, name=holiday.name)
+
+    async def delete_company_holiday(self, holiday_id: str) -> None:
+        """Delete a company holiday."""
+        deleted = await self._company_holiday_repo.delete(holiday_id)
+        if not deleted:
+            raise NotFoundError("CompanyHoliday", holiday_id)

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import mimetypes
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
+from datetime import date as date_type
 from urllib.parse import urlparse
 
 from fastapi import HTTPException, UploadFile
@@ -39,6 +40,7 @@ from app.schemas.shipment import (
     TrackingImportRequest,
 )
 from app.utils.exceptions import InvalidStatusTransitionError, NotFoundError, ValidationError
+from app.utils.business_day_calculator import add_business_days
 from app.utils.file_storage import FileStorage
 from app.utils.zip_builder import ZipBuilder
 
@@ -58,6 +60,7 @@ class ShipmentService:
         file_storage: FileStorage,
         order_source_repo: OrderSourceRepository | None = None,
         email_service: "EmailService | None" = None,
+        settings_service: "SettingsService | None" = None,
     ):
         from app.services.email_service import EmailService  # noqa: F811
 
@@ -66,6 +69,7 @@ class ShipmentService:
         self._file_storage = file_storage
         self._order_source_repo = order_source_repo
         self._email_service = email_service
+        self._settings_service = settings_service
 
     async def create(self, data: ShipmentCreate) -> ShipmentResponse:
         """Create a new shipment."""
@@ -136,6 +140,29 @@ class ShipmentService:
             limit=limit,
         )
 
+    def _calculate_estimated_shipping_date(
+        self,
+        orders: list,
+        prep_days: int,
+        company_holidays: set[date_type],
+    ) -> date_type | None:
+        """配送予定日を計算する."""
+        delivery_dates: list[date_type] = []
+        for order in orders:
+            if not order or not order.items:
+                continue
+            for order_item in order.items:
+                product = getattr(order_item, "product", None)
+                if product and hasattr(product, "lead_time_days") and product.lead_time_days:
+                    d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
+                    delivery_dates.append(d)
+
+        if not delivery_dates:
+            return None
+
+        latest_delivery = max(delivery_dates)
+        return add_business_days(latest_delivery, prep_days, company_holidays)
+
     async def list_with_pending_orders(
         self,
         page: int = 1,
@@ -169,6 +196,13 @@ class ShipmentService:
         shipment_total = 0
         pending_total = 0
 
+        # Fetch settings for estimated shipping date calculation (once per request)
+        prep_days = 5  # default
+        company_holidays: set[date_type] = set()
+        if self._settings_service:
+            prep_days = await self._settings_service.get_shipping_preparation_days_value()
+            company_holidays = await self._settings_service.get_company_holiday_dates()
+
         # If filtering by PendingOrderStatus, skip shipments
         if pending_order_status is None:
             # Get shipments
@@ -189,7 +223,13 @@ class ShipmentService:
                 sort_order=sort_order,
             )
             # Convert shipments to responses
-            items = [self._to_response(shipment) for shipment in shipments]
+            for shipment in shipments:
+                response = self._to_response(shipment)
+                orders_for_calc = [si.order for si in shipment.items if si.order]
+                response.estimated_shipping_date = self._calculate_estimated_shipping_date(
+                    orders_for_calc, prep_days, company_holidays
+                )
+                items.append(response)
 
         # If filtering by ShipmentStatus, skip pending orders
         if shipment_status is None:
@@ -201,7 +241,11 @@ class ShipmentService:
             )
             # Convert pending orders to responses
             for order in pending_orders:
-                items.append(self._to_pending_order_response(order))
+                response = self._to_pending_order_response(order)
+                response.estimated_shipping_date = self._calculate_estimated_shipping_date(
+                    [order], prep_days, company_holidays
+                )
+                items.append(response)
 
         # Calculate total
         total = shipment_total + pending_total

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -232,7 +232,6 @@ class ShipmentService:
             # Convert shipments to responses
             for shipment in shipments:
                 response = self._to_response(shipment)
-                response.estimated_shipping_date = shipment.estimated_shipping_date
                 items.append(response)
 
         # If filtering by ShipmentStatus, skip pending orders
@@ -933,6 +932,7 @@ class ShipmentService:
             customer_address_building=first_order.customer_address_building if first_order else None,
             customer_phone=first_order.customer_phone if first_order else "",
             items=items,
+            estimated_shipping_date=shipment.estimated_shipping_date,
             created_at=shipment.created_at,
             updated_at=shipment.updated_at,
         )

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import mimetypes
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 from urllib.parse import urlparse
 
 from fastapi import HTTPException, UploadFile
@@ -160,16 +160,14 @@ class ShipmentService:
         prep_days: int,
         company_holidays: set[date],
     ) -> date | None:
-        """配送予定日を計算する."""
+        """配送予定日を計算する。OrderItemの納品予定日から算出."""
         delivery_dates: list[date] = []
         for order in orders:
             if not order or not order.items:
                 continue
             for order_item in order.items:
-                product = order_item.product if order_item.product else None
-                if product and product.lead_time_days is not None:
-                    d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
-                    delivery_dates.append(d)
+                if order_item.expected_delivery_date is not None:
+                    delivery_dates.append(order_item.expected_delivery_date)
 
         if not delivery_dates:
             return None

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -72,21 +72,36 @@ class ShipmentService:
 
     async def create(self, data: ShipmentCreate) -> ShipmentResponse:
         """Create a new shipment."""
-        # Verify all orders exist and are in the correct status
+        orders = []
         for order_id in data.order_ids:
             order = await self._order_repo.find_by_id(order_id)
             if not order:
                 raise ValidationError(f"Order {order_id} not found")
             if order.status != OrderStatus.DELIVERED.value:
                 raise ValidationError(f"Order {order_id} is not in delivered status")
-            # Check if shipment already exists for this order (prevent duplicates)
             if await self._shipment_repo.exists_for_order(order_id):
                 raise ValidationError(f"Order {order_id} already has a shipment")
+            orders.append(order)
 
-        # Create shipment (customer info is accessed via first order relationship)
-        shipment = await self._shipment_repo.create(order_ids=data.order_ids)
+        estimated_date = await self._calculate_estimated_shipping_date_for_orders(orders)
+        shipment = await self._shipment_repo.create(
+            order_ids=data.order_ids,
+            estimated_shipping_date=estimated_date,
+        )
 
         return self._to_response(shipment)
+
+    async def _calculate_estimated_shipping_date_for_orders(
+        self, orders: list
+    ) -> date | None:
+        """複数注文から納品予定日を計算する."""
+        if not self._settings_service:
+            return None
+
+        prep_days = await self._settings_service.get_shipping_preparation_days_value()
+        company_holidays = await self._settings_service.get_company_holiday_dates()
+
+        return self._calculate_estimated_shipping_date(orders, prep_days, company_holidays)
 
     async def get_by_id(self, shipment_id: str) -> ShipmentResponse:
         """Get a shipment by ID."""
@@ -151,8 +166,8 @@ class ShipmentService:
             if not order or not order.items:
                 continue
             for order_item in order.items:
-                product = getattr(order_item, "product", None)
-                if product and hasattr(product, "lead_time_days") and product.lead_time_days:
+                product = order_item.product if order_item.product else None
+                if product and product.lead_time_days is not None:
                     d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
                     delivery_dates.append(d)
 
@@ -195,13 +210,6 @@ class ShipmentService:
         shipment_total = 0
         pending_total = 0
 
-        # Fetch settings for estimated shipping date calculation (once per request)
-        prep_days = 5  # default
-        company_holidays: set[date] = set()
-        if self._settings_service:
-            prep_days = await self._settings_service.get_shipping_preparation_days_value()
-            company_holidays = await self._settings_service.get_company_holiday_dates()
-
         # If filtering by PendingOrderStatus, skip shipments
         if pending_order_status is None:
             # Get shipments
@@ -224,10 +232,7 @@ class ShipmentService:
             # Convert shipments to responses
             for shipment in shipments:
                 response = self._to_response(shipment)
-                orders_for_calc = [si.order for si in shipment.items if si.order]
-                response.estimated_shipping_date = self._calculate_estimated_shipping_date(
-                    orders_for_calc, prep_days, company_holidays
-                )
+                response.estimated_shipping_date = shipment.estimated_shipping_date
                 items.append(response)
 
         # If filtering by ShipmentStatus, skip pending orders
@@ -241,9 +246,8 @@ class ShipmentService:
             # Convert pending orders to responses
             for order in pending_orders:
                 response = self._to_pending_order_response(order)
-                response.estimated_shipping_date = self._calculate_estimated_shipping_date(
-                    [order], prep_days, company_holidays
-                )
+                # pending orderは納品予定日なし（フロントで「-」表示）
+                response.estimated_shipping_date = None
                 items.append(response)
 
         # Calculate total

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import mimetypes
 from datetime import date, datetime, timedelta, timezone
-from datetime import date as date_type
 from urllib.parse import urlparse
 
 from fastapi import HTTPException, UploadFile
@@ -144,10 +143,10 @@ class ShipmentService:
         self,
         orders: list,
         prep_days: int,
-        company_holidays: set[date_type],
-    ) -> date_type | None:
+        company_holidays: set[date],
+    ) -> date | None:
         """配送予定日を計算する."""
-        delivery_dates: list[date_type] = []
+        delivery_dates: list[date] = []
         for order in orders:
             if not order or not order.items:
                 continue
@@ -198,7 +197,7 @@ class ShipmentService:
 
         # Fetch settings for estimated shipping date calculation (once per request)
         prep_days = 5  # default
-        company_holidays: set[date_type] = set()
+        company_holidays: set[date] = set()
         if self._settings_service:
             prep_days = await self._settings_service.get_shipping_preparation_days_value()
             company_holidays = await self._settings_service.get_company_holiday_dates()

--- a/api/app/utils/business_day_calculator.py
+++ b/api/app/utils/business_day_calculator.py
@@ -1,0 +1,50 @@
+"""Business day calculator utility.
+
+営業日計算ユーティリティ。
+土日、日本の祝日、TOSYO独自休日を除外して営業日を加算する。
+"""
+
+from datetime import date, timedelta
+
+import jpholiday
+
+
+def is_business_day(target_date: date, company_holidays: set[date]) -> bool:
+    """指定日が営業日かどうかを判定する.
+
+    Args:
+        target_date: 判定対象の日付
+        company_holidays: TOSYO独自休日の日付セット
+
+    Returns:
+        営業日であればTrue
+    """
+    if target_date.weekday() >= 5:
+        return False
+    if jpholiday.is_holiday(target_date):
+        return False
+    if target_date in company_holidays:
+        return False
+    return True
+
+
+def add_business_days(start_date: date, days: int, company_holidays: set[date]) -> date:
+    """起算日の翌日から営業日を加算した日付を返す.
+
+    Args:
+        start_date: 起算日（この日はカウントに含まない）
+        days: 加算する営業日数
+        company_holidays: TOSYO独自休日の日付セット
+
+    Returns:
+        加算後の日付
+    """
+    current = start_date
+    remaining = days
+
+    while True:
+        current += timedelta(days=1)
+        if is_business_day(current, company_holidays):
+            remaining -= 1
+            if remaining <= 0:
+                return current

--- a/api/app/utils/business_day_calculator.py
+++ b/api/app/utils/business_day_calculator.py
@@ -39,6 +39,9 @@ def add_business_days(start_date: date, days: int, company_holidays: set[date]) 
     Returns:
         加算後の日付
     """
+    if days < 0:
+        raise ValueError("days must be non-negative")
+
     current = start_date
     remaining = days
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "python-multipart>=0.0.17",
     # Utilities
     "httpx>=0.28.0",
+    "jpholiday>=0.1.9",
     "aiofiles>=24.1.0",
     # PDF Generation
     "weasyprint>=62.0",

--- a/api/tests/unit/test_all_manufacturer_order_items.py
+++ b/api/tests/unit/test_all_manufacturer_order_items.py
@@ -13,7 +13,7 @@ FEAT-0018: 全メーカー分の発注明細を一覧で確認できる「すべ
 """
 
 import pytest
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -50,6 +50,8 @@ def _make_order_item_tuple(
     lead_time_days: int = 7,
 ) -> tuple:
     """リポジトリの find_all_ordered_items_detail の戻り値形式に合わせたタプルを生成"""
+    effective_ordered_at = ordered_at or datetime(2026, 2, 24, 10, 0, 0)
+
     order_item = MagicMock()
     order_item.id = item_id or str(uuid4())
     order_item.order_id = order_id or str(uuid4())
@@ -64,11 +66,12 @@ def _make_order_item_tuple(
     order_item.color = color
     order_item.design_image_url = design_image_url
     order_item.thumbnail_image_url = thumbnail_image_url
+    order_item.expected_delivery_date = effective_ordered_at.date() + timedelta(days=lead_time_days)
 
     return (
         order_item,
         order_number,
-        ordered_at or datetime(2026, 2, 24, 10, 0, 0),
+        effective_ordered_at,
         customer_name,
         cost,
         status,

--- a/api/tests/unit/test_all_manufacturer_order_service.py
+++ b/api/tests/unit/test_all_manufacturer_order_service.py
@@ -10,7 +10,7 @@ FEAT-0018: 全メーカー横断発注明細一覧
 """
 
 import pytest
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -45,6 +45,8 @@ def _make_all_order_item(
 ) -> tuple:
     """Create a mock order item tuple matching the repository return format
     for find_all_ordered_items_detail."""
+    effective_ordered_at = ordered_at or datetime(2026, 2, 24, 10, 0, 0)
+
     order_item = MagicMock()
     order_item.id = str(uuid4())
     order_item.order_id = str(uuid4())
@@ -59,13 +61,14 @@ def _make_all_order_item(
     order_item.color = color
     order_item.design_image_url = design_image_url
     order_item.thumbnail_image_url = thumbnail_image_url
+    order_item.expected_delivery_date = effective_ordered_at.date() + timedelta(days=lead_time_days)
 
     mfr_id = manufacturer_id or str(uuid4())
 
     return (
         order_item,
         order_number,
-        ordered_at or datetime(2026, 2, 24, 10, 0, 0),
+        effective_ordered_at,
         customer_name,
         cost,
         status,

--- a/api/tests/unit/test_business_day_calculator.py
+++ b/api/tests/unit/test_business_day_calculator.py
@@ -1,0 +1,66 @@
+"""Tests for business day calculator."""
+
+from datetime import date
+
+import pytest
+
+from app.utils.business_day_calculator import add_business_days, is_business_day
+
+
+class TestIsBusinessDay:
+    def test_weekday_is_business_day(self):
+        assert is_business_day(date(2026, 3, 30), set()) is True  # Monday
+
+    def test_saturday_is_not_business_day(self):
+        assert is_business_day(date(2026, 3, 28), set()) is False
+
+    def test_sunday_is_not_business_day(self):
+        assert is_business_day(date(2026, 3, 29), set()) is False
+
+    def test_national_holiday_is_not_business_day(self):
+        assert is_business_day(date(2026, 1, 1), set()) is False  # 元日
+
+    def test_company_holiday_is_not_business_day(self):
+        company_holidays = {date(2026, 8, 13)}
+        assert is_business_day(date(2026, 8, 13), company_holidays) is False
+
+    def test_weekday_not_holiday_is_business_day(self):
+        assert is_business_day(date(2026, 4, 1), set()) is True
+
+
+class TestAddBusinessDays:
+    def test_add_zero_days(self):
+        # Friday + 0 = next business day = Monday
+        result = add_business_days(date(2026, 3, 27), 0, set())
+        assert result == date(2026, 3, 30)
+
+    def test_add_days_within_week(self):
+        # Monday + 3 = Thursday
+        result = add_business_days(date(2026, 3, 30), 3, set())
+        assert result == date(2026, 4, 2)
+
+    def test_add_days_across_weekend(self):
+        # Thursday + 5 = next Thu (skipping weekend)
+        result = add_business_days(date(2026, 3, 26), 5, set())
+        assert result == date(2026, 4, 2)
+
+    def test_add_days_with_national_holiday(self):
+        # Monday 4/27 + 3 days, skipping 4/29 (昭和の日)
+        result = add_business_days(date(2026, 4, 27), 3, set())
+        assert result == date(2026, 5, 1)
+
+    def test_add_days_with_company_holiday(self):
+        company_holidays = {date(2026, 3, 31)}
+        # Monday 3/30 + 2 days, skipping 3/31 (company holiday)
+        result = add_business_days(date(2026, 3, 30), 2, company_holidays)
+        assert result == date(2026, 4, 2)
+
+    def test_add_five_business_days_default(self):
+        # Monday 3/30 + 5 = Mon 4/6
+        result = add_business_days(date(2026, 3, 30), 5, set())
+        assert result == date(2026, 4, 6)
+
+    def test_start_date_is_friday(self):
+        # Friday 3/27 + 5 = Fri 4/3
+        result = add_business_days(date(2026, 3, 27), 5, set())
+        assert result == date(2026, 4, 3)

--- a/api/tests/unit/test_business_day_calculator.py
+++ b/api/tests/unit/test_business_day_calculator.py
@@ -64,3 +64,18 @@ class TestAddBusinessDays:
         # Friday 3/27 + 5 = Fri 4/3
         result = add_business_days(date(2026, 3, 27), 5, set())
         assert result == date(2026, 4, 3)
+
+    def test_golden_week(self):
+        """GW期間の計算."""
+        # 2026-04-28 (Tuesday) + 5 business days
+        # 4/29 昭和の日(skip), 4/30(Thu=1), 5/1(Fri=2),
+        # 5/2-3(weekend skip), 5/4 みどりの日(skip),
+        # 5/5 こどもの日(skip), 5/6 振替休日(skip),
+        # 5/7(Thu=3), 5/8(Fri=4), 5/9-10(weekend skip), 5/11(Mon=5)
+        result = add_business_days(date(2026, 4, 28), 5, set())
+        assert result == date(2026, 5, 11)
+
+    def test_negative_days_raises_error(self):
+        """負の日数はエラーになる."""
+        with pytest.raises(ValueError, match="days must be non-negative"):
+            add_business_days(date(2026, 3, 30), -1, set())

--- a/api/tests/unit/test_manufacturer_order_estimated_date.py
+++ b/api/tests/unit/test_manufacturer_order_estimated_date.py
@@ -1,0 +1,85 @@
+"""Test ManufacturerOrderService persists estimated_shipping_date on shipment creation."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.order import Order, OrderItem
+from app.services.manufacturer_order_service import ManufacturerOrderService
+
+
+@pytest.mark.asyncio
+async def test_create_shipment_persists_estimated_shipping_date():
+    """全OrderItem delivered時にShipment作成でestimated_shipping_dateが渡される."""
+    order_repo = AsyncMock()
+    manufacturer_repo = AsyncMock()
+    shipment_repo = AsyncMock()
+    settings_service = AsyncMock()
+
+    settings_service.get_shipping_preparation_days_value = AsyncMock(return_value=5)
+    settings_service.get_company_holiday_dates = AsyncMock(return_value=set())
+
+    service = ManufacturerOrderService(
+        order_repo=order_repo,
+        manufacturer_repo=manufacturer_repo,
+        shipment_repo=shipment_repo,
+        settings_service=settings_service,
+    )
+
+    product = MagicMock()
+    product.lead_time_days = 7
+
+    order_item = MagicMock(spec=OrderItem)
+    order_item.product = product
+
+    order = MagicMock(spec=Order)
+    order.id = "order-1"
+    order.ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.items = [order_item]
+
+    shipment_repo.exists_for_order = AsyncMock(return_value=False)
+    shipment_repo.create = AsyncMock()
+
+    result = await service._create_shipment_for_order(order)
+
+    assert result is True
+    shipment_repo.create.assert_called_once()
+    call_kwargs = shipment_repo.create.call_args
+    assert call_kwargs.kwargs.get("estimated_shipping_date") is not None
+    assert isinstance(call_kwargs.kwargs["estimated_shipping_date"], date)
+
+
+@pytest.mark.asyncio
+async def test_create_shipment_without_settings_service():
+    """settings_serviceがNoneの場合、estimated_shipping_dateはNone."""
+    order_repo = AsyncMock()
+    manufacturer_repo = AsyncMock()
+    shipment_repo = AsyncMock()
+
+    service = ManufacturerOrderService(
+        order_repo=order_repo,
+        manufacturer_repo=manufacturer_repo,
+        shipment_repo=shipment_repo,
+        settings_service=None,
+    )
+
+    product = MagicMock()
+    product.lead_time_days = 7
+
+    order_item = MagicMock(spec=OrderItem)
+    order_item.product = product
+
+    order = MagicMock(spec=Order)
+    order.id = "order-1"
+    order.ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.items = [order_item]
+
+    shipment_repo.exists_for_order = AsyncMock(return_value=False)
+    shipment_repo.create = AsyncMock()
+
+    result = await service._create_shipment_for_order(order)
+
+    assert result is True
+    call_kwargs = shipment_repo.create.call_args
+    assert call_kwargs.kwargs.get("estimated_shipping_date") is None

--- a/api/tests/unit/test_manufacturer_order_estimated_date.py
+++ b/api/tests/unit/test_manufacturer_order_estimated_date.py
@@ -1,6 +1,6 @@
 """Test ManufacturerOrderService persists estimated_shipping_date on shipment creation."""
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -27,15 +27,14 @@ async def test_create_shipment_persists_estimated_shipping_date():
         settings_service=settings_service,
     )
 
-    product = MagicMock()
-    product.lead_time_days = 7
+    ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
 
     order_item = MagicMock(spec=OrderItem)
-    order_item.product = product
+    order_item.expected_delivery_date = ordered_at.date() + timedelta(days=7)
 
     order = MagicMock(spec=Order)
     order.id = "order-1"
-    order.ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.ordered_at = ordered_at
     order.items = [order_item]
 
     shipment_repo.exists_for_order = AsyncMock(return_value=False)
@@ -64,15 +63,14 @@ async def test_create_shipment_without_settings_service():
         settings_service=None,
     )
 
-    product = MagicMock()
-    product.lead_time_days = 7
+    ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
 
     order_item = MagicMock(spec=OrderItem)
-    order_item.product = product
+    order_item.expected_delivery_date = ordered_at.date() + timedelta(days=7)
 
     order = MagicMock(spec=Order)
     order.id = "order-1"
-    order.ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.ordered_at = ordered_at
     order.items = [order_item]
 
     shipment_repo.exists_for_order = AsyncMock(return_value=False)

--- a/api/tests/unit/test_manufacturer_order_status_filter.py
+++ b/api/tests/unit/test_manufacturer_order_status_filter.py
@@ -9,7 +9,7 @@ FEAT-0012: 発注詳細画面にステータスフィルター・キーワード
 """
 
 import pytest
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -66,6 +66,7 @@ class TestGetOrderItemsByManufacturerStatusFilter:
             OrderStatus.DELIVERED,
         ]
         for i, status in enumerate(statuses):
+            ordered_at = datetime.now()
             order_item = MagicMock()
             order_item.id = str(uuid4())
             order_item.order_id = str(uuid4())
@@ -81,11 +82,12 @@ class TestGetOrderItemsByManufacturerStatusFilter:
             order_item.design_image_url = None
             order_item.thumbnail_image_url = None
             order_item.status = status.value
+            order_item.expected_delivery_date = ordered_at.date() + timedelta(days=7)
 
             items.append((
                 order_item,
                 f"ORD-{i+1:04d}",  # order_number
-                datetime.now(),  # ordered_at
+                ordered_at,  # ordered_at
                 "顧客名",  # customer_name
                 500,  # cost
                 status.value,  # item_status (OrderItem.status)

--- a/api/tests/unit/test_order_estimated_shipping_date.py
+++ b/api/tests/unit/test_order_estimated_shipping_date.py
@@ -1,0 +1,84 @@
+"""Test estimated_shipping_date is persisted when OrderService creates a shipment."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.order import Order, OrderItem, OrderStatus
+from app.services.order_service import OrderService
+
+
+def _make_order(ordered_at: datetime, lead_time_days: int = 10) -> MagicMock:
+    """Create a mock Order with items."""
+    product = MagicMock()
+    product.lead_time_days = lead_time_days
+
+    order_item = MagicMock(spec=OrderItem)
+    order_item.product = product
+
+    order = MagicMock(spec=Order)
+    order.id = "order-1"
+    order.status = OrderStatus.DELIVERED.value
+    order.ordered_at = ordered_at
+    order.items = [order_item]
+    return order
+
+
+@pytest.mark.asyncio
+async def test_create_shipment_persists_estimated_shipping_date():
+    """delivered時にShipment作成で estimated_shipping_date が渡される."""
+    order_repo = AsyncMock()
+    product_repo = AsyncMock()
+    shipment_repo = AsyncMock()
+    settings_service = AsyncMock()
+
+    settings_service.get_shipping_preparation_days_value = AsyncMock(return_value=5)
+    settings_service.get_company_holiday_dates = AsyncMock(return_value=set())
+
+    service = OrderService(
+        order_repo=order_repo,
+        product_repo=product_repo,
+        shipment_repo=shipment_repo,
+        settings_service=settings_service,
+    )
+
+    ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order = _make_order(ordered_at=ordered_at, lead_time_days=10)
+
+    shipment_repo.exists_for_order = AsyncMock(return_value=False)
+    shipment_repo.create = AsyncMock()
+
+    await service._create_shipment_for_order(order)
+
+    shipment_repo.create.assert_called_once()
+    call_kwargs = shipment_repo.create.call_args
+    assert call_kwargs.kwargs.get("estimated_shipping_date") is not None
+    assert isinstance(call_kwargs.kwargs["estimated_shipping_date"], date)
+
+
+@pytest.mark.asyncio
+async def test_create_shipment_without_settings_service():
+    """settings_serviceがNoneの場合、estimated_shipping_dateはNone."""
+    order_repo = AsyncMock()
+    product_repo = AsyncMock()
+    shipment_repo = AsyncMock()
+
+    service = OrderService(
+        order_repo=order_repo,
+        product_repo=product_repo,
+        shipment_repo=shipment_repo,
+        settings_service=None,
+    )
+
+    ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order = _make_order(ordered_at=ordered_at, lead_time_days=10)
+
+    shipment_repo.exists_for_order = AsyncMock(return_value=False)
+    shipment_repo.create = AsyncMock()
+
+    await service._create_shipment_for_order(order)
+
+    shipment_repo.create.assert_called_once()
+    call_kwargs = shipment_repo.create.call_args
+    assert call_kwargs.kwargs.get("estimated_shipping_date") is None

--- a/api/tests/unit/test_order_estimated_shipping_date.py
+++ b/api/tests/unit/test_order_estimated_shipping_date.py
@@ -1,6 +1,6 @@
 """Test estimated_shipping_date is persisted when OrderService creates a shipment."""
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -11,11 +11,8 @@ from app.services.order_service import OrderService
 
 def _make_order(ordered_at: datetime, lead_time_days: int = 10) -> MagicMock:
     """Create a mock Order with items."""
-    product = MagicMock()
-    product.lead_time_days = lead_time_days
-
     order_item = MagicMock(spec=OrderItem)
-    order_item.product = product
+    order_item.expected_delivery_date = ordered_at.date() + timedelta(days=lead_time_days)
 
     order = MagicMock(spec=Order)
     order.id = "order-1"

--- a/api/tests/unit/test_order_service_status.py
+++ b/api/tests/unit/test_order_service_status.py
@@ -170,7 +170,9 @@ class TestOrderStatusTransition:
 
         # Assert
         assert order.status == OrderStatus.DELIVERED.value
-        mock_shipment_repo.create.assert_called_once_with(order_ids=["order-123"])
+        mock_shipment_repo.create.assert_called_once_with(
+            order_ids=["order-123"], estimated_shipping_date=None
+        )
 
     @pytest.mark.asyncio
     async def test_manufacturing_to_delivered_creates_shipment(

--- a/api/tests/unit/test_shipment_detail_product_view.py
+++ b/api/tests/unit/test_shipment_detail_product_view.py
@@ -116,6 +116,7 @@ def create_mock_shipment(
     shipment.shipped_at = None
     shipment.delivered_at = None
     shipment.note = None
+    shipment.estimated_shipping_date = None
     shipment.created_at = datetime.now(timezone.utc)
     shipment.updated_at = datetime.now(timezone.utc)
     shipment.items = []
@@ -403,6 +404,7 @@ class TestShipmentDetailProductView:
         shipment.shipped_at = None
         shipment.delivered_at = None
         shipment.note = None
+        shipment.estimated_shipping_date = None
         shipment.created_at = datetime.now(timezone.utc)
         shipment.updated_at = datetime.now(timezone.utc)
 

--- a/api/tests/unit/test_shipment_estimated_date_persistence.py
+++ b/api/tests/unit/test_shipment_estimated_date_persistence.py
@@ -1,0 +1,117 @@
+"""Test that ShipmentService uses DB value for estimated_shipping_date."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.shipment import Shipment, ShipmentItem, ShipmentStatus
+from app.schemas.shipment import PendingOrderStatus
+from app.services.shipment_service import ShipmentService
+
+
+def _make_shipment(estimated_date: date | None = None) -> MagicMock:
+    """Create a mock Shipment with estimated_shipping_date."""
+    order = MagicMock()
+    order.id = "order-1"
+    order.order_number = "ORD-001"
+    order.customer_name = "テスト太郎"
+    order.customer_postal_code = "100-0001"
+    order.customer_address_prefecture = "東京都"
+    order.customer_address_city = "千代田区"
+    order.customer_address_building = None
+    order.customer_phone = "03-1234-5678"
+
+    order_item = MagicMock()
+    order_item.id = "oi-1"
+    order_item.product_name = "テスト商品"
+    order_item.quantity = 1
+    order_item.thumbnail_image_url = None
+    order.items = [order_item]
+
+    item = MagicMock(spec=ShipmentItem)
+    item.id = "item-1"
+    item.order_id = "order-1"
+    item.order = order
+
+    shipment = MagicMock(spec=Shipment)
+    shipment.id = "ship-1"
+    shipment.status = ShipmentStatus.PENDING.value
+    shipment.tracking_number = None
+    shipment.carrier = None
+    shipment.packing_photo_path = None
+    shipment.shipped_at = None
+    shipment.delivered_at = None
+    shipment.note = None
+    shipment.created_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    shipment.updated_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    shipment.estimated_shipping_date = estimated_date
+    shipment.items = [item]
+    shipment.first_order = order
+    return shipment
+
+
+@pytest.mark.asyncio
+async def test_list_shipment_uses_db_estimated_date():
+    """Shipmentの納品予定日はDBの値をそのまま返す."""
+    shipment_repo = AsyncMock()
+    order_repo = AsyncMock()
+    file_storage = MagicMock()
+    settings_service = AsyncMock()
+
+    shipment = _make_shipment(estimated_date=date(2026, 4, 20))
+    shipment_repo.find_all = AsyncMock(return_value=([shipment], 1))
+    order_repo.find_pending_orders = AsyncMock(return_value=([], 0))
+
+    service = ShipmentService(
+        shipment_repo=shipment_repo,
+        order_repo=order_repo,
+        file_storage=file_storage,
+        settings_service=settings_service,
+    )
+
+    result = await service.list_with_pending_orders()
+
+    assert result.items[0].estimated_shipping_date == date(2026, 4, 20)
+    # settings_service should NOT be called for calculation
+    settings_service.get_shipping_preparation_days_value.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pending_order_has_null_estimated_date():
+    """Pending orderの納品予定日はNone（フロントで「-」表示）."""
+    shipment_repo = AsyncMock()
+    order_repo = AsyncMock()
+    file_storage = MagicMock()
+    settings_service = AsyncMock()
+
+    order = MagicMock()
+    order.id = "order-1"
+    order.order_number = "ORD-001"
+    order.customer_name = "テスト太郎"
+    order.customer_postal_code = "100-0001"
+    order.customer_address_prefecture = "東京都"
+    order.customer_address_city = "千代田区"
+    order.customer_address_building = None
+    order.customer_phone = "03-1234-5678"
+    order.ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.created_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.items = []
+
+    shipment_repo.find_all = AsyncMock(return_value=([], 0))
+    order_repo.find_pending_orders = AsyncMock(return_value=([order], 1))
+
+    service = ShipmentService(
+        shipment_repo=shipment_repo,
+        order_repo=order_repo,
+        file_storage=file_storage,
+        settings_service=settings_service,
+    )
+
+    result = await service.list_with_pending_orders(
+        pending_order_status=PendingOrderStatus.PREPARING,
+    )
+
+    assert result.items[0].estimated_shipping_date is None
+    # settings_service should NOT be called
+    settings_service.get_shipping_preparation_days_value.assert_not_called()

--- a/api/tests/unit/test_shipment_pending_orders.py
+++ b/api/tests/unit/test_shipment_pending_orders.py
@@ -293,6 +293,7 @@ class TestShipmentServiceListWithPendingOrders:
         mock_shipment.shipped_at = None
         mock_shipment.delivered_at = None
         mock_shipment.note = None
+        mock_shipment.estimated_shipping_date = None
         mock_shipment.created_at = datetime.now(timezone.utc)
         mock_shipment.updated_at = datetime.now(timezone.utc)
         mock_shipment.items = []

--- a/api/tests/unit/test_shipment_product_name.py
+++ b/api/tests/unit/test_shipment_product_name.py
@@ -112,6 +112,7 @@ def create_mock_shipment(
     shipment.shipped_at = None
     shipment.delivered_at = None
     shipment.note = None
+    shipment.estimated_shipping_date = None
     shipment.created_at = datetime.now(timezone.utc)
     shipment.updated_at = datetime.now(timezone.utc)
     shipment.items = []
@@ -220,6 +221,7 @@ class TestShipmentProductName:
         shipment.shipped_at = None
         shipment.delivered_at = None
         shipment.note = None
+        shipment.estimated_shipping_date = None
         shipment.created_at = datetime.now(timezone.utc)
         shipment.updated_at = datetime.now(timezone.utc)
 

--- a/api/tests/unit/test_shipment_repo_estimated_date.py
+++ b/api/tests/unit/test_shipment_repo_estimated_date.py
@@ -1,0 +1,69 @@
+"""Test ShipmentRepository.create with estimated_shipping_date."""
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.repositories.shipment_repository import ShipmentRepository
+
+
+@pytest.mark.asyncio
+async def test_create_sets_estimated_shipping_date():
+    """Shipment作成時にestimated_shipping_dateがセットされる."""
+    db = AsyncMock()
+    repo = ShipmentRepository(db)
+
+    mock_shipment = MagicMock()
+    mock_shipment.id = "ship-1"
+
+    with patch.object(repo, "find_by_id", return_value=mock_shipment):
+        db.flush = AsyncMock()
+        db.refresh = AsyncMock()
+        db.add = MagicMock()
+
+        created_shipments = []
+
+        def capture_add(obj):
+            from app.models.shipment import Shipment
+            if isinstance(obj, Shipment):
+                created_shipments.append(obj)
+
+        db.add.side_effect = capture_add
+
+        await repo.create(
+            order_ids=["order-1"],
+            estimated_shipping_date=date(2026, 4, 15),
+        )
+
+        assert len(created_shipments) == 1
+        assert created_shipments[0].estimated_shipping_date == date(2026, 4, 15)
+
+
+@pytest.mark.asyncio
+async def test_create_without_estimated_shipping_date():
+    """estimated_shipping_dateがNoneの場合もShipmentが作成される."""
+    db = AsyncMock()
+    repo = ShipmentRepository(db)
+
+    mock_shipment = MagicMock()
+    mock_shipment.id = "ship-1"
+
+    with patch.object(repo, "find_by_id", return_value=mock_shipment):
+        db.flush = AsyncMock()
+        db.refresh = AsyncMock()
+        db.add = MagicMock()
+
+        created_shipments = []
+
+        def capture_add(obj):
+            from app.models.shipment import Shipment
+            if isinstance(obj, Shipment):
+                created_shipments.append(obj)
+
+        db.add.side_effect = capture_add
+
+        await repo.create(order_ids=["order-1"])
+
+        assert len(created_shipments) == 1
+        assert created_shipments[0].estimated_shipping_date is None

--- a/api/tests/unit/test_shipment_service_status.py
+++ b/api/tests/unit/test_shipment_service_status.py
@@ -89,6 +89,7 @@ def create_mock_shipment(
     shipment.shipped_at = shipped_at
     shipment.delivered_at = None
     shipment.note = None
+    shipment.estimated_shipping_date = None
     shipment.created_at = datetime.now(timezone.utc)
     shipment.updated_at = datetime.now(timezone.utc)
     shipment.items = []

--- a/autopilot-log.md
+++ b/autopilot-log.md
@@ -8,3 +8,9 @@
 - **修正内容**: 用語定義テーブル追加、リレーションパス明記、起算ルール明記、Noneケース定義、バッチ取得方針明記
 - **2回目レビュー**: 承認 - 全要件カバー、前回指摘事項すべて解消
 - **設計書**: `docs/superpowers/specs/2026-03-27-shipment-estimated-delivery-date-design.md`
+
+### Phase: Writing Plans → Implementation Plan
+- **Status**: APPROVED (批評家レビュー1回目で承認)
+- **軽微な指摘**: settings名前衝突の記述改善、jpholiday追加タイミング、PendingOrderのeager loading確認
+- **対応方針**: 実装時に対処
+- **実装計画**: `docs/superpowers/plans/2026-03-27-shipment-estimated-delivery-date.md`

--- a/autopilot-log.md
+++ b/autopilot-log.md
@@ -14,3 +14,22 @@
 - **軽微な指摘**: settings名前衝突の記述改善、jpholiday追加タイミング、PendingOrderのeager loading確認
 - **対応方針**: 実装時に対処
 - **実装計画**: `docs/superpowers/plans/2026-03-27-shipment-estimated-delivery-date.md`
+
+### Phase: Implementation (Subagent-Driven Development)
+- **Status**: COMPLETED
+- **タスク数**: 8/8 完了
+- **コミット**: 7コミット (設計書, 計画書, Task1-8, レビュー修正)
+
+### Phase: Code Review
+- **1回目レビュー**: CHANGES_REQUESTED
+  - Critical: dependencies.py関数順序
+  - Important: 重複日付エラーハンドリング、GWテスト不足、int()変換安全性、フロントエンドエラー表示
+  - Minor: date_type alias、negative days guard
+- **修正**: 全8件の指摘事項を修正
+- **2回目レビュー**: PASS - 全問題解消、新規問題なし
+
+### Phase: Completion
+- **Status**: DONE
+- **PR**: https://github.com/Raiku-Setoyama/pod-admin/pull/66
+- **ブランチ**: feat/shipment-estimated-delivery-date
+- **PR Status**: Ready for review (人間レビュー待ち)

--- a/docs/superpowers/plans/2026-03-27-shipment-estimated-delivery-date.md
+++ b/docs/superpowers/plans/2026-03-27-shipment-estimated-delivery-date.md
@@ -1,0 +1,1296 @@
+# 配送予定日表示機能 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 配送一覧に配送予定日カラムを追加し、営業日ベースで自動計算・表示する。設定ページで発送準備日数と独自休日を管理できるようにする。
+
+**Architecture:** バックエンドで営業日計算ユーティリティを作成し、ShipmentServiceで配送予定日を算出してAPIレスポンスに含める。設定（発送準備日数・独自休日）はsystem_settings/company_holidaysテーブルで管理し、設定APIで操作する。フロントエンドは配送一覧テーブルにカラム追加と設定ページ拡張。
+
+**Tech Stack:** Python(FastAPI, SQLAlchemy, jpholiday, Alembic), TypeScript(Next.js, React, SWR), PostgreSQL
+
+---
+
+## File Structure
+
+### 新規ファイル（バックエンド）
+- `api/app/models/system_setting.py` - SystemSettingモデル
+- `api/app/models/company_holiday.py` - CompanyHolidayモデル
+- `api/app/repositories/system_setting_repository.py` - 設定CRUD
+- `api/app/repositories/company_holiday_repository.py` - 独自休日CRUD
+- `api/app/services/settings_service.py` - 設定管理サービス
+- `api/app/schemas/settings.py` - 設定Pydanticスキーマ
+- `api/app/routers/settings.py` - 設定APIルーター
+- `api/app/utils/business_day_calculator.py` - 営業日計算ユーティリティ
+- `api/alembic/versions/xxxx_add_system_settings_and_company_holidays.py` - マイグレーション
+- `api/tests/unit/test_business_day_calculator.py` - 営業日計算テスト
+- `api/tests/unit/test_settings_service.py` - 設定サービステスト
+
+### 新規ファイル（フロントエンド）
+- `web/src/features/settings/components/shipping-settings.tsx` - 発送準備日数設定UI
+- `web/src/features/settings/components/company-holidays.tsx` - 独自休日管理UI
+
+### 変更ファイル（バックエンド）
+- `api/app/schemas/shipment.py` - ShipmentResponse/PendingOrderResponseにestimated_shipping_date追加
+- `api/app/services/shipment_service.py` - 配送予定日計算ロジック追加
+- `api/app/repositories/shipment_repository.py` - Product eager loading追加
+- `api/app/dependencies.py` - 新リポジトリ/サービスのDI登録
+- `api/app/main.py` - 設定ルーター登録
+- `api/alembic/env.py` - 新モデルimport追加
+
+### 変更ファイル（フロントエンド）
+- `web/src/types/api/index.ts` - 型定義追加
+- `web/src/features/shipments/components/shipment-list.tsx` - 配送予定日カラム追加
+- `web/src/app/(dashboard)/settings/page.tsx` - 設定ページ拡張
+
+---
+
+## Task 1: 営業日計算ユーティリティ
+
+**Files:**
+- Create: `api/app/utils/business_day_calculator.py`
+- Create: `api/tests/unit/test_business_day_calculator.py`
+
+- [ ] **Step 1: テストファイルを作成**
+
+```python
+# api/tests/unit/test_business_day_calculator.py
+"""Tests for business day calculator."""
+
+from datetime import date
+
+import pytest
+
+from app.utils.business_day_calculator import add_business_days, is_business_day
+
+
+class TestIsBusinessDay:
+    """Test is_business_day function."""
+
+    def test_weekday_is_business_day(self):
+        """月曜日は営業日."""
+        assert is_business_day(date(2026, 3, 30), set()) is True  # Monday
+
+    def test_saturday_is_not_business_day(self):
+        """土曜日は営業日ではない."""
+        assert is_business_day(date(2026, 3, 28), set()) is False  # Saturday
+
+    def test_sunday_is_not_business_day(self):
+        """日曜日は営業日ではない."""
+        assert is_business_day(date(2026, 3, 29), set()) is False  # Sunday
+
+    def test_national_holiday_is_not_business_day(self):
+        """祝日は営業日ではない（元日）."""
+        assert is_business_day(date(2026, 1, 1), set()) is False  # 元日
+
+    def test_company_holiday_is_not_business_day(self):
+        """独自休日は営業日ではない."""
+        company_holidays = {date(2026, 8, 13)}
+        assert is_business_day(date(2026, 8, 13), company_holidays) is False
+
+    def test_weekday_not_holiday_is_business_day(self):
+        """祝日でない平日は営業日."""
+        assert is_business_day(date(2026, 4, 1), set()) is True  # Wednesday
+
+
+class TestAddBusinessDays:
+    """Test add_business_days function."""
+
+    def test_add_zero_days(self):
+        """0日加算は翌営業日を返す（起算日の翌日から）."""
+        # 2026-03-27 (Friday) + 0 business days = next business day = 2026-03-30 (Monday)
+        result = add_business_days(date(2026, 3, 27), 0, set())
+        assert result == date(2026, 3, 30)
+
+    def test_add_days_within_week(self):
+        """平日のみの加算（週内）."""
+        # 2026-03-30 (Monday) + 3 business days = Thursday 2026-04-02
+        result = add_business_days(date(2026, 3, 30), 3, set())
+        assert result == date(2026, 4, 2)
+
+    def test_add_days_across_weekend(self):
+        """週末をまたぐ加算."""
+        # 2026-03-26 (Thursday) + 5 business days
+        # Fri 27, Mon 30, Tue 31, Wed Apr1, Thu Apr2
+        result = add_business_days(date(2026, 3, 26), 5, set())
+        assert result == date(2026, 4, 2)
+
+    def test_add_days_with_national_holiday(self):
+        """祝日を含む加算（昭和の日: 4/29）."""
+        # 2026-04-27 (Monday) + 3 business days
+        # Tue 28, (Wed 29 = 昭和の日 skip), Thu 30, Fri May 1
+        result = add_business_days(date(2026, 4, 27), 3, set())
+        assert result == date(2026, 5, 1)
+
+    def test_add_days_with_company_holiday(self):
+        """独自休日を含む加算."""
+        company_holidays = {date(2026, 3, 31)}
+        # 2026-03-30 (Monday) + 2 business days
+        # (Tue 31 = company holiday skip), Wed Apr1, Thu Apr2
+        result = add_business_days(date(2026, 3, 30), 2, company_holidays)
+        assert result == date(2026, 4, 2)
+
+    def test_add_five_business_days_default(self):
+        """デフォルト5営業日加算."""
+        # 2026-03-30 (Monday) + 5 business days
+        # Tue 31, Wed Apr1, Thu Apr2, Fri Apr3, Mon Apr6
+        result = add_business_days(date(2026, 3, 30), 5, set())
+        assert result == date(2026, 4, 6)
+
+    def test_start_date_is_friday(self):
+        """金曜日起算の場合、翌営業日（月曜日）からカウント."""
+        # 2026-03-27 (Friday) + 5 business days
+        # Mon 30, Tue 31, Wed Apr1, Thu Apr2, Fri Apr3
+        result = add_business_days(date(2026, 3, 27), 5, set())
+        assert result == date(2026, 4, 3)
+
+    def test_golden_week(self):
+        """GW期間の計算."""
+        # 2026-04-28 (Tuesday) + 5 business days
+        # 4/29 昭和の日(skip), 4/30(Thu), 5/1(Fri), 5/2(Sat skip), 5/3(Sun skip),
+        # 5/4 みどりの日(skip), 5/5 こどもの日(skip), 5/6 振替休日(skip),
+        # 5/7(Thu), 5/8(Fri), 5/11(Mon)
+        result = add_business_days(date(2026, 4, 28), 5, set())
+        # 4/30, 5/1, 5/7, 5/8, 5/11
+        assert result == date(2026, 5, 11)
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd /Users/raiku_setoyama/github/tosyo/pod-admin/api && python -m pytest tests/unit/test_business_day_calculator.py -v`
+Expected: FAIL with import error
+
+- [ ] **Step 3: 営業日計算ユーティリティを実装**
+
+```python
+# api/app/utils/business_day_calculator.py
+"""Business day calculator utility.
+
+営業日計算ユーティリティ。
+土日、日本の祝日、TOSYO独自休日を除外して営業日を加算する。
+"""
+
+from datetime import date, timedelta
+
+import jpholiday
+
+
+def is_business_day(target_date: date, company_holidays: set[date]) -> bool:
+    """指定日が営業日かどうかを判定する.
+
+    Args:
+        target_date: 判定対象の日付
+        company_holidays: TOSYO独自休日の日付セット
+
+    Returns:
+        営業日であればTrue
+    """
+    # 土日チェック
+    if target_date.weekday() >= 5:  # 5=Saturday, 6=Sunday
+        return False
+
+    # 日本の祝日チェック
+    if jpholiday.is_holiday(target_date):
+        return False
+
+    # 独自休日チェック
+    if target_date in company_holidays:
+        return False
+
+    return True
+
+
+def add_business_days(start_date: date, days: int, company_holidays: set[date]) -> date:
+    """起算日の翌日から営業日を加算した日付を返す.
+
+    Args:
+        start_date: 起算日（この日はカウントに含まない）
+        days: 加算する営業日数
+        company_holidays: TOSYO独自休日の日付セット
+
+    Returns:
+        加算後の日付
+    """
+    current = start_date
+    remaining = days
+
+    while True:
+        current += timedelta(days=1)
+        if is_business_day(current, company_holidays):
+            if remaining <= 0:
+                return current
+            remaining -= 1
+```
+
+- [ ] **Step 4: jpholidayパッケージをインストール**
+
+Run: `cd /Users/raiku_setoyama/github/tosyo/pod-admin/api && pip install jpholiday`
+Also add to requirements if exists.
+
+- [ ] **Step 5: テストが通ることを確認**
+
+Run: `cd /Users/raiku_setoyama/github/tosyo/pod-admin/api && python -m pytest tests/unit/test_business_day_calculator.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add api/app/utils/business_day_calculator.py api/tests/unit/test_business_day_calculator.py
+git commit -m "feat: add business day calculator utility with jpholiday support"
+```
+
+---
+
+## Task 2: SystemSettingモデルとCompanyHolidayモデル
+
+**Files:**
+- Create: `api/app/models/system_setting.py`
+- Create: `api/app/models/company_holiday.py`
+- Modify: `api/alembic/env.py`
+
+- [ ] **Step 1: SystemSettingモデルを作成**
+
+```python
+# api/app/models/system_setting.py
+"""System setting model."""
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class SystemSetting(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    """System setting model - key/value store for application settings."""
+
+    __tablename__ = "system_settings"
+
+    key: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    value: Mapped[str] = mapped_column(Text)
+    description: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<SystemSetting(key={self.key}, value={self.value})>"
+```
+
+- [ ] **Step 2: CompanyHolidayモデルを作成**
+
+```python
+# api/app/models/company_holiday.py
+"""Company holiday model."""
+
+from datetime import date as date_type
+
+from sqlalchemy import Date, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class CompanyHoliday(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    """Company holiday model - TOSYO独自休日."""
+
+    __tablename__ = "company_holidays"
+
+    date: Mapped[date_type] = mapped_column(Date, unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(100))
+
+    def __repr__(self) -> str:
+        return f"<CompanyHoliday(date={self.date}, name={self.name})>"
+```
+
+- [ ] **Step 3: alembic/env.pyに新モデルのimportを追加**
+
+`api/alembic/env.py` の既存import群の後に追加:
+```python
+from app.models.system_setting import SystemSetting  # noqa: F401
+from app.models.company_holiday import CompanyHoliday  # noqa: F401
+```
+
+- [ ] **Step 4: Alembicマイグレーションを生成**
+
+Run: `cd /Users/raiku_setoyama/github/tosyo/pod-admin/api && python -m alembic revision --autogenerate -m "add_system_settings_and_company_holidays"`
+
+Note: DBに接続できない場合は手動でマイグレーションファイルを作成する。
+
+- [ ] **Step 5: マイグレーションファイルに初期データ挿入を追加**
+
+生成されたマイグレーションファイルの `upgrade()` 関数の末尾に追加:
+```python
+# Insert default shipping preparation days
+op.execute(
+    "INSERT INTO system_settings (id, key, value, description, created_at, updated_at) "
+    "VALUES (gen_random_uuid(), 'shipping_preparation_days', '5', '発送準備日数', now(), now())"
+)
+```
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add api/app/models/system_setting.py api/app/models/company_holiday.py api/alembic/env.py api/alembic/versions/
+git commit -m "feat: add SystemSetting and CompanyHoliday models with migration"
+```
+
+---
+
+## Task 3: リポジトリ層
+
+**Files:**
+- Create: `api/app/repositories/system_setting_repository.py`
+- Create: `api/app/repositories/company_holiday_repository.py`
+
+- [ ] **Step 1: SystemSettingRepositoryを作成**
+
+```python
+# api/app/repositories/system_setting_repository.py
+"""System setting repository for database operations."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.system_setting import SystemSetting
+
+
+class SystemSettingRepository:
+    """Repository for SystemSetting model."""
+
+    def __init__(self, db: AsyncSession):
+        self._db = db
+
+    async def get_by_key(self, key: str) -> SystemSetting | None:
+        """Get a setting by key."""
+        result = await self._db.execute(
+            select(SystemSetting).where(SystemSetting.key == key)
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert(self, key: str, value: str, description: str | None = None) -> SystemSetting:
+        """Create or update a setting."""
+        setting = await self.get_by_key(key)
+        if setting:
+            setting.value = value
+            if description is not None:
+                setting.description = description
+        else:
+            setting = SystemSetting(key=key, value=value, description=description)
+            self._db.add(setting)
+        await self._db.flush()
+        await self._db.refresh(setting)
+        return setting
+```
+
+- [ ] **Step 2: CompanyHolidayRepositoryを作成**
+
+```python
+# api/app/repositories/company_holiday_repository.py
+"""Company holiday repository for database operations."""
+
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.company_holiday import CompanyHoliday
+
+
+class CompanyHolidayRepository:
+    """Repository for CompanyHoliday model."""
+
+    def __init__(self, db: AsyncSession):
+        self._db = db
+
+    async def find_all(self) -> list[CompanyHoliday]:
+        """Get all company holidays ordered by date."""
+        result = await self._db.execute(
+            select(CompanyHoliday).order_by(CompanyHoliday.date.asc())
+        )
+        return list(result.scalars().all())
+
+    async def find_all_dates(self) -> set[date]:
+        """Get all company holiday dates as a set (for business day calculation)."""
+        holidays = await self.find_all()
+        return {h.date for h in holidays}
+
+    async def find_by_id(self, holiday_id: str) -> CompanyHoliday | None:
+        """Find a company holiday by ID."""
+        result = await self._db.execute(
+            select(CompanyHoliday).where(CompanyHoliday.id == holiday_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def create(self, holiday_date: date, name: str) -> CompanyHoliday:
+        """Create a new company holiday."""
+        holiday = CompanyHoliday(date=holiday_date, name=name)
+        self._db.add(holiday)
+        await self._db.flush()
+        await self._db.refresh(holiday)
+        return holiday
+
+    async def delete(self, holiday_id: str) -> bool:
+        """Delete a company holiday. Returns True if deleted."""
+        holiday = await self.find_by_id(holiday_id)
+        if not holiday:
+            return False
+        await self._db.delete(holiday)
+        await self._db.flush()
+        return True
+```
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add api/app/repositories/system_setting_repository.py api/app/repositories/company_holiday_repository.py
+git commit -m "feat: add SystemSetting and CompanyHoliday repositories"
+```
+
+---
+
+## Task 4: 設定スキーマ・サービス・ルーター
+
+**Files:**
+- Create: `api/app/schemas/settings.py`
+- Create: `api/app/services/settings_service.py`
+- Create: `api/app/routers/settings.py`
+- Modify: `api/app/dependencies.py`
+- Modify: `api/app/main.py`
+
+- [ ] **Step 1: Pydanticスキーマを作成**
+
+```python
+# api/app/schemas/settings.py
+"""Settings schemas."""
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ShippingPreparationDaysResponse(BaseModel):
+    """Response for shipping preparation days setting."""
+
+    value: int
+    description: str | None = None
+
+
+class ShippingPreparationDaysUpdate(BaseModel):
+    """Request to update shipping preparation days."""
+
+    value: int = Field(..., ge=0, le=30, description="発送準備日数（0〜30日）")
+
+
+class CompanyHolidayResponse(BaseModel):
+    """Response for a company holiday."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    date: date
+    name: str
+
+
+class CompanyHolidayCreate(BaseModel):
+    """Request to create a company holiday."""
+
+    date: date
+    name: str = Field(..., min_length=1, max_length=100)
+
+
+class CompanyHolidayListResponse(BaseModel):
+    """Response for company holiday list."""
+
+    items: list[CompanyHolidayResponse]
+```
+
+- [ ] **Step 2: 設定サービスを作成**
+
+```python
+# api/app/services/settings_service.py
+"""Settings service."""
+
+from datetime import date
+
+from app.models.company_holiday import CompanyHoliday
+from app.repositories.company_holiday_repository import CompanyHolidayRepository
+from app.repositories.system_setting_repository import SystemSettingRepository
+from app.schemas.settings import (
+    CompanyHolidayCreate,
+    CompanyHolidayListResponse,
+    CompanyHolidayResponse,
+    ShippingPreparationDaysResponse,
+    ShippingPreparationDaysUpdate,
+)
+from app.utils.exceptions import NotFoundError, ValidationError
+
+SHIPPING_PREPARATION_DAYS_KEY = "shipping_preparation_days"
+SHIPPING_PREPARATION_DAYS_DEFAULT = 5
+
+
+class SettingsService:
+    """Service for settings operations."""
+
+    def __init__(
+        self,
+        system_setting_repo: SystemSettingRepository,
+        company_holiday_repo: CompanyHolidayRepository,
+    ):
+        self._system_setting_repo = system_setting_repo
+        self._company_holiday_repo = company_holiday_repo
+
+    async def get_shipping_preparation_days(self) -> ShippingPreparationDaysResponse:
+        """Get shipping preparation days setting."""
+        setting = await self._system_setting_repo.get_by_key(SHIPPING_PREPARATION_DAYS_KEY)
+        if setting:
+            return ShippingPreparationDaysResponse(
+                value=int(setting.value),
+                description=setting.description,
+            )
+        return ShippingPreparationDaysResponse(
+            value=SHIPPING_PREPARATION_DAYS_DEFAULT,
+            description="発送準備日数",
+        )
+
+    async def update_shipping_preparation_days(
+        self, data: ShippingPreparationDaysUpdate
+    ) -> ShippingPreparationDaysResponse:
+        """Update shipping preparation days setting."""
+        setting = await self._system_setting_repo.upsert(
+            key=SHIPPING_PREPARATION_DAYS_KEY,
+            value=str(data.value),
+            description="発送準備日数",
+        )
+        return ShippingPreparationDaysResponse(
+            value=int(setting.value),
+            description=setting.description,
+        )
+
+    async def get_shipping_preparation_days_value(self) -> int:
+        """Get shipping preparation days as integer (for internal use)."""
+        setting = await self._system_setting_repo.get_by_key(SHIPPING_PREPARATION_DAYS_KEY)
+        if setting:
+            return int(setting.value)
+        return SHIPPING_PREPARATION_DAYS_DEFAULT
+
+    async def get_company_holidays(self) -> CompanyHolidayListResponse:
+        """Get all company holidays."""
+        holidays = await self._company_holiday_repo.find_all()
+        return CompanyHolidayListResponse(
+            items=[
+                CompanyHolidayResponse(id=h.id, date=h.date, name=h.name)
+                for h in holidays
+            ]
+        )
+
+    async def get_company_holiday_dates(self) -> set[date]:
+        """Get all company holiday dates as set (for business day calculation)."""
+        return await self._company_holiday_repo.find_all_dates()
+
+    async def create_company_holiday(
+        self, data: CompanyHolidayCreate
+    ) -> CompanyHolidayResponse:
+        """Create a new company holiday."""
+        holiday = await self._company_holiday_repo.create(
+            holiday_date=data.date, name=data.name
+        )
+        return CompanyHolidayResponse(id=holiday.id, date=holiday.date, name=holiday.name)
+
+    async def delete_company_holiday(self, holiday_id: str) -> None:
+        """Delete a company holiday."""
+        deleted = await self._company_holiday_repo.delete(holiday_id)
+        if not deleted:
+            raise NotFoundError("CompanyHoliday", holiday_id)
+```
+
+- [ ] **Step 3: 設定ルーターを作成**
+
+```python
+# api/app/routers/settings.py
+"""Settings router."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from app.dependencies import get_current_admin, get_settings_service
+from app.models.user import User
+from app.schemas.settings import (
+    CompanyHolidayCreate,
+    CompanyHolidayListResponse,
+    CompanyHolidayResponse,
+    ShippingPreparationDaysResponse,
+    ShippingPreparationDaysUpdate,
+)
+from app.services.settings_service import SettingsService
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+@router.get("/shipping-preparation-days", response_model=ShippingPreparationDaysResponse)
+async def get_shipping_preparation_days(
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ShippingPreparationDaysResponse:
+    """発送準備日数を取得."""
+    return await service.get_shipping_preparation_days()
+
+
+@router.put("/shipping-preparation-days", response_model=ShippingPreparationDaysResponse)
+async def update_shipping_preparation_days(
+    data: ShippingPreparationDaysUpdate,
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ShippingPreparationDaysResponse:
+    """発送準備日数を更新."""
+    return await service.update_shipping_preparation_days(data)
+
+
+@router.get("/company-holidays", response_model=CompanyHolidayListResponse)
+async def get_company_holidays(
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> CompanyHolidayListResponse:
+    """独自休日一覧を取得."""
+    return await service.get_company_holidays()
+
+
+@router.post("/company-holidays", response_model=CompanyHolidayResponse, status_code=201)
+async def create_company_holiday(
+    data: CompanyHolidayCreate,
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> CompanyHolidayResponse:
+    """独自休日を追加."""
+    return await service.create_company_holiday(data)
+
+
+@router.delete("/company-holidays/{holiday_id}", status_code=204)
+async def delete_company_holiday(
+    holiday_id: str,
+    service: Annotated[SettingsService, Depends(get_settings_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> None:
+    """独自休日を削除."""
+    await service.delete_company_holiday(holiday_id)
+```
+
+- [ ] **Step 4: dependencies.pyに新しいDIを追加**
+
+`api/app/dependencies.py` に以下を追加:
+
+imports:
+```python
+from app.repositories.system_setting_repository import SystemSettingRepository
+from app.repositories.company_holiday_repository import CompanyHolidayRepository
+from app.services.settings_service import SettingsService
+```
+
+repository functions:
+```python
+def get_system_setting_repository(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SystemSettingRepository:
+    """Get system setting repository."""
+    return SystemSettingRepository(db)
+
+
+def get_company_holiday_repository(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> CompanyHolidayRepository:
+    """Get company holiday repository."""
+    return CompanyHolidayRepository(db)
+```
+
+service function:
+```python
+def get_settings_service(
+    system_setting_repo: Annotated[SystemSettingRepository, Depends(get_system_setting_repository)],
+    company_holiday_repo: Annotated[CompanyHolidayRepository, Depends(get_company_holiday_repository)],
+) -> SettingsService:
+    """Get settings service."""
+    return SettingsService(system_setting_repo, company_holiday_repo)
+```
+
+- [ ] **Step 5: main.pyに設定ルーターを登録**
+
+`api/app/main.py` のimportsに追加:
+```python
+from app.routers import (
+    ...
+    settings,
+)
+```
+
+router登録に追加:
+```python
+app.include_router(settings.router, prefix=settings_module.API_V1_PREFIX)
+```
+
+Note: `settings` が config の `settings` と名前衝突するため、router importは `from app.routers import settings as settings_router` とし、 `app.include_router(settings_router.router, prefix=settings.API_V1_PREFIX)` とする。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add api/app/schemas/settings.py api/app/services/settings_service.py api/app/routers/settings.py api/app/dependencies.py api/app/main.py
+git commit -m "feat: add settings API for shipping preparation days and company holidays"
+```
+
+---
+
+## Task 5: ShipmentServiceに配送予定日計算を追加
+
+**Files:**
+- Modify: `api/app/repositories/shipment_repository.py` - Product eager loading追加
+- Modify: `api/app/schemas/shipment.py` - estimated_shipping_date追加
+- Modify: `api/app/services/shipment_service.py` - 配送予定日計算追加
+- Modify: `api/app/dependencies.py` - ShipmentServiceにSettingsService DI追加
+
+- [ ] **Step 1: ShipmentRepositoryにProduct eager loadingを追加**
+
+`api/app/repositories/shipment_repository.py` の `find_all` メソッドのqueryに、OrderItemのProductをeager loadするオプションを追加:
+
+```python
+query = select(Shipment).options(
+    selectinload(Shipment.items)
+    .selectinload(ShipmentItem.order)
+    .selectinload(Order.items)
+    .selectinload(OrderItem.product),  # ← 追加
+    selectinload(Shipment.items)
+    .selectinload(ShipmentItem.order)
+    .selectinload(Order.items),
+)
+```
+
+同様に `find_by_id` にも追加。
+
+Note: `OrderItem.product` のリレーションと `Product` のimportが必要:
+```python
+from app.models.product import Product  # noqa: F401
+```
+
+- [ ] **Step 2: ShipmentResponseとPendingOrderResponseにestimated_shipping_dateを追加**
+
+`api/app/schemas/shipment.py` に追加:
+
+`ShipmentResponse` クラスに:
+```python
+estimated_shipping_date: date | None = None
+```
+
+`PendingOrderResponse` クラスに:
+```python
+estimated_shipping_date: date | None = None
+```
+
+importに `date` を追加:
+```python
+from datetime import date, datetime
+```
+
+- [ ] **Step 3: ShipmentServiceのコンストラクタにsettings_serviceを追加**
+
+`api/app/services/shipment_service.py` のコンストラクタを変更:
+
+```python
+def __init__(
+    self,
+    shipment_repo: ShipmentRepository,
+    order_repo: OrderRepository,
+    file_storage: FileStorage,
+    order_source_repo: OrderSourceRepository | None = None,
+    email_service: "EmailService | None" = None,
+    settings_service: "SettingsService | None" = None,
+):
+    ...
+    self._settings_service = settings_service
+```
+
+imports追加:
+```python
+from datetime import date, datetime, timedelta, timezone
+from app.utils.business_day_calculator import add_business_days
+```
+
+- [ ] **Step 4: 配送予定日計算メソッドを追加**
+
+`api/app/services/shipment_service.py` に以下のメソッドを追加:
+
+```python
+def _calculate_estimated_shipping_date(
+    self,
+    orders: list,
+    prep_days: int,
+    company_holidays: set[date],
+) -> date | None:
+    """配送予定日を計算する.
+
+    Args:
+        orders: 注文リスト（OrderモデルまたはOrderItem.productを含む）
+        prep_days: 発送準備日数
+        company_holidays: 独自休日セット
+
+    Returns:
+        配送予定日、または計算できない場合はNone
+    """
+    delivery_dates: list[date] = []
+    for order in orders:
+        if not order or not order.items:
+            continue
+        for order_item in order.items:
+            product = getattr(order_item, "product", None)
+            if product and hasattr(product, "lead_time_days") and product.lead_time_days:
+                d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
+                delivery_dates.append(d)
+
+    if not delivery_dates:
+        return None
+
+    latest_delivery = max(delivery_dates)
+    return add_business_days(latest_delivery, prep_days, company_holidays)
+```
+
+- [ ] **Step 5: list_with_pending_ordersに配送予定日計算を組み込む**
+
+`list_with_pending_orders` メソッド内で、設定とホリデーを1回取得し、各アイテムに配送予定日を設定:
+
+```python
+async def list_with_pending_orders(self, ...):
+    # 配送予定日計算用データを1回取得
+    prep_days = 5  # default
+    company_holidays: set[date] = set()
+    if self._settings_service:
+        prep_days = await self._settings_service.get_shipping_preparation_days_value()
+        company_holidays = await self._settings_service.get_company_holiday_dates()
+
+    # ... existing logic ...
+
+    # Shipment responses に配送予定日を設定
+    for shipment in shipments:
+        response = self._to_response(shipment)
+        orders = [si.order for si in shipment.items if si.order]
+        response.estimated_shipping_date = self._calculate_estimated_shipping_date(
+            orders, prep_days, company_holidays
+        )
+        items.append(response)
+
+    # PendingOrder responses に配送予定日を設定
+    for order in pending_orders:
+        response = self._to_pending_order_response(order)
+        response.estimated_shipping_date = self._calculate_estimated_shipping_date(
+            [order], prep_days, company_holidays
+        )
+        items.append(response)
+```
+
+- [ ] **Step 6: dependencies.pyのget_shipment_serviceを更新**
+
+```python
+def get_shipment_service(
+    shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
+    order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
+    file_storage: Annotated[FileStorage, Depends(lambda: LocalFileStorage(settings.UPLOAD_DIR))],
+    order_source_repo: Annotated[OrderSourceRepository, Depends(get_order_source_repository)],
+    email_service: Annotated[EmailService | None, Depends(get_email_service)],
+    settings_service: Annotated[SettingsService, Depends(get_settings_service)],
+) -> ShipmentService:
+    """Get shipment service."""
+    return ShipmentService(
+        shipment_repo, order_repo, file_storage, order_source_repo, email_service, settings_service
+    )
+```
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add api/app/repositories/shipment_repository.py api/app/schemas/shipment.py api/app/services/shipment_service.py api/app/dependencies.py
+git commit -m "feat: calculate estimated shipping date in shipment list API"
+```
+
+---
+
+## Task 6: フロントエンド - 型定義と配送一覧テーブル更新
+
+**Files:**
+- Modify: `web/src/types/api/index.ts`
+- Modify: `web/src/features/shipments/components/shipment-list.tsx`
+
+- [ ] **Step 1: TypeScript型にestimated_shipping_dateを追加**
+
+`web/src/types/api/index.ts` の `Shipment` インターフェースに追加:
+```typescript
+estimated_shipping_date: string | null;
+```
+
+`PendingOrder` インターフェースに追加:
+```typescript
+estimated_shipping_date: string | null;
+```
+
+設定API用の型を追加:
+```typescript
+// Settings types
+export interface ShippingPreparationDays {
+  value: number;
+  description: string | null;
+}
+
+export interface CompanyHoliday {
+  id: string;
+  date: string;
+  name: string;
+}
+
+export interface CompanyHolidayListResponse {
+  items: CompanyHoliday[];
+}
+```
+
+- [ ] **Step 2: shipment-list.tsxに配送予定日カラムを追加**
+
+`web/src/features/shipments/components/shipment-list.tsx` に以下の変更:
+
+ヘルパー関数を追加:
+```typescript
+function getEstimatedShippingDate(item: ShipmentOrPendingOrder): string {
+  const dateStr = "estimated_shipping_date" in item ? item.estimated_shipping_date : null;
+  if (!dateStr) return "-";
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+```
+
+TableHeaderに「配送予定日」を追加（「作成日」と「ステータス」の間）:
+```tsx
+<TableHead>配送予定日</TableHead>
+```
+
+TableBodyの各行に対応するセルを追加:
+```tsx
+<TableCell>{getEstimatedShippingDate(item)}</TableCell>
+```
+
+colSpanを7→8に変更（空行のセル数）。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add web/src/types/api/index.ts web/src/features/shipments/components/shipment-list.tsx
+git commit -m "feat: display estimated shipping date column in shipment list"
+```
+
+---
+
+## Task 7: フロントエンド - 設定ページ拡張
+
+**Files:**
+- Create: `web/src/features/settings/components/shipping-settings.tsx`
+- Create: `web/src/features/settings/components/company-holidays.tsx`
+- Modify: `web/src/app/(dashboard)/settings/page.tsx`
+
+- [ ] **Step 1: 発送準備日数設定コンポーネントを作成**
+
+```tsx
+// web/src/features/settings/components/shipping-settings.tsx
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api/client";
+import type { ShippingPreparationDays } from "@/types/api";
+
+export function ShippingSettings() {
+  const [days, setDays] = useState<number>(5);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchSettings() {
+      try {
+        const data = await apiClient<ShippingPreparationDays>(
+          "/settings/shipping-preparation-days"
+        );
+        setDays(data.value);
+      } catch {
+        // Use default
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSettings();
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMessage(null);
+    try {
+      await apiClient<ShippingPreparationDays>(
+        "/settings/shipping-preparation-days",
+        { method: "PUT", body: { value: days } }
+      );
+      setMessage("保存しました");
+      setTimeout(() => setMessage(null), 3000);
+    } catch {
+      setMessage("保存に失敗しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>配送設定</CardTitle>
+        <CardDescription>発送準備に必要な営業日数を設定します</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-end gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="prep-days">発送準備日数</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="prep-days"
+                type="number"
+                min={0}
+                max={30}
+                value={days}
+                onChange={(e) => setDays(Number(e.target.value))}
+                className="w-24"
+              />
+              <span className="text-sm text-muted-foreground">営業日</span>
+            </div>
+          </div>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "保存中..." : "保存"}
+          </Button>
+        </div>
+        {message && (
+          <p className="text-sm text-muted-foreground">{message}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 2: 独自休日管理コンポーネントを作成**
+
+```tsx
+// web/src/features/settings/components/company-holidays.tsx
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { apiClient } from "@/lib/api/client";
+import type { CompanyHoliday, CompanyHolidayListResponse } from "@/types/api";
+
+export function CompanyHolidays() {
+  const [holidays, setHolidays] = useState<CompanyHoliday[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newDate, setNewDate] = useState("");
+  const [newName, setNewName] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  const fetchHolidays = useCallback(async () => {
+    try {
+      const data = await apiClient<CompanyHolidayListResponse>(
+        "/settings/company-holidays"
+      );
+      setHolidays(data.items);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHolidays();
+  }, [fetchHolidays]);
+
+  const handleAdd = async () => {
+    if (!newDate || !newName) return;
+    setAdding(true);
+    try {
+      await apiClient<CompanyHoliday>("/settings/company-holidays", {
+        method: "POST",
+        body: { date: newDate, name: newName },
+      });
+      setNewDate("");
+      setNewName("");
+      await fetchHolidays();
+    } catch {
+      // ignore
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await apiClient<void>(`/settings/company-holidays/${id}`, {
+        method: "DELETE",
+      });
+      await fetchHolidays();
+    } catch {
+      // ignore
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>会社休日</CardTitle>
+        <CardDescription>
+          TOSYO独自の休日を登録します。配送予定日の計算から除外されます。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-end gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="holiday-date">日付</Label>
+            <Input
+              id="holiday-date"
+              type="date"
+              value={newDate}
+              onChange={(e) => setNewDate(e.target.value)}
+              className="w-44"
+            />
+          </div>
+          <div className="space-y-2 flex-1">
+            <Label htmlFor="holiday-name">休日名</Label>
+            <Input
+              id="holiday-name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="例: 夏季休暇"
+            />
+          </div>
+          <Button onClick={handleAdd} disabled={adding || !newDate || !newName}>
+            {adding ? "追加中..." : "追加"}
+          </Button>
+        </div>
+
+        {holidays.length > 0 && (
+          <div className="rounded-lg border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>日付</TableHead>
+                  <TableHead>休日名</TableHead>
+                  <TableHead className="w-[80px]"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {holidays.map((holiday) => (
+                  <TableRow key={holiday.id}>
+                    <TableCell>{holiday.date}</TableCell>
+                    <TableCell>{holiday.name}</TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(holiday.id)}
+                        className="text-destructive hover:text-destructive"
+                      >
+                        削除
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {holidays.length === 0 && (
+          <p className="text-sm text-muted-foreground">登録された休日はありません</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 3: 設定ページを拡張**
+
+`web/src/app/(dashboard)/settings/page.tsx` を更新:
+
+```tsx
+"use client";
+
+import { PageContainer } from "@/components/layout/page-container";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { ShippingSettings } from "@/features/settings/components/shipping-settings";
+import { CompanyHolidays } from "@/features/settings/components/company-holidays";
+
+export default function SettingsPage() {
+  return (
+    <PageContainer title="設定" description="システム設定">
+      <div className="max-w-2xl space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>アカウント情報</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">メールアドレス</Label>
+              <Input id="email" defaultValue="admin@example.com" disabled />
+            </div>
+          </CardContent>
+        </Card>
+
+        <ShippingSettings />
+        <CompanyHolidays />
+      </div>
+    </PageContainer>
+  );
+}
+```
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add web/src/features/settings/components/shipping-settings.tsx web/src/features/settings/components/company-holidays.tsx web/src/app/\(dashboard\)/settings/page.tsx
+git commit -m "feat: add shipping preparation days and company holidays to settings page"
+```
+
+---
+
+## Task 8: jpholidayをrequirementsに追加
+
+**Files:**
+- Modify: `api/requirements.txt` or `api/pyproject.toml` (whichever exists)
+
+- [ ] **Step 1: requirements/依存関係ファイルを確認し、jpholidayを追加**
+
+Run: `ls api/requirements*.txt api/pyproject.toml 2>/dev/null` to find the dependency file.
+Add `jpholiday` to the appropriate file.
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add api/requirements*.txt api/pyproject.toml  # whichever was modified
+git commit -m "chore: add jpholiday dependency for Japanese holiday calculation"
+```

--- a/docs/superpowers/plans/2026-04-07-persist-estimated-shipping-date.md
+++ b/docs/superpowers/plans/2026-04-07-persist-estimated-shipping-date.md
@@ -1,0 +1,873 @@
+# 納品予定日のDB永続化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shipment作成時に `estimated_shipping_date` を計算してDBに永続化する。未発注（pending order）は「-」表示にする。
+
+**Architecture:** `shipments` テーブルに `estimated_shipping_date` カラム（DATE, nullable）を追加。Shipment自動作成時（OrderService, ManufacturerOrderService）に計算してセット。`list_with_pending_orders()` のShipment側はDB値をそのまま返し、pending order側は `estimated_shipping_date = None` を返す（フロントは既に null → "-" 表示済み）。
+
+**Tech Stack:** Alembic, SQLAlchemy, FastAPI, pytest
+
+---
+
+### Task 1: Alembicマイグレーション — `estimated_shipping_date` カラム追加
+
+**Files:**
+- Create: `api/alembic/versions/add_estimated_shipping_date.py`
+
+- [ ] **Step 1: マイグレーションファイルを作成**
+
+```python
+"""Add estimated_shipping_date column to shipments table.
+
+Revision ID: add_est_ship_date_001
+Revises: add_sys_settings_001
+Create Date: 2026-04-07
+
+Shipment作成時に計算した納品予定日を永続化する。
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "add_est_ship_date_001"
+down_revision = "add_sys_settings_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "shipments",
+        sa.Column("estimated_shipping_date", sa.Date(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("shipments", "estimated_shipping_date")
+```
+
+- [ ] **Step 2: マイグレーション実行確認**
+
+Run: `cd api && uv run alembic upgrade head`
+Expected: SUCCESS, カラムが追加される
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/alembic/versions/add_estimated_shipping_date.py
+git commit -m "feat: add estimated_shipping_date column to shipments table"
+```
+
+---
+
+### Task 2: Shipmentモデルにカラム追加
+
+**Files:**
+- Modify: `api/app/models/shipment.py:1-10` (import追加), `api/app/models/shipment.py:39-40` (カラム追加)
+
+- [ ] **Step 1: importに `Date` を追加**
+
+`api/app/models/shipment.py` の import行を修正:
+
+```python
+# Before:
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+
+# After:
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, String, Text
+```
+
+- [ ] **Step 2: `estimated_shipping_date` カラムをモデルに追加**
+
+`api/app/models/shipment.py` の `note` カラムの後に追加:
+
+```python
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    estimated_shipping_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    shipping_email_sent: Mapped[bool] = mapped_column(
+```
+
+`datetime` importに `date` を追加:
+
+```python
+# Before:
+from datetime import datetime
+
+# After:
+from datetime import date, datetime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/app/models/shipment.py
+git commit -m "feat: add estimated_shipping_date field to Shipment model"
+```
+
+---
+
+### Task 3: ShipmentRepository.create に `estimated_shipping_date` パラメータ追加
+
+**Files:**
+- Modify: `api/app/repositories/shipment_repository.py:153-173`
+- Test: `api/tests/unit/test_shipment_repo_estimated_date.py`
+
+- [ ] **Step 1: テストを書く**
+
+```python
+"""Test ShipmentRepository.create with estimated_shipping_date."""
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.repositories.shipment_repository import ShipmentRepository
+
+
+@pytest.mark.asyncio
+async def test_create_sets_estimated_shipping_date():
+    """Shipment作成時にestimated_shipping_dateがセットされる."""
+    db = AsyncMock()
+    repo = ShipmentRepository(db)
+
+    mock_shipment = MagicMock()
+    mock_shipment.id = "ship-1"
+
+    # Patch find_by_id to return a mock
+    with patch.object(repo, "find_by_id", return_value=mock_shipment):
+        db.flush = AsyncMock()
+        db.refresh = AsyncMock()
+        db.add = MagicMock()
+
+        # capture what Shipment() gets created with
+        created_shipments = []
+        original_add = db.add
+
+        def capture_add(obj):
+            from app.models.shipment import Shipment
+            if isinstance(obj, Shipment):
+                created_shipments.append(obj)
+
+        db.add.side_effect = capture_add
+
+        await repo.create(
+            order_ids=["order-1"],
+            estimated_shipping_date=date(2026, 4, 15),
+        )
+
+        assert len(created_shipments) == 1
+        assert created_shipments[0].estimated_shipping_date == date(2026, 4, 15)
+
+
+@pytest.mark.asyncio
+async def test_create_without_estimated_shipping_date():
+    """estimated_shipping_dateがNoneの場合もShipmentが作成される."""
+    db = AsyncMock()
+    repo = ShipmentRepository(db)
+
+    mock_shipment = MagicMock()
+    mock_shipment.id = "ship-1"
+
+    with patch.object(repo, "find_by_id", return_value=mock_shipment):
+        db.flush = AsyncMock()
+        db.refresh = AsyncMock()
+        db.add = MagicMock()
+
+        created_shipments = []
+
+        def capture_add(obj):
+            from app.models.shipment import Shipment
+            if isinstance(obj, Shipment):
+                created_shipments.append(obj)
+
+        db.add.side_effect = capture_add
+
+        await repo.create(order_ids=["order-1"])
+
+        assert len(created_shipments) == 1
+        assert created_shipments[0].estimated_shipping_date is None
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_shipment_repo_estimated_date.py -v`
+Expected: FAIL — `create()` が `estimated_shipping_date` パラメータを受け取らない
+
+- [ ] **Step 3: Repository.create を修正**
+
+`api/app/repositories/shipment_repository.py` の `create` メソッドを修正:
+
+```python
+    async def create(
+        self,
+        order_ids: list[str],
+        estimated_shipping_date: date | None = None,
+    ) -> Shipment:
+        """Create a new shipment.
+
+        顧客情報は order_ids の最初の注文から参照します。
+        """
+        shipment = Shipment(estimated_shipping_date=estimated_shipping_date)
+        self._db.add(shipment)
+        await self._db.flush()
+
+        # Create items
+        for order_id in order_ids:
+            item = ShipmentItem(
+                shipment_id=shipment.id,
+                order_id=order_id,
+            )
+            self._db.add(item)
+
+        await self._db.flush()
+        await self._db.refresh(shipment)
+
+        return await self.find_by_id(shipment.id)  # type: ignore
+```
+
+`date` の import を追加（ファイル先頭）:
+
+```python
+# Before:
+from datetime import date
+
+# After (変更なし — 既にimportされている):
+from datetime import date
+```
+
+- [ ] **Step 4: テストがパスすることを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_shipment_repo_estimated_date.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/repositories/shipment_repository.py api/tests/unit/test_shipment_repo_estimated_date.py
+git commit -m "feat: accept estimated_shipping_date in ShipmentRepository.create"
+```
+
+---
+
+### Task 4: Shipment作成時に納品予定日を計算して保存 — OrderService
+
+**Files:**
+- Modify: `api/app/services/order_service.py:250-270`
+- Test: `api/tests/unit/test_order_service_status.py` (既存テストに追加)
+
+- [ ] **Step 1: テストを書く**
+
+`api/tests/unit/test_order_estimated_shipping_date.py` を新規作成:
+
+```python
+"""Test estimated_shipping_date is persisted when OrderService creates a shipment."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.order import Order, OrderItem, OrderStatus
+from app.services.order_service import OrderService
+
+
+def _make_order(ordered_at: datetime, lead_time_days: int = 10) -> MagicMock:
+    """Create a mock Order with items."""
+    product = MagicMock()
+    product.lead_time_days = lead_time_days
+
+    order_item = MagicMock(spec=OrderItem)
+    order_item.product = product
+
+    order = MagicMock(spec=Order)
+    order.id = "order-1"
+    order.status = OrderStatus.DELIVERED.value
+    order.ordered_at = ordered_at
+    order.items = [order_item]
+    return order
+
+
+@pytest.mark.asyncio
+async def test_create_shipment_persists_estimated_shipping_date():
+    """delivered時にShipment作成で estimated_shipping_date が渡される."""
+    order_repo = AsyncMock()
+    shipment_repo = AsyncMock()
+    file_storage = MagicMock()
+    settings_service = AsyncMock()
+
+    settings_service.get_shipping_preparation_days_value = AsyncMock(return_value=5)
+    settings_service.get_company_holiday_dates = AsyncMock(return_value=set())
+
+    service = OrderService(
+        order_repo=order_repo,
+        shipment_repo=shipment_repo,
+        file_storage=file_storage,
+        settings_service=settings_service,
+    )
+
+    ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order = _make_order(ordered_at=ordered_at, lead_time_days=10)
+
+    shipment_repo.exists_for_order = AsyncMock(return_value=False)
+    shipment_repo.create = AsyncMock()
+
+    await service._create_shipment_for_order(order)
+
+    shipment_repo.create.assert_called_once()
+    call_kwargs = shipment_repo.create.call_args
+    assert call_kwargs.kwargs.get("estimated_shipping_date") is not None
+    # ordered_at(4/1) + 10日 = 4/11, then + 5 business days
+    assert isinstance(call_kwargs.kwargs["estimated_shipping_date"], date)
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_order_estimated_shipping_date.py -v`
+Expected: FAIL — `_create_shipment_for_order` がまだ `estimated_shipping_date` を渡していない
+
+- [ ] **Step 3: OrderService._create_shipment_for_order を修正**
+
+`api/app/services/order_service.py` の `_create_shipment_for_order` メソッドを修正:
+
+```python
+    async def _create_shipment_for_order(self, order: Order) -> None:
+        """Create a shipment for the delivered order.
+
+        This method is idempotent - if a shipment already exists for the order,
+        it will not create a duplicate. The shipment creation happens within
+        the same transaction as the order status update, ensuring atomicity.
+
+        顧客情報は Shipment から Order のリレーションを経由して取得します。
+
+        Args:
+            order: The order that was just marked as delivered.
+
+        Raises:
+            Exception: If shipment creation fails, the entire transaction
+                       (including order status update) will be rolled back.
+        """
+        # Check if shipment already exists (prevent duplicates)
+        if await self._shipment_repo.exists_for_order(order.id):
+            return
+
+        estimated_date = await self._calculate_estimated_shipping_date(order)
+        await self._shipment_repo.create(
+            order_ids=[order.id],
+            estimated_shipping_date=estimated_date,
+        )
+
+    async def _calculate_estimated_shipping_date(self, order: Order) -> date | None:
+        """注文の納品予定日を計算する."""
+        if not self._settings_service:
+            return None
+
+        from datetime import timedelta
+        from app.utils.business_day_calculator import add_business_days
+
+        prep_days = await self._settings_service.get_shipping_preparation_days_value()
+        company_holidays = await self._settings_service.get_company_holiday_dates()
+
+        delivery_dates: list[date] = []
+        if order.items:
+            for order_item in order.items:
+                product = order_item.product if order_item.product else None
+                if product and product.lead_time_days is not None:
+                    d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
+                    delivery_dates.append(d)
+
+        if not delivery_dates:
+            return None
+
+        latest_delivery = max(delivery_dates)
+        return add_business_days(latest_delivery, prep_days, company_holidays)
+```
+
+`OrderService.__init__` に `settings_service` パラメータが既にあるか確認し、なければ追加する。
+
+- [ ] **Step 4: テストがパスすることを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_order_estimated_shipping_date.py -v`
+Expected: PASS
+
+- [ ] **Step 5: 既存テストが壊れていないことを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_order_service_status.py tests/unit/test_order_service_bulk_status.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/app/services/order_service.py api/tests/unit/test_order_estimated_shipping_date.py
+git commit -m "feat: persist estimated_shipping_date when OrderService creates shipment"
+```
+
+---
+
+### Task 5: Shipment作成時に納品予定日を計算して保存 — ManufacturerOrderService
+
+**Files:**
+- Modify: `api/app/services/manufacturer_order_service.py:278-293`
+- Test: `api/tests/unit/test_manufacturer_order_estimated_date.py`
+
+- [ ] **Step 1: テストを書く**
+
+```python
+"""Test ManufacturerOrderService persists estimated_shipping_date on shipment creation."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.order import Order, OrderItem, OrderItemStatus
+from app.services.manufacturer_order_service import ManufacturerOrderService
+
+
+@pytest.mark.asyncio
+async def test_create_shipment_persists_estimated_shipping_date():
+    """全OrderItem delivered時にShipment作成でestimated_shipping_dateが渡される."""
+    order_repo = AsyncMock()
+    shipment_repo = AsyncMock()
+    settings_service = AsyncMock()
+
+    settings_service.get_shipping_preparation_days_value = AsyncMock(return_value=5)
+    settings_service.get_company_holiday_dates = AsyncMock(return_value=set())
+
+    service = ManufacturerOrderService(
+        order_repo=order_repo,
+        shipment_repo=shipment_repo,
+        settings_service=settings_service,
+    )
+
+    product = MagicMock()
+    product.lead_time_days = 7
+
+    order_item = MagicMock(spec=OrderItem)
+    order_item.product = product
+
+    order = MagicMock(spec=Order)
+    order.id = "order-1"
+    order.ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.items = [order_item]
+
+    shipment_repo.exists_for_order = AsyncMock(return_value=False)
+    shipment_repo.create = AsyncMock()
+
+    await service._create_shipment_for_order(order)
+
+    shipment_repo.create.assert_called_once()
+    call_kwargs = shipment_repo.create.call_args
+    assert call_kwargs.kwargs.get("estimated_shipping_date") is not None
+    assert isinstance(call_kwargs.kwargs["estimated_shipping_date"], date)
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_manufacturer_order_estimated_date.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: ManufacturerOrderService._create_shipment_for_order を修正**
+
+`api/app/services/manufacturer_order_service.py` の `_create_shipment_for_order` メソッドを修正:
+
+```python
+    async def _create_shipment_for_order(self, order: Order) -> bool:
+        """Create a shipment for the delivered order.
+
+        This method is idempotent - if a shipment already exists for the order,
+        it will not create a duplicate.
+
+        Returns:
+            bool: True if a shipment was created, False if it already existed
+        """
+        # Check if shipment already exists (prevent duplicates)
+        if await self._shipment_repo.exists_for_order(order.id):
+            return False
+
+        estimated_date = await self._calculate_estimated_shipping_date(order)
+        await self._shipment_repo.create(
+            order_ids=[order.id],
+            estimated_shipping_date=estimated_date,
+        )
+        return True
+
+    async def _calculate_estimated_shipping_date(self, order: Order) -> date | None:
+        """注文の納品予定日を計算する."""
+        if not self._settings_service:
+            return None
+
+        from datetime import timedelta
+        from app.utils.business_day_calculator import add_business_days
+
+        prep_days = await self._settings_service.get_shipping_preparation_days_value()
+        company_holidays = await self._settings_service.get_company_holiday_dates()
+
+        delivery_dates: list[date] = []
+        if order.items:
+            for order_item in order.items:
+                product = order_item.product if order_item.product else None
+                if product and product.lead_time_days is not None:
+                    d = order.ordered_at.date() + timedelta(days=product.lead_time_days)
+                    delivery_dates.append(d)
+
+        if not delivery_dates:
+            return None
+
+        latest_delivery = max(delivery_dates)
+        return add_business_days(latest_delivery, prep_days, company_holidays)
+```
+
+`ManufacturerOrderService.__init__` に `settings_service` パラメータが既にあるか確認し、なければ追加。DIコンテナ（依存注入の箇所）でも `settings_service` を渡すようにする。
+
+- [ ] **Step 4: テストがパスすることを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_manufacturer_order_estimated_date.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/services/manufacturer_order_service.py api/tests/unit/test_manufacturer_order_estimated_date.py
+git commit -m "feat: persist estimated_shipping_date when ManufacturerOrderService creates shipment"
+```
+
+---
+
+### Task 6: ShipmentService — DB値を使うように変更 & pending orderのestimated_shipping_dateをNullに
+
+**Files:**
+- Modify: `api/app/services/shipment_service.py:142-163, 198-247`
+- Modify: `api/app/services/shipment_service.py:73-89` (ShipmentService.create)
+- Test: `api/tests/unit/test_shipment_pending_orders.py` (既存テスト修正)
+
+- [ ] **Step 1: テストを書く**
+
+`api/tests/unit/test_shipment_estimated_date_persistence.py` を新規作成:
+
+```python
+"""Test that ShipmentService uses DB value for estimated_shipping_date."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.shipment import Shipment, ShipmentItem, ShipmentStatus
+from app.schemas.shipment import PendingOrderStatus
+from app.services.shipment_service import ShipmentService
+
+
+def _make_shipment(estimated_date: date | None = None) -> MagicMock:
+    """Create a mock Shipment with estimated_shipping_date."""
+    order = MagicMock()
+    order.id = "order-1"
+    order.order_number = "ORD-001"
+    order.customer_name = "テスト太郎"
+    order.customer_postal_code = "100-0001"
+    order.customer_address_prefecture = "東京都"
+    order.customer_address_city = "千代田区"
+    order.customer_address_building = None
+    order.customer_phone = "03-1234-5678"
+    order.items = []
+
+    item = MagicMock(spec=ShipmentItem)
+    item.id = "item-1"
+    item.order_id = "order-1"
+    item.order = order
+
+    shipment = MagicMock(spec=Shipment)
+    shipment.id = "ship-1"
+    shipment.status = ShipmentStatus.PENDING.value
+    shipment.tracking_number = None
+    shipment.carrier = None
+    shipment.packing_photo_path = None
+    shipment.shipped_at = None
+    shipment.delivered_at = None
+    shipment.note = None
+    shipment.created_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    shipment.updated_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    shipment.estimated_shipping_date = estimated_date
+    shipment.items = [item]
+    shipment.first_order = order
+    return shipment
+
+
+@pytest.mark.asyncio
+async def test_list_shipment_uses_db_estimated_date():
+    """Shipmentの納品予定日はDBの値をそのまま返す."""
+    shipment_repo = AsyncMock()
+    order_repo = AsyncMock()
+    file_storage = MagicMock()
+    settings_service = AsyncMock()
+
+    shipment = _make_shipment(estimated_date=date(2026, 4, 20))
+    shipment_repo.find_all = AsyncMock(return_value=([shipment], 1))
+    order_repo.find_pending_orders = AsyncMock(return_value=([], 0))
+
+    service = ShipmentService(
+        shipment_repo=shipment_repo,
+        order_repo=order_repo,
+        file_storage=file_storage,
+        settings_service=settings_service,
+    )
+
+    result = await service.list_with_pending_orders()
+
+    assert result.items[0].estimated_shipping_date == date(2026, 4, 20)
+    # settings_service should NOT be called for calculation
+    settings_service.get_shipping_preparation_days_value.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pending_order_has_null_estimated_date():
+    """Pending orderの納品予定日はNone（フロントで「-」表示）."""
+    shipment_repo = AsyncMock()
+    order_repo = AsyncMock()
+    file_storage = MagicMock()
+    settings_service = AsyncMock()
+
+    order = MagicMock()
+    order.id = "order-1"
+    order.order_number = "ORD-001"
+    order.customer_name = "テスト太郎"
+    order.customer_postal_code = "100-0001"
+    order.customer_address_prefecture = "東京都"
+    order.customer_address_city = "千代田区"
+    order.customer_address_building = None
+    order.customer_phone = "03-1234-5678"
+    order.ordered_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.created_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    order.items = []
+
+    shipment_repo.find_all = AsyncMock(return_value=([], 0))
+    order_repo.find_pending_orders = AsyncMock(return_value=([order], 1))
+
+    service = ShipmentService(
+        shipment_repo=shipment_repo,
+        order_repo=order_repo,
+        file_storage=file_storage,
+        settings_service=settings_service,
+    )
+
+    result = await service.list_with_pending_orders(
+        pending_order_status=PendingOrderStatus.PREPARING,
+    )
+
+    assert result.items[0].estimated_shipping_date is None
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_shipment_estimated_date_persistence.py -v`
+Expected: FAIL — まだ動的計算している
+
+- [ ] **Step 3: ShipmentService.list_with_pending_orders を修正**
+
+`api/app/services/shipment_service.py` の `list_with_pending_orders` メソッドを修正:
+
+1. Shipment側: 動的計算を削除し、`_to_response` がDB値をそのまま返すようにする
+2. Pending order側: `estimated_shipping_date` の動的計算を削除（常にNone）
+3. settings取得ロジック（prep_days, company_holidays）を削除
+
+```python
+    async def list_with_pending_orders(
+        self,
+        page: int = 1,
+        limit: int = 20,
+        shipment_status: ShipmentStatus | None = None,
+        pending_order_status: PendingOrderStatus | None = None,
+        created_from: date | None = None,
+        created_to: date | None = None,
+        search: str | None = None,
+        tracking_number: str | None = None,
+        carrier: str | None = None,
+        shipped_from: date | None = None,
+        shipped_to: date | None = None,
+        delivered_from: date | None = None,
+        delivered_to: date | None = None,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> ShipmentListWithPendingResponse:
+        """List shipments with pending orders."""
+        items: list = []
+        shipment_total = 0
+        pending_total = 0
+
+        # If filtering by PendingOrderStatus, skip shipments
+        if pending_order_status is None:
+            shipments, shipment_total = await self._shipment_repo.find_all(
+                page=page,
+                limit=limit,
+                status=shipment_status,
+                created_from=created_from,
+                created_to=created_to,
+                search=search,
+                tracking_number=tracking_number,
+                carrier=carrier,
+                shipped_from=shipped_from,
+                shipped_to=shipped_to,
+                delivered_from=delivered_from,
+                delivered_to=delivered_to,
+                sort_by=sort_by,
+                sort_order=sort_order,
+            )
+            for shipment in shipments:
+                response = self._to_response(shipment)
+                response.estimated_shipping_date = shipment.estimated_shipping_date
+                items.append(response)
+
+        # If filtering by ShipmentStatus, skip pending orders
+        if shipment_status is None:
+            pending_orders, pending_total = await self._order_repo.find_pending_orders(
+                page=page,
+                limit=limit,
+                status=pending_order_status,
+            )
+            for order in pending_orders:
+                response = self._to_pending_order_response(order)
+                # pending orderは納品予定日なし（フロントで「-」表示）
+                response.estimated_shipping_date = None
+                items.append(response)
+
+        total = shipment_total + pending_total
+
+        return ShipmentListWithPendingResponse(
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+        )
+```
+
+- [ ] **Step 4: ShipmentService.create にもestimated_shipping_date計算を追加**
+
+`api/app/services/shipment_service.py` の `create` メソッドを修正（手動でShipment作成する場合もDB保存する）:
+
+```python
+    async def create(self, data: ShipmentCreate) -> ShipmentResponse:
+        """Create a new shipment."""
+        orders = []
+        for order_id in data.order_ids:
+            order = await self._order_repo.find_by_id(order_id)
+            if not order:
+                raise ValidationError(f"Order {order_id} not found")
+            if order.status != OrderStatus.DELIVERED.value:
+                raise ValidationError(f"Order {order_id} is not in delivered status")
+            if await self._shipment_repo.exists_for_order(order_id):
+                raise ValidationError(f"Order {order_id} already has a shipment")
+            orders.append(order)
+
+        estimated_date = await self._calculate_estimated_shipping_date_for_orders(orders)
+        shipment = await self._shipment_repo.create(
+            order_ids=data.order_ids,
+            estimated_shipping_date=estimated_date,
+        )
+
+        return self._to_response(shipment)
+
+    async def _calculate_estimated_shipping_date_for_orders(
+        self, orders: list
+    ) -> date | None:
+        """複数注文から納品予定日を計算する."""
+        if not self._settings_service:
+            return None
+
+        prep_days = await self._settings_service.get_shipping_preparation_days_value()
+        company_holidays = await self._settings_service.get_company_holiday_dates()
+
+        return self._calculate_estimated_shipping_date(orders, prep_days, company_holidays)
+```
+
+- [ ] **Step 5: テストがパスすることを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_shipment_estimated_date_persistence.py -v`
+Expected: PASS
+
+- [ ] **Step 6: 既存テストが壊れていないことを確認**
+
+Run: `cd api && uv run pytest tests/unit/test_shipment_pending_orders.py tests/unit/test_shipment_service_status.py -v`
+Expected: ALL PASS（既存テストの修正が必要な場合は対応）
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/app/services/shipment_service.py api/tests/unit/test_shipment_estimated_date_persistence.py
+git commit -m "feat: use DB-persisted estimated_shipping_date, remove dynamic calculation for pending orders"
+```
+
+---
+
+### Task 7: フロントエンド — pending orderで「-」表示の確認
+
+**Files:**
+- Review: `web/src/features/shipments/components/shipment-list.tsx:63-65`
+
+- [ ] **Step 1: 既存のフロント実装を確認**
+
+`shipment-list.tsx` の `getEstimatedShippingDate` 関数を確認:
+
+```typescript
+function getEstimatedShippingDate(item: ShipmentOrPendingOrder): string {
+  const dateStr = "estimated_shipping_date" in item ? item.estimated_shipping_date : null;
+  if (!dateStr) return "-";
+  // ...
+}
+```
+
+既に `null` → `"-"` の変換が実装されている。バックエンドが pending order に対して `estimated_shipping_date: null` を返すようにしたので、**フロントエンドの変更は不要**。
+
+- [ ] **Step 2: Commit（変更なし）**
+
+フロントエンドの変更は不要。確認のみ。
+
+---
+
+### Task 8: 全体テスト実行 & DIコンテナ修正
+
+**Files:**
+- Modify: DI設定ファイル（`settings_service` の注入箇所を確認・修正）
+
+- [ ] **Step 1: OrderServiceのDI設定を確認**
+
+`OrderService` に `settings_service` が注入されているか確認。されていなければ、DIコンテナ（`api/app/dependencies.py` や `api/app/routers/` の依存注入箇所）で `settings_service` を渡すように修正。
+
+- [ ] **Step 2: ManufacturerOrderServiceのDI設定を確認**
+
+同様に `ManufacturerOrderService` に `settings_service` が注入されているか確認・修正。
+
+- [ ] **Step 3: 全ユニットテスト実行**
+
+Run: `cd api && uv run pytest tests/unit/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 4: 全統合テスト実行**
+
+Run: `cd api && uv run pytest tests/integration/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit（DI修正があった場合）**
+
+```bash
+git add -A
+git commit -m "fix: inject settings_service into OrderService and ManufacturerOrderService for estimated date calculation"
+```
+
+---
+
+### Task 9: 既存Shipmentデータのバックフィル（オプション）
+
+**Files:**
+- Review: 既存データの扱い
+
+- [ ] **Step 1: 既存データの扱いを確認**
+
+既存Shipmentの `estimated_shipping_date` は `NULL` のまま。フロントで `null` → `"-"` 表示されるので表示上は問題なし。
+
+必要に応じて手動でバックフィルするSQLを用意できるが、「発注時点で確定」の方針なので、過去データは NULL のままが自然。
+
+- [ ] **Step 2: 完了確認**
+
+動作確認を実施して完了。

--- a/web/src/app/(dashboard)/settings/page.tsx
+++ b/web/src/app/(dashboard)/settings/page.tsx
@@ -4,10 +4,12 @@ import { PageContainer } from "@/components/layout/page-container";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { ShippingSettings } from "@/features/settings/components/shipping-settings";
+import { CompanyHolidays } from "@/features/settings/components/company-holidays";
 
 export default function SettingsPage() {
   return (
-    <PageContainer title="設定" description="アカウント設定">
+    <PageContainer title="設定" description="システム設定">
       <div className="max-w-2xl space-y-6">
         <Card>
           <CardHeader>
@@ -20,6 +22,9 @@ export default function SettingsPage() {
             </div>
           </CardContent>
         </Card>
+
+        <ShippingSettings />
+        <CompanyHolidays />
       </div>
     </PageContainer>
   );

--- a/web/src/features/settings/components/company-holidays.tsx
+++ b/web/src/features/settings/components/company-holidays.tsx
@@ -51,8 +51,8 @@ export function CompanyHolidays() {
       setNewDate("");
       setNewName("");
       await fetchHolidays();
-    } catch {
-      // ignore
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "追加に失敗しました");
     } finally {
       setAdding(false);
     }
@@ -64,8 +64,8 @@ export function CompanyHolidays() {
         method: "DELETE",
       });
       await fetchHolidays();
-    } catch {
-      // ignore
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "削除に失敗しました");
     }
   };
 

--- a/web/src/features/settings/components/company-holidays.tsx
+++ b/web/src/features/settings/components/company-holidays.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { apiClient } from "@/lib/api/client";
+import type { CompanyHoliday, CompanyHolidayListResponse } from "@/types/api";
+
+export function CompanyHolidays() {
+  const [holidays, setHolidays] = useState<CompanyHoliday[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newDate, setNewDate] = useState("");
+  const [newName, setNewName] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  const fetchHolidays = useCallback(async () => {
+    try {
+      const data = await apiClient<CompanyHolidayListResponse>(
+        "/settings/company-holidays"
+      );
+      setHolidays(data.items);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHolidays();
+  }, [fetchHolidays]);
+
+  const handleAdd = async () => {
+    if (!newDate || !newName) return;
+    setAdding(true);
+    try {
+      await apiClient<CompanyHoliday>("/settings/company-holidays", {
+        method: "POST",
+        body: { date: newDate, name: newName },
+      });
+      setNewDate("");
+      setNewName("");
+      await fetchHolidays();
+    } catch {
+      // ignore
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await apiClient<void>(`/settings/company-holidays/${id}`, {
+        method: "DELETE",
+      });
+      await fetchHolidays();
+    } catch {
+      // ignore
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>会社休日</CardTitle>
+        <CardDescription>
+          TOSYO独自の休日を登録します。配送予定日の計算から除外されます。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-end gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="holiday-date">日付</Label>
+            <Input
+              id="holiday-date"
+              type="date"
+              value={newDate}
+              onChange={(e) => setNewDate(e.target.value)}
+              className="w-44"
+            />
+          </div>
+          <div className="space-y-2 flex-1">
+            <Label htmlFor="holiday-name">休日名</Label>
+            <Input
+              id="holiday-name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="例: 夏季休暇"
+            />
+          </div>
+          <Button onClick={handleAdd} disabled={adding || !newDate || !newName}>
+            {adding ? "追加中..." : "追加"}
+          </Button>
+        </div>
+
+        {holidays.length > 0 && (
+          <div className="rounded-lg border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>日付</TableHead>
+                  <TableHead>休日名</TableHead>
+                  <TableHead className="w-[80px]"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {holidays.map((holiday) => (
+                  <TableRow key={holiday.id}>
+                    <TableCell>{holiday.date}</TableCell>
+                    <TableCell>{holiday.name}</TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(holiday.id)}
+                        className="text-destructive hover:text-destructive"
+                      >
+                        削除
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {holidays.length === 0 && (
+          <p className="text-sm text-muted-foreground">登録された休日はありません</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/settings/components/shipping-settings.tsx
+++ b/web/src/features/settings/components/shipping-settings.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api/client";
+import type { ShippingPreparationDays } from "@/types/api";
+
+export function ShippingSettings() {
+  const [days, setDays] = useState<number>(5);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchSettings() {
+      try {
+        const data = await apiClient<ShippingPreparationDays>(
+          "/settings/shipping-preparation-days"
+        );
+        setDays(data.value);
+      } catch {
+        // Use default
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSettings();
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMessage(null);
+    try {
+      await apiClient<ShippingPreparationDays>(
+        "/settings/shipping-preparation-days",
+        { method: "PUT", body: { value: days } }
+      );
+      setMessage("保存しました");
+      setTimeout(() => setMessage(null), 3000);
+    } catch {
+      setMessage("保存に失敗しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>配送設定</CardTitle>
+        <CardDescription>発送準備に必要な営業日数を設定します</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-end gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="prep-days">発送準備日数</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="prep-days"
+                type="number"
+                min={0}
+                max={30}
+                value={days}
+                onChange={(e) => setDays(Number(e.target.value))}
+                className="w-24"
+              />
+              <span className="text-sm text-muted-foreground">営業日</span>
+            </div>
+          </div>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "保存中..." : "保存"}
+          </Button>
+        </div>
+        {message && (
+          <p className="text-sm text-muted-foreground">{message}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/shipments/components/shipment-list.tsx
+++ b/web/src/features/shipments/components/shipment-list.tsx
@@ -60,6 +60,17 @@ function getDisplayId(item: ShipmentOrPendingOrder): string {
   return item.id.slice(0, 8);
 }
 
+function getEstimatedShippingDate(item: ShipmentOrPendingOrder): string {
+  const dateStr = "estimated_shipping_date" in item ? item.estimated_shipping_date : null;
+  if (!dateStr) return "-";
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
   return date.toLocaleDateString("ja-JP", {
@@ -119,13 +130,14 @@ export function ShipmentList({
             <TableHead>商品数</TableHead>
             <TableHead>伝票番号</TableHead>
             <TableHead>作成日</TableHead>
+            <TableHead>配送予定日</TableHead>
             <TableHead>ステータス</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {shipments.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+              <TableCell colSpan={8} className="h-24 text-center text-muted-foreground">
                 該当する配送がありません
               </TableCell>
             </TableRow>
@@ -159,6 +171,7 @@ export function ShipmentList({
                   <TableCell>{getItemCount(item)}点</TableCell>
                   <TableCell>{getTrackingNumber(item)}</TableCell>
                   <TableCell>{formatDate(item.created_at)}</TableCell>
+                  <TableCell>{getEstimatedShippingDate(item)}</TableCell>
                   <TableCell>
                     <StatusBadge status={item.status} />
                   </TableCell>

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -192,6 +192,7 @@ export interface PendingOrder {
   status: PendingOrderStatus;
   created_at: string;
   order_items: OrderItemSummary[];
+  estimated_shipping_date: string | null;
 }
 
 export interface ShipmentItem {
@@ -212,6 +213,7 @@ export interface Shipment {
   packing_photo_path: string | null;
   shipped_at: string | null;
   delivered_at: string | null;
+  estimated_shipping_date: string | null;
   note: string | null;
   customer_name: string;
   customer_postal_code: string;
@@ -410,6 +412,22 @@ export interface ManufacturerProfile {
   bank_account_holder: string | null;
   representative_name: string | null;
   invoice_notes: string | null;
+}
+
+// Settings types
+export interface ShippingPreparationDays {
+  value: number;
+  description: string | null;
+}
+
+export interface CompanyHoliday {
+  id: string;
+  date: string;
+  name: string;
+}
+
+export interface CompanyHolidayListResponse {
+  items: CompanyHoliday[];
 }
 
 export interface ManufacturerProfileUpdate {

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -20,6 +20,7 @@ export interface OrderItem {
   color: string | null;
   design_image_url: string | null;
   thumbnail_image_url: string | null;
+  expected_delivery_date: string | null;
   status?: OrderItemStatus;  // 製品単位のステータス
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary

- 配送一覧に「配送予定日」カラムを追加
- 配送予定日の自動計算: `MAX(各商品の納品予定日) + 発送準備日数(営業日)`
- 設定ページで「発送準備日数」(デフォルト5営業日)を変更可能に
- 営業日計算で土日・祝日・TOSYO独自休日を除外
- 独自休日の登録・削除UIを設定ページに追加

## 変更内容

### バックエンド
- `business_day_calculator.py`: 営業日計算ユーティリティ(jpholidayで祝日判定)
- `SystemSetting`/`CompanyHoliday` モデル + マイグレーション
- 設定API: `/settings/shipping-preparation-days` (GET/PUT), `/settings/company-holidays` (GET/POST/DELETE)
- `ShipmentService`: 配送予定日計算ロジック追加、Productのeager loading追加

### フロントエンド
- 配送一覧テーブルに「配送予定日」カラム追加
- 設定ページに「配送設定」「会社休日」セクション追加
- TypeScript型定義更新

## Test plan
- [x] 営業日計算ユニットテスト (13件パス)
- [ ] 設定APIの動作確認
- [ ] 配送一覧での配送予定日表示確認
- [ ] 設定ページでの発送準備日数変更確認
- [ ] 独自休日の追加・削除確認
- [ ] マイグレーション実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)