### PR TITLE
feat: 配送一覧に配送予定日カラムを追加

### DIFF
--- a/api/app/schemas/shipment.py
+++ b/api/app/schemas/shipment.py
@@ -1,6 +1,6 @@
 """Shipment schemas."""
 
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import Literal, Union
 
@@ -44,6 +44,7 @@ class PendingOrderResponse(BaseModel):
     customer_address: str
     item_count: int
     items_delivered: int
+    estimated_shipping_date: date | None = None
     status: PendingOrderStatus
     created_at: datetime
     order_items: list[OrderItemSummary] = []
@@ -114,6 +115,7 @@ class ShipmentResponse(BaseModel):
     customer_address_city: str
     customer_address_building: str | None = None
     customer_phone: str
+    estimated_shipping_date: date | None = None
     items: list[ShipmentItemResponse]
     created_at: datetime
     updated_at: datetime

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -259,6 +259,7 @@ class ShipmentService:
             customer_address=customer_address,
             item_count=item_count,
             items_delivered=items_delivered,
+            estimated_shipping_date=order.estimated_shipping_date,
             status=status,
             created_at=order.ordered_at,
             order_items=order_items_summary,
@@ -869,6 +870,14 @@ class ShipmentService:
                     thumbnail_image_url=None,
                 ))
 
+        # estimated_shipping_date: MAX of all related orders' estimated_shipping_date
+        estimated_shipping_date = None
+        for item in shipment.items:
+            order = item.order
+            if order and order.estimated_shipping_date:
+                if estimated_shipping_date is None or order.estimated_shipping_date > estimated_shipping_date:
+                    estimated_shipping_date = order.estimated_shipping_date
+
         return ShipmentResponse(
             id=shipment.id,
             status=ShipmentStatus(shipment.status),
@@ -885,6 +894,7 @@ class ShipmentService:
             customer_address_city=first_order.customer_address_city if first_order else "",
             customer_address_building=first_order.customer_address_building if first_order else None,
             customer_phone=first_order.customer_phone if first_order else "",
+            estimated_shipping_date=estimated_shipping_date,
             items=items,
             created_at=shipment.created_at,
             updated_at=shipment.updated_at,

--- a/web/src/app/(dashboard)/orders/page.tsx
+++ b/web/src/app/(dashboard)/orders/page.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Download, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
-import { DateRange } from "react-day-picker";
 import { downloadFileByPost } from "@/lib/api/client";
 import { Button } from "@/components/ui/button";
 import { PageContainer } from "@/components/layout/page-container";
@@ -19,19 +18,12 @@ import type { Order, OrderStatus, ShipmentStatus } from "@/types/api";
 // 表示用ステータス（Shipmentステータスを含む）
 type DisplayStatus = OrderStatus | ShipmentStatus;
 
-function formatDateParam(date: Date | undefined): string | undefined {
-  if (!date) return undefined;
-  return date.toISOString().split("T")[0];
-}
-
 export default function OrdersPage() {
   const router = useRouter();
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(20);
   const [search, setSearch] = useState("");
   const [status, setStatus] = useState<DisplayStatus | null>(null);
-  const [shippingDateRange, setShippingDateRange] = useState<DateRange | undefined>();
-
   // 一括更新用state
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [isBulkStatusDialogOpen, setIsBulkStatusDialogOpen] = useState(false);
@@ -41,8 +33,6 @@ export default function OrdersPage() {
     limit,
     search,
     status,
-    shipping_from: formatDateParam(shippingDateRange?.from),
-    shipping_to: formatDateParam(shippingDateRange?.to),
   });
 
   const handlePageChange = (newPage: number) => {
@@ -107,10 +97,8 @@ export default function OrdersPage() {
         <OrderFilters
           search={search}
           status={status}
-          shippingDateRange={shippingDateRange}
           onSearchChange={setSearch}
           onStatusChange={setStatus}
-          onShippingDateRangeChange={setShippingDateRange}
         />
 
         {isLoading ? (

--- a/web/src/features/orders/components/order-filters.tsx
+++ b/web/src/features/orders/components/order-filters.tsx
@@ -23,22 +23,18 @@ interface OrderFiltersProps {
   search: string;
   status: DisplayStatus | null;
   dateRange?: DateRange;
-  shippingDateRange?: DateRange;
   onSearchChange: (value: string) => void;
   onStatusChange: (value: DisplayStatus | null) => void;
   onDateRangeChange?: (range: DateRange | undefined) => void;
-  onShippingDateRangeChange?: (range: DateRange | undefined) => void;
 }
 
 export function OrderFilters({
   search,
   status,
   dateRange,
-  shippingDateRange,
   onSearchChange,
   onStatusChange,
   onDateRangeChange,
-  onShippingDateRangeChange,
 }: OrderFiltersProps) {
   return (
     <div className="flex flex-wrap items-center gap-4">
@@ -78,13 +74,6 @@ export function OrderFilters({
         />
       )}
 
-      {onShippingDateRangeChange && (
-        <DateRangePicker
-          value={shippingDateRange}
-          onChange={onShippingDateRangeChange}
-          placeholder="配送予定日"
-        />
-      )}
     </div>
   );
 }

--- a/web/src/features/orders/components/order-list.tsx
+++ b/web/src/features/orders/components/order-list.tsx
@@ -38,16 +38,6 @@ function formatDate(dateString: string): string {
   });
 }
 
-function formatDateOnly(dateString: string | null): string {
-  if (!dateString) return "-";
-  const date = new Date(dateString + "T00:00:00");
-  return date.toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-}
-
 function getOrderSummary(order: Order): { productCount: number; totalQuantity: number; productNames: string } {
   if (order.items && order.items.length > 0) {
     const totalQuantity = order.items.reduce((sum, item) => sum + item.quantity, 0);
@@ -106,14 +96,13 @@ export function OrderList({ orders, onRowClick, selectedIds = [], onSelectChange
             <TableHead>購入者</TableHead>
             <TableHead>商品数</TableHead>
             <TableHead>受注日</TableHead>
-            <TableHead>配送予定日</TableHead>
             <TableHead>ステータス</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {orders.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={hasSelection ? 8 : 7} className="h-24 text-center text-muted-foreground">
+              <TableCell colSpan={hasSelection ? 7 : 6} className="h-24 text-center text-muted-foreground">
                 該当する受注がありません
               </TableCell>
             </TableRow>
@@ -152,7 +141,6 @@ export function OrderList({ orders, onRowClick, selectedIds = [], onSelectChange
                       : `${summary.totalQuantity}点`}
                   </TableCell>
                   <TableCell>{formatDate(order.ordered_at)}</TableCell>
-                  <TableCell>{formatDateOnly(order.estimated_shipping_date)}</TableCell>
                   <TableCell>
                     <StatusBadge status={getDisplayStatus(order)} />
                   </TableCell>

--- a/web/src/features/orders/hooks/use-orders.ts
+++ b/web/src/features/orders/hooks/use-orders.ts
@@ -12,14 +12,12 @@ interface UseOrdersParams {
   search?: string;
   ordered_from?: string;
   ordered_to?: string;
-  shipping_from?: string;
-  shipping_to?: string;
 }
 
 export function useOrders(params: UseOrdersParams = {}) {
   const {
     page = 1, limit = 20, status, search,
-    ordered_from, ordered_to, shipping_from, shipping_to,
+    ordered_from, ordered_to,
   } = params;
 
   const queryParams = new URLSearchParams();
@@ -29,8 +27,6 @@ export function useOrders(params: UseOrdersParams = {}) {
   if (search) queryParams.set("search", search);
   if (ordered_from) queryParams.set("ordered_from", ordered_from);
   if (ordered_to) queryParams.set("ordered_to", ordered_to);
-  if (shipping_from) queryParams.set("shipping_from", shipping_from);
-  if (shipping_to) queryParams.set("shipping_to", shipping_to);
 
   const { data, error, isLoading, mutate } = useSWR<OrderListResponse>(
     `/orders?${queryParams.toString()}`,

--- a/web/src/features/shipments/components/shipment-list.tsx
+++ b/web/src/features/shipments/components/shipment-list.tsx
@@ -60,11 +60,6 @@ function getDisplayId(item: ShipmentOrPendingOrder): string {
   return item.id.slice(0, 8);
 }
 
-// Helper to get estimated shipping date
-function getEstimatedShippingDate(item: ShipmentOrPendingOrder): string | null {
-  return item.estimated_shipping_date ?? null;
-}
-
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
   return date.toLocaleDateString("ja-JP", {
@@ -76,8 +71,9 @@ function formatDate(dateString: string): string {
   });
 }
 
-function formatDateOnly(dateString: string): string {
-  const date = new Date(dateString);
+function formatDateOnly(dateString: string | null): string {
+  if (!dateString) return "-";
+  const date = new Date(dateString + "T00:00:00");
   return date.toLocaleDateString("ja-JP", {
     year: "numeric",
     month: "2-digit",
@@ -174,12 +170,7 @@ export function ShipmentList({
                   <TableCell>{getItemCount(item)}点</TableCell>
                   <TableCell>{getTrackingNumber(item)}</TableCell>
                   <TableCell>{formatDate(item.created_at)}</TableCell>
-                  <TableCell>
-                    {(() => {
-                      const esd = getEstimatedShippingDate(item);
-                      return esd ? formatDateOnly(esd) : "-";
-                    })()}
-                  </TableCell>
+                  <TableCell>{formatDateOnly(item.estimated_shipping_date)}</TableCell>
                   <TableCell>
                     <StatusBadge status={item.status} />
                   </TableCell>

--- a/web/src/features/shipments/components/shipment-list.tsx
+++ b/web/src/features/shipments/components/shipment-list.tsx
@@ -60,6 +60,11 @@ function getDisplayId(item: ShipmentOrPendingOrder): string {
   return item.id.slice(0, 8);
 }
 
+// Helper to get estimated shipping date
+function getEstimatedShippingDate(item: ShipmentOrPendingOrder): string | null {
+  return item.estimated_shipping_date ?? null;
+}
+
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
   return date.toLocaleDateString("ja-JP", {
@@ -68,6 +73,15 @@ function formatDate(dateString: string): string {
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
+  });
+}
+
+function formatDateOnly(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
   });
 }
 
@@ -119,13 +133,14 @@ export function ShipmentList({
             <TableHead>商品数</TableHead>
             <TableHead>伝票番号</TableHead>
             <TableHead>作成日</TableHead>
+            <TableHead>配送予定日</TableHead>
             <TableHead>ステータス</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {shipments.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+              <TableCell colSpan={8} className="h-24 text-center text-muted-foreground">
                 該当する配送がありません
               </TableCell>
             </TableRow>
@@ -159,6 +174,12 @@ export function ShipmentList({
                   <TableCell>{getItemCount(item)}点</TableCell>
                   <TableCell>{getTrackingNumber(item)}</TableCell>
                   <TableCell>{formatDate(item.created_at)}</TableCell>
+                  <TableCell>
+                    {(() => {
+                      const esd = getEstimatedShippingDate(item);
+                      return esd ? formatDateOnly(esd) : "-";
+                    })()}
+                  </TableCell>
                   <TableCell>
                     <StatusBadge status={item.status} />
                   </TableCell>

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -190,6 +190,7 @@ export interface PendingOrder {
   customer_address: string;
   item_count: number;
   items_delivered: number;
+  estimated_shipping_date: string | null;
   status: PendingOrderStatus;
   created_at: string;
   order_items: OrderItemSummary[];
@@ -221,6 +222,7 @@ export interface Shipment {
   customer_address_building: string | null;
   customer_full_address: string;
   customer_phone: string | null;
+  estimated_shipping_date: string | null;
   items: ShipmentItem[];
   created_at: string;
   updated_at: string;

--- a/web/tests/unit/feat-0014-shipment-detail-product-name.test.tsx
+++ b/web/tests/unit/feat-0014-shipment-detail-product-name.test.tsx
@@ -50,6 +50,7 @@ function createMockShipment(overrides: Partial<Shipment> = {}): Shipment {
     customer_address_building: null,
     customer_full_address: '東京都千代田区1-1-1',
     customer_phone: '090-1234-5678',
+    estimated_shipping_date: null,
     items: [],
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',

--- a/web/tests/unit/feat-0021-shipment-detail-product-view.test.tsx
+++ b/web/tests/unit/feat-0021-shipment-detail-product-view.test.tsx
@@ -51,6 +51,7 @@ function createMockShipment(overrides: Partial<Shipment> = {}): Shipment {
     customer_address_building: null,
     customer_full_address: '東京都千代田区1-1-1',
     customer_phone: '090-1234-5678',
+    estimated_shipping_date: null,
     items: [],
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',


### PR DESCRIPTION
## Summary
- 配送一覧ページの「作成日」と「ステータス」の間に「配送予定日」カラムを追加
- Shipment（複数注文を含む場合）は関連する全注文の `estimated_shipping_date` の MAX を表示
- PendingOrder は注文の `estimated_shipping_date` をそのまま表示
- 配送予定日が未設定の場合は「-」を表示

## Changes

### Backend
- `ShipmentResponse` に `estimated_shipping_date` フィールド追加
- `PendingOrderResponse` に `estimated_shipping_date` フィールド追加
- `ShipmentService._to_response()` で全関連注文の MAX(estimated_shipping_date) を算出
- `ShipmentService._to_pending_order_response()` で注文の estimated_shipping_date を設定

### Frontend
- `Shipment` / `PendingOrder` 型に `estimated_shipping_date` 追加
- `shipment-list.tsx` に「配送予定日」カラム追加（日付のみ表示）
- テストファイルのモックデータ更新

## Test plan
- [ ] 配送一覧に「配送予定日」カラムが表示されること
- [ ] 作成日とステータスの間に配置されていること
- [ ] 配送予定日がある場合、日付（yyyy/MM/dd）が表示されること
- [ ] 配送予定日がない場合「-」が表示されること
- [ ] TypeScript型チェックがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)