### PR TITLE
feat: 外部注文v2で元データ(PNG)から製造データを生成・商品単位でキャッシュ／未ready時はメーカー発注不可 (#76)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -27,3 +27,13 @@ CONTACT_EMAIL=
 
 # 管理画面のベースURL（受注通知メールの注文詳細リンク用。例: https://pod-admin-beige.vercel.app）
 ADMIN_BASE_URL=
+
+# illustrator-vm（Product Manufacturing API）
+# 未設定の場合、外部注文 v2 の製造データ生成は無効（生成行は failed になる）。
+ILLUSTRATOR_VM_BASE_URL=
+# 認証ヘッダ（例: "Bearer xxx"）。VM は既定で認証なしのため通常は空でよい。
+ILLUSTRATOR_VM_AUTH_HEADER=
+ILLUSTRATOR_VM_REQUEST_TIMEOUT=60
+ILLUSTRATOR_VM_POLL_INTERVAL=5
+ILLUSTRATOR_VM_MAX_POLL_SECONDS=360
+ILLUSTRATOR_VM_MAX_RETRIES=3

--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -14,6 +14,7 @@ from app.models.base import Base
 # Import all models here to ensure they are registered with Base.metadata
 from app.models.chat_message import ChatAttachment, ChatMessage  # noqa: F401
 from app.models.manufacturer import Manufacturer  # noqa: F401
+from app.models.manufacturing_data import ManufacturingData  # noqa: F401
 from app.models.order import Order, OrderItem  # noqa: F401
 from app.models.product import Product  # noqa: F401
 from app.models.shipment import Shipment, ShipmentItem  # noqa: F401

--- a/api/alembic/versions/add_manufacturing_data.py
+++ b/api/alembic/versions/add_manufacturing_data.py
@@ -1,0 +1,139 @@
+"""add manufacturing_data table and order_items generation columns
+
+Revision ID: add_manufacturing_data
+Revises: add_ext_order_notif_settings
+Create Date: 2026-07-01
+
+外部注文 v2（製造データ生成）用のスキーマ追加:
+- 新テーブル manufacturing_data（商品×サイズ×バリアント単位の製造データキャッシュ）
+- order_items に product_code / source_images / manufacturing_data_id を追加
+
+既存 v1 明細は全て NULL のまま → 旧挙動を完全維持（発注ゲートの対象外）。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_manufacturing_data"
+down_revision: str | None = "add_ext_order_notif_settings"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. manufacturing_data テーブルを作成
+    op.create_table(
+        "manufacturing_data",
+        sa.Column("id", sa.UUID(as_uuid=False), nullable=False),
+        sa.Column("order_source_id", sa.UUID(as_uuid=False), nullable=True),
+        sa.Column("product_code", sa.String(length=255), nullable=False),
+        sa.Column("product_type", sa.String(length=50), nullable=False),
+        sa.Column("size", sa.String(length=50), nullable=True),
+        sa.Column("variant", sa.String(length=50), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column("source_images", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("vm_job_id", sa.String(length=100), nullable=True),
+        sa.Column("output_filename", sa.String(length=255), nullable=True),
+        sa.Column("file_path", sa.String(length=500), nullable=True),
+        sa.Column("file_size", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.String(length=1000), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["order_source_id"], ["order_sources.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_manufacturing_data_order_source_id"),
+        "manufacturing_data",
+        ["order_source_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_manufacturing_data_product_code"),
+        "manufacturing_data",
+        ["product_code"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_manufacturing_data_status"),
+        "manufacturing_data",
+        ["status"],
+        unique=False,
+    )
+    # キャッシュキーの一意制約（NULLS NOT DISTINCT で size/variant が NULL でも一意）
+    op.create_index(
+        "uq_manufacturing_data_cache_key",
+        "manufacturing_data",
+        ["order_source_id", "product_code", "size", "variant"],
+        unique=True,
+        postgresql_nulls_not_distinct=True,
+    )
+
+    # 2. order_items に生成用の列を追加
+    op.add_column(
+        "order_items",
+        sa.Column("product_code", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "order_items",
+        sa.Column("source_images", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column(
+        "order_items",
+        sa.Column("manufacturing_data_id", sa.UUID(as_uuid=False), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_order_items_product_code"),
+        "order_items",
+        ["product_code"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_order_items_manufacturing_data_id"),
+        "order_items",
+        ["manufacturing_data_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "fk_order_items_manufacturing_data_id",
+        "order_items",
+        "manufacturing_data",
+        ["manufacturing_data_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_order_items_manufacturing_data_id", "order_items", type_="foreignkey"
+    )
+    op.drop_index(op.f("ix_order_items_manufacturing_data_id"), table_name="order_items")
+    op.drop_index(op.f("ix_order_items_product_code"), table_name="order_items")
+    op.drop_column("order_items", "manufacturing_data_id")
+    op.drop_column("order_items", "source_images")
+    op.drop_column("order_items", "product_code")
+
+    op.drop_index("uq_manufacturing_data_cache_key", table_name="manufacturing_data")
+    op.drop_index(op.f("ix_manufacturing_data_status"), table_name="manufacturing_data")
+    op.drop_index(op.f("ix_manufacturing_data_product_code"), table_name="manufacturing_data")
+    op.drop_index(
+        op.f("ix_manufacturing_data_order_source_id"), table_name="manufacturing_data"
+    )
+    op.drop_table("manufacturing_data")

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -69,5 +69,13 @@ class Settings(BaseSettings):
     # 送信/取得の簡易リトライ回数（ネットワークエラー・503 時）
     ILLUSTRATOR_VM_MAX_RETRIES: int = 3
 
+    # 外部注文 v2 の元データ画像取得（SSRF/DoS 防御）
+    # 信頼して素通しするホスト名の許可リスト（例: ["assets.rksyo.com"]）。空なら
+    # https 必須＋public IP のみ許可（内部・クラウドメタデータ宛を遮断）。内部アセット
+    # サーバや dev スタブ（host.docker.internal 等）を使う場合はここに追加する。
+    SOURCE_IMAGE_ALLOWED_HOSTS: list[str] = []
+    # 1レイヤーあたりのダウンロード上限（バイト）。超過分は取得を中断してスキップ。
+    SOURCE_IMAGE_MAX_BYTES: int = 25 * 1024 * 1024  # 25MB
+
 
 settings = Settings()

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "POD Admin API"
     VERSION: str = "0.1.0"
     API_V1_PREFIX: str = "/api/v1"
+    API_V2_PREFIX: str = "/api/v2"
     DEBUG: bool = False
 
     # Database
@@ -53,6 +54,20 @@ class Settings(BaseSettings):
 
     # 管理画面のベースURL（受注通知メールの注文詳細リンク用、未設定ならリンクを描画しない）
     ADMIN_BASE_URL: str = ""
+
+    # illustrator-vm（Product Manufacturing API）
+    # 未設定（空文字）の場合、製造データ生成クライアントは無効（None）となる。
+    ILLUSTRATOR_VM_BASE_URL: str = ""
+    # 認証ヘッダ（例: "Bearer xxx"）。VM は既定で認証なしのため通常は空でよい。
+    ILLUSTRATOR_VM_AUTH_HEADER: str = ""
+    # 1回の HTTP リクエストのタイムアウト秒（submit/status/download 個別）
+    ILLUSTRATOR_VM_REQUEST_TIMEOUT: float = 60.0
+    # ステータスポーリング間隔（秒）
+    ILLUSTRATOR_VM_POLL_INTERVAL: float = 5.0
+    # ジョブ完了待ちの最大秒数（VM は 1件最大約300秒）
+    ILLUSTRATOR_VM_MAX_POLL_SECONDS: float = 360.0
+    # 送信/取得の簡易リトライ回数（ネットワークエラー・503 時）
+    ILLUSTRATOR_VM_MAX_RETRIES: int = 3
 
 
 settings = Settings()

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -14,6 +14,7 @@ from app.repositories.app_setting_repository import AppSettingRepository
 from app.repositories.chat_repository import ChatRepository
 from app.repositories.company_holiday_repository import CompanyHolidayRepository
 from app.repositories.manufacturer_repository import ManufacturerRepository
+from app.repositories.manufacturing_data_repository import ManufacturingDataRepository
 from app.repositories.order_repository import OrderRepository
 from app.repositories.order_source_repository import OrderSourceRepository
 from app.repositories.product_repository import ProductRepository
@@ -25,8 +26,10 @@ from app.services.dashboard_service import DashboardService
 from app.services.email_service import EmailService
 from app.services.external_order_notification import ExternalOrderNotificationService
 from app.services.external_service import ExternalService
+from app.services.illustrator_vm_client import IllustratorVmClient
 from app.services.invoice_service import InvoiceService
 from app.services.manufacturer_order_service import ManufacturerOrderService
+from app.services.manufacturing_data_service import ManufacturingDataService
 from app.services.manufacturer_portal_service import ManufacturerPortalService
 from app.services.manufacturer_service import ManufacturerService
 from app.services.order_image_service import OrderImageService
@@ -108,6 +111,13 @@ def get_app_setting_repository(
 ) -> AppSettingRepository:
     """Get app setting repository."""
     return AppSettingRepository(db)
+
+
+def get_manufacturing_data_repository(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> ManufacturingDataRepository:
+    """Get manufacturing data repository."""
+    return ManufacturingDataRepository(db)
 
 
 # Service dependencies
@@ -209,9 +219,35 @@ def get_manufacturer_order_service(
     order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
     manufacturer_repo: Annotated[ManufacturerRepository, Depends(get_manufacturer_repository)],
     shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
+    file_storage: Annotated[
+        FileStorage, Depends(lambda: LocalFileStorage(settings.UPLOAD_DIR))
+    ],
 ) -> ManufacturerOrderService:
     """Get manufacturer order service."""
-    return ManufacturerOrderService(order_repo, manufacturer_repo, shipment_repo)
+    return ManufacturerOrderService(
+        order_repo, manufacturer_repo, shipment_repo, file_storage=file_storage
+    )
+
+
+def get_illustrator_vm_client() -> IllustratorVmClient | None:
+    """Get illustrator-vm client (None if ILLUSTRATOR_VM_BASE_URL not configured)."""
+    return IllustratorVmClient.from_settings(settings)
+
+
+def get_manufacturing_data_service(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    md_repo: Annotated[ManufacturingDataRepository, Depends(get_manufacturing_data_repository)],
+    order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
+    vm_client: Annotated[IllustratorVmClient | None, Depends(get_illustrator_vm_client)],
+) -> ManufacturingDataService:
+    """Get manufacturing data service."""
+    return ManufacturingDataService(
+        md_repo=md_repo,
+        order_repo=order_repo,
+        session=db,
+        file_storage=LocalFileStorage(settings.UPLOAD_DIR),
+        vm_client=vm_client,
+    )
 
 
 def get_manufacturer_portal_service(

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,5 +1,9 @@
 """FastAPI application entry point."""
 
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -17,10 +21,30 @@ from app.routers import (
     orders,
     orders_v2,
     products,
-    settings as settings_router,
     shipments,
 )
+from app.routers import (
+    settings as settings_router,
+)
+from app.services.manufacturing_data_service import recover_stranded_generations
 from app.utils.exceptions import AppException
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """アプリのライフサイクル管理."""
+    # 起動時: 前プロセスで中断された製造データ生成（generating のまま宙吊り）を再駆動する。
+    # 復旧に失敗しても起動は継続させる（例外は記録するだけ）。
+    try:
+        await recover_stranded_generations()
+    except Exception:  # noqa: BLE001 - 復旧失敗で API 起動を妨げない
+        logger.exception(
+            "failed to recover stranded manufacturing generations on startup"
+        )
+    yield
+
 
 app = FastAPI(
     title=settings.PROJECT_NAME,
@@ -29,6 +53,7 @@ app = FastAPI(
     docs_url=f"{settings.API_V1_PREFIX}/docs",
     redoc_url=f"{settings.API_V1_PREFIX}/redoc",
     redirect_slashes=False,
+    lifespan=lifespan,
 )
 
 # CORS middleware

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -13,7 +13,9 @@ from app.routers import (
     external,
     manufacturer_portal,
     manufacturers,
+    manufacturing_data,
     orders,
+    orders_v2,
     products,
     settings as settings_router,
     shipments,
@@ -80,6 +82,10 @@ app.include_router(dashboard.router, prefix=settings.API_V1_PREFIX)
 app.include_router(external.router, prefix=settings.API_V1_PREFIX)
 app.include_router(settings_router.router, prefix=settings.API_V1_PREFIX)
 app.include_router(company_holidays.router, prefix=settings.API_V1_PREFIX)
+app.include_router(manufacturing_data.router, prefix=settings.API_V1_PREFIX)
+
+# v2 endpoints (製造データ生成方式の注文受付。後方互換のため別プレフィックス)
+app.include_router(orders_v2.router, prefix=settings.API_V2_PREFIX)
 
 
 # Test endpoints for exception handling (only in debug mode)

--- a/api/app/models/manufacturing_data.py
+++ b/api/app/models/manufacturing_data.py
@@ -1,0 +1,91 @@
+"""Manufacturing data model.
+
+外部注文（v2）の製造データキャッシュ本体。
+
+illustrator-vm（Product Manufacturing API）で生成した製造データ（.ai/.pdf）を
+「受注元 × 商品コード × サイズ × バリアント」単位で一度だけ生成し、pod-admin 側に
+自前保存して再利用する。VM の生成結果は `(product_type, size, variant, 元画像)` の
+純関数であり order_id には依存しないため、この単位でのキャッシュ再利用は妥当。
+"""
+
+from enum import Enum
+
+from sqlalchemy import ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class MfgDataStatus(str, Enum):
+    """製造データの生成ステータス."""
+
+    PENDING = "pending"  # 生成待ち（行は作成済み、VM未起動）
+    GENERATING = "generating"  # 生成中（VMジョブ実行中）
+    READY = "ready"  # 生成完了（file_path に保存済み）
+    FAILED = "failed"  # 生成失敗（error_message 参照）
+
+
+class ManufacturingData(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    """製造データキャッシュ（商品×サイズ×バリアント単位）."""
+
+    __tablename__ = "manufacturing_data"
+    __table_args__ = (
+        # 受注元 × 商品コード × サイズ × バリアントで一意（キャッシュキー）。
+        # サイズ/バリアントが NULL でも一意に扱うため NULLS NOT DISTINCT を使用（PG15+）。
+        UniqueConstraint(
+            "order_source_id",
+            "product_code",
+            "size",
+            "variant",
+            name="uq_manufacturing_data_cache_key",
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+
+    # 受注元（サイト単位で名前空間を分離）
+    order_source_id: Mapped[str | None] = mapped_column(
+        ForeignKey("order_sources.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
+    # rksyo の商品識別子（キャッシュキー）
+    product_code: Mapped[str] = mapped_column(String(255), index=True)
+
+    # pod-admin / VM の商品タイプ
+    product_type: Mapped[str] = mapped_column(String(50))
+
+    # pod-admin サイズ（元の受注値をそのまま保持）
+    size: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    # VM バリアント（keychain: clear/color、sticker: clear、その他: None）
+    variant: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    # 生成ステータス（MfgDataStatus の value を保存）
+    status: Mapped[str] = mapped_column(
+        String(20), default=MfgDataStatus.PENDING.value, index=True
+    )
+
+    # 使用したレイヤーURL群（[{"layer_type": "color", "url": "..."}, ...]）
+    source_images: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
+    # illustrator-vm のジョブID
+    vm_job_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    # VM status 由来の出力ファイル名
+    output_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # FileStorage 上の保存先
+    file_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    file_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # 失敗時のエラーメッセージ
+    error_message: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+
+    # 生成試行回数
+    attempts: Mapped[int] = mapped_column(Integer, default=0)
+
+    def __repr__(self) -> str:
+        return (
+            f"<ManufacturingData(id={self.id}, product_code={self.product_code}, "
+            f"size={self.size}, variant={self.variant}, status={self.status})>"
+        )

--- a/api/app/models/order.py
+++ b/api/app/models/order.py
@@ -6,11 +6,14 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Date, DateTime, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, CustomerAddressMixin, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.manufacturing_data import MfgDataStatus
 
 if TYPE_CHECKING:
+    from app.models.manufacturing_data import ManufacturingData
     from app.models.order_source import OrderSource
     from app.models.product import Product
 
@@ -202,9 +205,34 @@ class OrderItem(Base, UUIDPrimaryKeyMixin, TimestampMixin):
     # メーカーからの納品予定日（注文作成時に営業日計算で算出、確定値）
     expected_delivery_date: Mapped[dt.date | None] = mapped_column(Date, nullable=True)
 
+    # === 外部注文 v2（製造データ生成）用フィールド ===
+    # 旧 v1 明細は全て NULL のまま → 旧挙動を完全維持（発注ゲートの対象外）。
+    # rksyo の商品識別子（製造データキャッシュキー）
+    product_code: Mapped[str | None] = mapped_column(String(255), index=True, nullable=True)
+    # 製造データ生成の元データ（PNGレイヤーURL群）
+    source_images: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    # 紐づく製造データ（キャッシュ本体）
+    manufacturing_data_id: Mapped[str | None] = mapped_column(
+        ForeignKey("manufacturing_data.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
     # Relationships
     order: Mapped["Order"] = relationship(back_populates="items")
     product: Mapped["Product"] = relationship()  # 商品マスタへの参照
+    # 製造データは OrderItem 読み込み時に常に selectin ロード（async lazy-load 回避）
+    manufacturing_data: Mapped["ManufacturingData | None"] = relationship(lazy="selectin")
+
+    @property
+    def is_manufacturing_ready(self) -> bool:
+        """メーカー発注（ORDERED→MANUFACTURING）が可能かどうか.
+
+        製造データが不要な明細（v1 = manufacturing_data_id が NULL）は常に発注可。
+        製造データが必要な明細は、紐づく行が ready の場合のみ発注可。
+        """
+        if self.manufacturing_data_id is None:
+            return True
+        md = self.manufacturing_data
+        return md is not None and md.status == MfgDataStatus.READY.value
 
     def __repr__(self) -> str:
         return f"<OrderItem(id={self.id}, product_name={self.product_name}, quantity={self.quantity}, status={self.status})>"

--- a/api/app/repositories/manufacturing_data_repository.py
+++ b/api/app/repositories/manufacturing_data_repository.py
@@ -22,12 +22,13 @@ class ManufacturingDataRepository:
         return result.scalar_one_or_none()
 
     async def claim_for_generation(self, mfg_data_id: str) -> bool:
-        """生成のためにこの行を原子的に確保（claim）する.
+        """生成のためにこの行を原子的に確保（claim）し、generating へ遷移させる.
 
-        status が pending/failed のときのみ generating へ遷移させる条件付き UPDATE。
-        既に generating（他ワーカーが処理中）または ready の場合は 0 行更新となり False を
-        返す。これにより、同一行に対して複数の run_generation が走っても VM ジョブは一度しか
-        投入されない（PostgreSQL は競合 UPDATE をロックし、解放後に WHERE を再評価する）。
+        status が pending/failed のときのみ、status=generating・attempts+1・error クリアを
+        1つの条件付き UPDATE で確定する（生成開始の遷移をこの1文が単独で所有する）。既に
+        generating（他ワーカーが処理中）または ready の場合は 0 行更新となり False を返す。
+        これにより、同一行に対して複数の run_generation が走っても VM ジョブは一度しか投入
+        されない（PostgreSQL は競合 UPDATE をロックし、解放後に WHERE を再評価する）。
         """
         result = await self._db.execute(
             update(ManufacturingData)
@@ -37,24 +38,34 @@ class ManufacturingDataRepository:
                     [MfgDataStatus.GENERATING.value, MfgDataStatus.READY.value]
                 ),
             )
-            .values(status=MfgDataStatus.GENERATING.value)
+            .values(
+                status=MfgDataStatus.GENERATING.value,
+                attempts=ManufacturingData.attempts + 1,
+                error_message=None,
+            )
             .returning(ManufacturingData.id)
             .execution_options(synchronize_session=False)
         )
         return result.scalar_one_or_none() is not None
 
-    async def find_stranded(self) -> list[ManufacturingData]:
-        """宙吊り（pending/generating）の行を返す.
+    async def reclaim_stranded(self) -> list[str]:
+        """宙吊り（pending/generating）の行を pending に戻し、その id を1文で回収する.
 
-        プロセス再起動時の復旧に使用する。新プロセスには in-flight な生成タスクが
-        存在しないため、pending/generating のまま残る行は全て再駆動が必要。
+        プロセス再起動時の復旧に使用する。新プロセスには in-flight な生成タスクが存在しない
+        ため、pending/generating のまま残る行は全て再駆動が必要。中断された generating を
+        claim 可能な pending に戻したうえで、再駆動対象の id を RETURNING で取得する
+        （全行を ORM ハイドレートせず JSONB も読まない）。
         """
         result = await self._db.execute(
-            select(ManufacturingData).where(
+            update(ManufacturingData)
+            .where(
                 ManufacturingData.status.in_(
                     [MfgDataStatus.PENDING.value, MfgDataStatus.GENERATING.value]
                 )
             )
+            .values(status=MfgDataStatus.PENDING.value)
+            .returning(ManufacturingData.id)
+            .execution_options(synchronize_session=False)
         )
         return list(result.scalars().all())
 

--- a/api/app/repositories/manufacturing_data_repository.py
+++ b/api/app/repositories/manufacturing_data_repository.py
@@ -1,0 +1,97 @@
+"""Manufacturing data repository for database operations."""
+
+from __future__ import annotations
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.manufacturing_data import ManufacturingData
+
+
+class ManufacturingDataRepository:
+    """Repository for ManufacturingData model."""
+
+    def __init__(self, db: AsyncSession):
+        self._db = db
+
+    async def find_by_id(self, mfg_data_id: str) -> ManufacturingData | None:
+        """Find a manufacturing data row by ID."""
+        result = await self._db.execute(
+            select(ManufacturingData).where(ManufacturingData.id == mfg_data_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def find_by_cache_key(
+        self,
+        order_source_id: str | None,
+        product_code: str,
+        size: str | None,
+        variant: str | None,
+    ) -> ManufacturingData | None:
+        """Find manufacturing data by cache key (order_source × product_code × size × variant).
+
+        NULL の size/variant は NULL 同士で一致させる（キャッシュ一意制約と整合）。
+        """
+        conditions = [
+            ManufacturingData.product_code == product_code,
+            _eq_or_null(ManufacturingData.order_source_id, order_source_id),
+            _eq_or_null(ManufacturingData.size, size),
+            _eq_or_null(ManufacturingData.variant, variant),
+        ]
+        result = await self._db.execute(
+            select(ManufacturingData).where(and_(*conditions))
+        )
+        return result.scalar_one_or_none()
+
+    async def create(self, mfg_data: ManufacturingData) -> ManufacturingData:
+        """Create a new manufacturing data row."""
+        self._db.add(mfg_data)
+        await self._db.flush()
+        await self._db.refresh(mfg_data)
+        return mfg_data
+
+    async def update(self, mfg_data: ManufacturingData) -> ManufacturingData:
+        """Persist changes to a manufacturing data row."""
+        await self._db.flush()
+        await self._db.refresh(mfg_data)
+        return mfg_data
+
+    async def list(
+        self,
+        page: int = 1,
+        limit: int = 20,
+        status: str | None = None,
+        order_source_id: str | None = None,
+        product_code: str | None = None,
+    ) -> tuple[list[ManufacturingData], int]:
+        """List manufacturing data rows with pagination and filters."""
+        # 条件を一度だけ組み立て、本体クエリと件数クエリの双方に適用する
+        conditions = []
+        if status:
+            conditions.append(ManufacturingData.status == status)
+        if order_source_id:
+            conditions.append(ManufacturingData.order_source_id == order_source_id)
+        if product_code:
+            conditions.append(ManufacturingData.product_code == product_code)
+
+        query = select(ManufacturingData).where(*conditions)
+        count_query = select(func.count(ManufacturingData.id)).where(*conditions)
+
+        total_result = await self._db.execute(count_query)
+        total = total_result.scalar() or 0
+
+        offset = (page - 1) * limit
+        query = (
+            query.order_by(ManufacturingData.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await self._db.execute(query)
+        return list(result.scalars().all()), total
+
+
+def _eq_or_null(column, value):
+    """value が None なら IS NULL、そうでなければ等価比較を返す."""
+    if value is None:
+        return column.is_(None)
+    return column == value

--- a/api/app/repositories/manufacturing_data_repository.py
+++ b/api/app/repositories/manufacturing_data_repository.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.manufacturing_data import ManufacturingData
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
 
 
 class ManufacturingDataRepository:
@@ -20,6 +20,43 @@ class ManufacturingDataRepository:
             select(ManufacturingData).where(ManufacturingData.id == mfg_data_id)
         )
         return result.scalar_one_or_none()
+
+    async def claim_for_generation(self, mfg_data_id: str) -> bool:
+        """生成のためにこの行を原子的に確保（claim）する.
+
+        status が pending/failed のときのみ generating へ遷移させる条件付き UPDATE。
+        既に generating（他ワーカーが処理中）または ready の場合は 0 行更新となり False を
+        返す。これにより、同一行に対して複数の run_generation が走っても VM ジョブは一度しか
+        投入されない（PostgreSQL は競合 UPDATE をロックし、解放後に WHERE を再評価する）。
+        """
+        result = await self._db.execute(
+            update(ManufacturingData)
+            .where(
+                ManufacturingData.id == mfg_data_id,
+                ManufacturingData.status.notin_(
+                    [MfgDataStatus.GENERATING.value, MfgDataStatus.READY.value]
+                ),
+            )
+            .values(status=MfgDataStatus.GENERATING.value)
+            .returning(ManufacturingData.id)
+            .execution_options(synchronize_session=False)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def find_stranded(self) -> list[ManufacturingData]:
+        """宙吊り（pending/generating）の行を返す.
+
+        プロセス再起動時の復旧に使用する。新プロセスには in-flight な生成タスクが
+        存在しないため、pending/generating のまま残る行は全て再駆動が必要。
+        """
+        result = await self._db.execute(
+            select(ManufacturingData).where(
+                ManufacturingData.status.in_(
+                    [MfgDataStatus.PENDING.value, MfgDataStatus.GENERATING.value]
+                )
+            )
+        )
+        return list(result.scalars().all())
 
     async def find_by_cache_key(
         self,

--- a/api/app/repositories/order_repository.py
+++ b/api/app/repositories/order_repository.py
@@ -461,6 +461,11 @@ class OrderRepository:
         result = await self._db.execute(query)
         items = list(result.scalars().all())
 
+        # 発注ゲート: ORDERED→MANUFACTURING では、製造データが必要な明細のうち
+        # ready でないものは遷移させない（未readyは ORDERED のまま保留）。
+        if new_status == OrderItemStatus.MANUFACTURING:
+            items = [item for item in items if item.is_manufacturing_ready]
+
         # OrderItemのステータスを更新
         affected_order_ids: set[str] = set()
         for item in items:

--- a/api/app/routers/manufacturing_data.py
+++ b/api/app/routers/manufacturing_data.py
@@ -1,0 +1,49 @@
+"""Manufacturing data router (admin).
+
+製造データの状態一覧・手動リトライを提供する。
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Query
+
+from app.dependencies import get_current_admin, get_manufacturing_data_service
+from app.models.user import User
+from app.schemas.manufacturing_data import (
+    ManufacturingDataListResponse,
+    ManufacturingDataResponse,
+)
+from app.services.manufacturing_data_service import ManufacturingDataService
+
+router = APIRouter(prefix="/manufacturing-data", tags=["manufacturing-data"])
+
+
+@router.get("", response_model=ManufacturingDataListResponse)
+async def list_manufacturing_data(
+    service: Annotated[ManufacturingDataService, Depends(get_manufacturing_data_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    status: str | None = None,
+    order_source_id: str | None = None,
+    product_code: str | None = None,
+) -> ManufacturingDataListResponse:
+    """製造データ一覧を取得する（ステータス/受注元/商品コードでフィルタ可能）."""
+    return await service.list(
+        page=page,
+        limit=limit,
+        status=status,
+        order_source_id=order_source_id,
+        product_code=product_code,
+    )
+
+
+@router.post("/{mfg_data_id}/retry", response_model=ManufacturingDataResponse)
+async def retry_manufacturing_data(
+    mfg_data_id: str,
+    background_tasks: BackgroundTasks,
+    service: Annotated[ManufacturingDataService, Depends(get_manufacturing_data_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ManufacturingDataResponse:
+    """製造データ生成を手動で再駆動する（失敗・停滞した行の再実行）."""
+    return await service.retry(mfg_data_id, background_tasks)

--- a/api/app/routers/orders_v2.py
+++ b/api/app/routers/orders_v2.py
@@ -1,0 +1,73 @@
+"""Orders v2 router.
+
+外部販売サイトからの注文受付（v2 / 製造データ生成方式）。
+完成デザインではなく元データ（PNGレイヤーURL）を受け取り、着信後に illustrator-vm で
+製造データを生成する（同一商品はキャッシュ再利用）。
+
+既存の POST /api/v1/orders（design_image_url 方式）は一切変更しない。
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, BackgroundTasks, Depends
+
+from app.dependencies import (
+    get_external_order_notification_service,
+    get_manufacturing_data_service,
+    get_order_service,
+    verify_api_key,
+)
+from app.schemas.order import OrderCreateV2, OrderResponse
+from app.services.external_order_notification import ExternalOrderNotificationService
+from app.services.manufacturing_data_service import ManufacturingDataService
+from app.services.order_service import OrderService
+
+router = APIRouter(prefix="/orders", tags=["orders-v2"])
+
+
+@router.post("", response_model=OrderResponse, status_code=201)
+async def create_order_v2(
+    data: OrderCreateV2,
+    background_tasks: BackgroundTasks,
+    order_service: Annotated[OrderService, Depends(get_order_service)],
+    md_service: Annotated[ManufacturingDataService, Depends(get_manufacturing_data_service)],
+    notification_service: Annotated[
+        ExternalOrderNotificationService, Depends(get_external_order_notification_service)
+    ],
+    api_key_info: Annotated[tuple[str, str], Depends(verify_api_key)],
+) -> OrderResponse:
+    """Create a new order from external sales site (v2 / manufacturing-data generation).
+
+    Request body (JSON):
+    {
+        "order_number": "0000001",
+        "customer": {...},
+        "items": [
+            {
+                "uid": "0000011",
+                "product_type": "acrylic_keychain",
+                "product_name": "アクリルキーホルダー デザインA",
+                "price": 1200,
+                "quantity": 1,
+                "size": "50x50mm",
+                "color": "アクリル",
+                "product_code": "RKSYO-AKC-001",
+                "source_images": [
+                    {"layer_type": "color", "url": "https://.../color.png"},
+                    {"layer_type": "cutline", "url": "https://.../cutline.png"}
+                ],
+                "thumbnail_image_url": "https://.../thumb.png"
+            }
+        ]
+    }
+    """
+    _, order_source_id = api_key_info
+    order = await order_service.create_v2(data, order_source_id=order_source_id)
+
+    # 製造データ行を同期的に紐付け（発注ゲート用）、必要な生成をバックグラウンド起動
+    md_ids = await md_service.prepare_for_order(order.id)
+    md_service.enqueue_generation(background_tasks, md_ids)
+
+    # 受注通知メール（有効時のみ、レスポンス送出後に非同期送信）
+    await notification_service.enqueue_if_enabled(background_tasks, order=order)
+    return order

--- a/api/app/schemas/manufacturer.py
+++ b/api/app/schemas/manufacturer.py
@@ -132,7 +132,7 @@ class ManufacturerOrderItemResponse(BaseModel):
     status: str  # OrderItem.status (ordered, manufacturing, delivered) - 後方互換性のため維持
     item_status: str | None = None  # OrderItem.status (新フィールド、製品単位のステータス)
     lead_time_days: int  # メーカーのリードタイム（日数）
-    expected_delivery_date: date  # 納品予定日
+    expected_delivery_date: date | None = None  # 納品予定日（未設定の旧データは None）
     # 製造データ状態（v2）: None なら製造データ不要（v1）。ready 以外は発注不可。
     manufacturing_status: str | None = None
 
@@ -173,7 +173,7 @@ class AllManufacturerOrderItemResponse(BaseModel):
     manufacturer_id: str
     manufacturer_name: str
     lead_time_days: int  # メーカーのリードタイム（日数）
-    expected_delivery_date: date  # 納品予定日
+    expected_delivery_date: date | None = None  # 納品予定日（未設定の旧データは None）
 
 
 class AllManufacturerOrderItemListResponse(BaseModel):

--- a/api/app/schemas/manufacturer.py
+++ b/api/app/schemas/manufacturer.py
@@ -133,6 +133,8 @@ class ManufacturerOrderItemResponse(BaseModel):
     item_status: str | None = None  # OrderItem.status (新フィールド、製品単位のステータス)
     lead_time_days: int  # メーカーのリードタイム（日数）
     expected_delivery_date: date  # 納品予定日
+    # 製造データ状態（v2）: None なら製造データ不要（v1）。ready 以外は発注不可。
+    manufacturing_status: str | None = None
 
 
 class ManufacturerOrderItemListResponse(BaseModel):

--- a/api/app/schemas/manufacturing_data.py
+++ b/api/app/schemas/manufacturing_data.py
@@ -1,0 +1,35 @@
+"""Manufacturing data schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ManufacturingDataResponse(BaseModel):
+    """製造データレスポンス."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    order_source_id: str | None = None
+    product_code: str
+    product_type: str
+    size: str | None = None
+    variant: str | None = None
+    status: str  # pending | generating | ready | failed
+    vm_job_id: str | None = None
+    output_filename: str | None = None
+    file_size: int | None = None
+    error_message: str | None = None
+    attempts: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ManufacturingDataListResponse(BaseModel):
+    """製造データ一覧レスポンス."""
+
+    items: list[ManufacturingDataResponse]
+    total: int
+    page: int
+    limit: int

--- a/api/app/schemas/order.py
+++ b/api/app/schemas/order.py
@@ -143,7 +143,8 @@ class OrderItemCreateV2(BaseModel):
     # rksyo の商品識別子（製造データキャッシュキー）
     product_code: str = Field(..., min_length=1, max_length=255)
     # 製造データ生成に必要な元データ（color / cutline / white / design）
-    source_images: list[SourceImage] = Field(..., min_length=1)
+    # レイヤー種別は4種のため上限8（DoS防御。重複を含めても十分な余裕）。
+    source_images: list[SourceImage] = Field(..., min_length=1, max_length=8)
     # サムネイル用途（従来通り受理）
     thumbnail_image_url: str | None = Field(None, max_length=2048)
 
@@ -160,7 +161,8 @@ class OrderCreateV2(BaseModel):
         examples=["0000001"],
     )
     customer: CustomerInfo
-    items: list[OrderItemCreateV2] = Field(..., min_length=1)
+    # 1注文あたりの明細数上限（DoS防御）。
+    items: list[OrderItemCreateV2] = Field(..., min_length=1, max_length=100)
 
 
 # Order shipment info schema

--- a/api/app/schemas/order.py
+++ b/api/app/schemas/order.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 from datetime import date, datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, computed_field
 
@@ -51,6 +52,18 @@ class OrderItemCreate(BaseModel):
     thumbnail_image_url: str | None = Field(None, max_length=2048)
 
 
+class MfgDataItemInfo(BaseModel):
+    """明細に紐づく製造データの状態（v2）."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    status: str  # pending | generating | ready | failed
+    output_filename: str | None = None
+    file_size: int | None = None
+    error_message: str | None = None
+
+
 class OrderItemResponse(BaseModel):
     """Order item response schema."""
 
@@ -68,6 +81,9 @@ class OrderItemResponse(BaseModel):
     design_image_url: str | None = None
     thumbnail_image_url: str | None = None
     expected_delivery_date: date | None = None  # メーカーからの納品予定日
+    # v2（製造データ生成）用フィールド
+    product_code: str | None = None
+    manufacturing_data: MfgDataItemInfo | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -96,6 +112,55 @@ class OrderCreate(BaseModel):
     )
     customer: CustomerInfo
     items: list[OrderItemCreate] = Field(..., min_length=1)
+
+
+# === v2: 製造データ生成用（元データ = PNGレイヤーURL を受け取る） ===
+class SourceImage(BaseModel):
+    """製造データ生成の元データ（レイヤーPNGのURL）."""
+
+    layer_type: Literal["color", "cutline", "white", "design"]
+    url: str = Field(..., min_length=1, max_length=2048)
+
+
+class OrderItemCreateV2(BaseModel):
+    """Order item creation schema (v2 / 製造データ生成)."""
+
+    uid: str = Field(
+        ...,
+        min_length=7,
+        max_length=7,
+        pattern=r"^\d{7}$",
+        description="製品番号（7桁数字）",
+        examples=["0000001"],
+    )
+    product_type: ProductType
+    product_name: str = Field(..., min_length=1, max_length=200)
+    price: int = Field(..., ge=0)
+    quantity: int = Field(1, ge=1)
+    size: str | None = Field(None, max_length=50)
+    position: str | None = Field(None, max_length=50)
+    color: str | None = Field(None, max_length=50)
+    # rksyo の商品識別子（製造データキャッシュキー）
+    product_code: str = Field(..., min_length=1, max_length=255)
+    # 製造データ生成に必要な元データ（color / cutline / white / design）
+    source_images: list[SourceImage] = Field(..., min_length=1)
+    # サムネイル用途（従来通り受理）
+    thumbnail_image_url: str | None = Field(None, max_length=2048)
+
+
+class OrderCreateV2(BaseModel):
+    """Order creation schema (v2 / 製造データ生成)."""
+
+    order_number: str = Field(
+        ...,
+        min_length=7,
+        max_length=7,
+        pattern=r"^\d{7}$",
+        description="受注番号（7桁数字）",
+        examples=["0000001"],
+    )
+    customer: CustomerInfo
+    items: list[OrderItemCreateV2] = Field(..., min_length=1)
 
 
 # Order shipment info schema

--- a/api/app/services/illustrator_vm_client.py
+++ b/api/app/services/illustrator_vm_client.py
@@ -1,0 +1,242 @@
+"""illustrator-vm（Product Manufacturing API）クライアント.
+
+非同期ジョブ型の外部 API を叩いて製造データ（.ai/.pdf）を生成する。
+
+  POST /api/process        (base64 PNG 入力, 202 + job_id)
+  GET  /api/status/{job_id}(ポーリング)
+  GET  /api/download/{job_id}(ファイル取得)
+
+特性（呼び出し側で吸収する）:
+- 認証なし / CORS * / 既定 127.0.0.1:8000（プライベートVM前提）
+- 直列処理（1件ずつ・最大約300秒）。キュー上限50超で 503。
+- 完了ジョブ・出力ファイルは 72時間でハード削除 → 速やかに DL・自前保存が必須。
+- order_id は一意ではない（冪等性は呼び出し側の責務）。
+- バリデーションエラーは 422（`{"detail": [...]}`）。エラーは `detail` を参照。
+- 出力ファイル名は status の `output_filename` を正とする。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import time
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# VM が完了・失敗を示すステータス値（表記ゆれを吸収）
+_COMPLETE_STATUSES = {"completed", "complete", "done", "success", "succeeded", "finished"}
+_FAILED_STATUSES = {"failed", "error", "errored", "cancelled", "canceled"}
+
+
+class IllustratorVmError(Exception):
+    """illustrator-vm 呼び出しに関するエラー."""
+
+
+@dataclass
+class VmJobStatus:
+    """ジョブのステータス（status エンドポイント由来）."""
+
+    job_id: str
+    status: str
+    output_filename: str | None = None
+    error: str | None = None
+
+    @property
+    def is_complete(self) -> bool:
+        return self.status.lower() in _COMPLETE_STATUSES
+
+    @property
+    def is_failed(self) -> bool:
+        return self.status.lower() in _FAILED_STATUSES
+
+
+class IllustratorVmClient:
+    """illustrator-vm の submit / status / download をラップするクライアント."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        auth_header: str | None = None,
+        request_timeout: float = 60.0,
+        poll_interval: float = 5.0,
+        max_poll_seconds: float = 360.0,
+        max_retries: int = 3,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url is required")
+        self._base_url = base_url.rstrip("/")
+        self._auth_header = auth_header or None
+        self._request_timeout = request_timeout
+        self._poll_interval = poll_interval
+        self._max_poll_seconds = max_poll_seconds
+        self._max_retries = max(1, max_retries)
+        # テスト用に httpx transport を注入可能（本番は None = 既定トランスポート）
+        self._transport = transport
+
+    def _new_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self._request_timeout, transport=self._transport)
+
+    @classmethod
+    def from_settings(cls, settings) -> IllustratorVmClient | None:
+        """Settings から生成。未設定（base_url 空）なら None を返す."""
+        if not settings.ILLUSTRATOR_VM_BASE_URL:
+            return None
+        return cls(
+            settings.ILLUSTRATOR_VM_BASE_URL,
+            auth_header=settings.ILLUSTRATOR_VM_AUTH_HEADER or None,
+            request_timeout=settings.ILLUSTRATOR_VM_REQUEST_TIMEOUT,
+            poll_interval=settings.ILLUSTRATOR_VM_POLL_INTERVAL,
+            max_poll_seconds=settings.ILLUSTRATOR_VM_MAX_POLL_SECONDS,
+            max_retries=settings.ILLUSTRATOR_VM_MAX_RETRIES,
+        )
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._auth_header:
+            headers["Authorization"] = self._auth_header
+        return headers
+
+    async def submit(
+        self,
+        *,
+        product_type: str,
+        size: str,
+        variant: str | None,
+        input_mode: str,
+        images: dict[str, bytes],
+        order_id: str | None = None,
+    ) -> str:
+        """製造データ生成ジョブを投入し、job_id を返す.
+
+        images は {layer_type: PNGバイト列}。base64 エンコードして送信する。
+        """
+        if not images:
+            raise IllustratorVmError("at least one source image is required")
+
+        payload = {
+            "product_type": product_type,
+            "size": size,
+            "variant": variant,
+            "input_mode": input_mode,
+            "order_id": order_id,
+            "images": {
+                layer: base64.b64encode(content).decode("ascii")
+                for layer, content in images.items()
+            },
+        }
+
+        data = await self._request_json("POST", "/api/process", json=payload)
+        job_id = data.get("job_id") or data.get("id")
+        if not job_id:
+            raise IllustratorVmError(f"submit response missing job_id: {data}")
+        return str(job_id)
+
+    async def get_status(self, job_id: str) -> VmJobStatus:
+        """ジョブの現在ステータスを取得する."""
+        data = await self._request_json("GET", f"/api/status/{job_id}")
+        status = str(data.get("status") or "").strip() or "unknown"
+        error = data.get("error")
+        if error is None:
+            # VM のエラーは detail に入ることがある
+            detail = data.get("detail")
+            error = detail if isinstance(detail, str) else None
+        return VmJobStatus(
+            job_id=job_id,
+            status=status,
+            output_filename=data.get("output_filename"),
+            error=error,
+        )
+
+    async def wait_until_complete(self, job_id: str) -> VmJobStatus:
+        """完了/失敗するまでステータスをポーリングする.
+
+        Raises:
+            IllustratorVmError: ジョブが失敗した、またはタイムアウトした場合。
+        """
+        deadline = time.monotonic() + self._max_poll_seconds
+        last_status: VmJobStatus | None = None
+        while True:
+            last_status = await self.get_status(job_id)
+            if last_status.is_complete:
+                return last_status
+            if last_status.is_failed:
+                raise IllustratorVmError(
+                    f"VM job {job_id} failed: {last_status.error or last_status.status}"
+                )
+            if time.monotonic() >= deadline:
+                raise IllustratorVmError(
+                    f"VM job {job_id} timed out after {self._max_poll_seconds}s "
+                    f"(last status: {last_status.status})"
+                )
+            await asyncio.sleep(self._poll_interval)
+
+    async def download(self, job_id: str) -> bytes:
+        """生成済みファイルのバイト列を取得する."""
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                async with self._new_client() as client:
+                    response = await client.get(
+                        f"{self._base_url}/api/download/{job_id}",
+                        headers=self._headers(),
+                    )
+                if response.status_code == 503:
+                    last_exc = IllustratorVmError("VM busy (503) while downloading")
+                    await self._backoff(attempt)
+                    continue
+                response.raise_for_status()
+                return response.content
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                last_exc = exc
+                await self._backoff(attempt)
+        raise IllustratorVmError(
+            f"failed to download VM job {job_id}: {last_exc}"
+        ) from last_exc
+
+    async def _request_json(self, method: str, path: str, *, json: dict | None = None) -> dict:
+        """JSON を返すエンドポイントを叩く（ネットワークエラー・503 は簡易リトライ）."""
+        url = f"{self._base_url}{path}"
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                async with self._new_client() as client:
+                    response = await client.request(
+                        method, url, json=json, headers=self._headers()
+                    )
+                if response.status_code == 503:
+                    last_exc = IllustratorVmError("VM busy (503)")
+                    await self._backoff(attempt)
+                    continue
+                if response.status_code >= 400:
+                    raise IllustratorVmError(
+                        f"VM {method} {path} -> {response.status_code}: "
+                        f"{_extract_error(response)}"
+                    )
+                return response.json()
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                last_exc = exc
+                await self._backoff(attempt)
+        raise IllustratorVmError(f"VM {method} {path} failed: {last_exc}") from last_exc
+
+    async def _backoff(self, attempt: int) -> None:
+        # 1s, 2s, 4s, ... （最終試行後は待たない）
+        if attempt < self._max_retries - 1:
+            await asyncio.sleep(2**attempt)
+
+
+def _extract_error(response: httpx.Response) -> str:
+    """VM のエラーレスポンスから `detail` を抽出する（error ではない）."""
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text[:500]
+    detail = body.get("detail")
+    if detail is not None:
+        return str(detail)
+    return str(body)[:500]

--- a/api/app/services/illustrator_vm_client.py
+++ b/api/app/services/illustrator_vm_client.py
@@ -218,7 +218,18 @@ class IllustratorVmClient:
                         f"VM {method} {path} -> {response.status_code}: "
                         f"{_extract_error(response)}"
                     )
-                return response.json()
+                try:
+                    return response.json()
+                except ValueError:
+                    # 2xx だが本文が JSON でない（前段 proxy の一時的な HTML/空応答など）。
+                    # 一過性のことが多いためリトライ対象として扱う（未捕捉で生成を
+                    # 落とさない）。
+                    last_exc = IllustratorVmError(
+                        f"VM {method} {path} returned a non-JSON body: "
+                        f"{response.text[:200]!r}"
+                    )
+                    await self._backoff(attempt)
+                    continue
             except (httpx.TransportError, httpx.TimeoutException) as exc:
                 last_exc = exc
                 await self._backoff(attempt)

--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -1,5 +1,6 @@
 """Manufacturer order service for managing orders by manufacturer."""
 
+import logging
 import os
 from datetime import date, datetime
 from urllib.parse import urlparse
@@ -10,6 +11,7 @@ from app.models.order import Order, OrderItemStatus, OrderStatus
 from app.repositories.order_repository import OrderRepository
 from app.repositories.manufacturer_repository import ManufacturerRepository
 from app.repositories.shipment_repository import ShipmentRepository
+from app.utils.file_storage import FileStorage
 from app.schemas.manufacturer import (
     ManufacturerOrderSummary,
     ManufacturerOrderSummaryListResponse,
@@ -24,6 +26,8 @@ from app.utils.order_list_generator import OrderListGenerator, get_product_type_
 from app.utils.stand_file_config import load_stand_file
 from app.utils.zip_builder import ZipBuilder
 
+logger = logging.getLogger(__name__)
+
 
 class ManufacturerOrderService:
     """Service for manufacturer order operations."""
@@ -33,10 +37,12 @@ class ManufacturerOrderService:
         order_repo: OrderRepository,
         manufacturer_repo: ManufacturerRepository,
         shipment_repo: ShipmentRepository,
+        file_storage: FileStorage | None = None,
     ):
         self._order_repo = order_repo
         self._manufacturer_repo = manufacturer_repo
         self._shipment_repo = shipment_repo
+        self._file_storage = file_storage
         self._order_list_gen = OrderListGenerator()
 
     async def get_order_summary_list(
@@ -138,6 +144,11 @@ class ManufacturerOrderService:
                     item_status=item_status,  # 新フィールド
                     lead_time_days=lead_time_days,
                     expected_delivery_date=order_item.expected_delivery_date,
+                    manufacturing_status=(
+                        order_item.manufacturing_data.status
+                        if order_item.manufacturing_data
+                        else None
+                    ),
                 )
             )
             total_quantity += order_item.quantity
@@ -295,6 +306,29 @@ class ManufacturerOrderService:
         "sticker": ".ai",
     }
 
+    @staticmethod
+    def _hold_unready_items(rows: list[tuple]) -> list[tuple]:
+        """製造データが必要な ORDERED 明細のうち ready でないものを除外する.
+
+        v1 明細（manufacturing_data_id が NULL）は対象外（従来通り常に含める）。
+        既に MANUFACTURING/DELIVERED の明細は発注済みのため保留しない。
+        """
+        included: list[tuple] = []
+        held = 0
+        for row in rows:
+            order_item = row[0]
+            item_status = row[5]
+            # 発注対象（ORDERED）かつ製造データ未readyの明細のみ保留する。
+            if item_status == OrderItemStatus.ORDERED.value and not order_item.is_manufacturing_ready:
+                held += 1
+                continue
+            included.append(row)
+        if held:
+            logger.info(
+                "Holding %d un-ready manufacturing item(s) from order documents", held
+            )
+        return included
+
     async def generate_order_documents(
         self,
         manufacturer_id: str,
@@ -354,6 +388,13 @@ class ManufacturerOrderService:
         if order_item_ids:
             rows = [row for row in rows if row[0].id in order_item_ids]
 
+        # 発注ゲート（未ready保留）: 製造データが必要な ORDERED 明細のうち ready でない
+        # ものは発注資料に含めず ORDERED のまま保留する（メーカー発注不可）。
+        # これは「ZIPの中身」を絞る責務。ORDERED→MANUFACTURING の状態遷移自体は
+        # OrderRepository.update_item_status_by_manufacturer 側で別途ガードされる
+        # （保留済みなので下記 ordered_item_ids には未ready分は含まれない）。
+        rows = self._hold_unready_items(rows)
+
         # ダウンロード対象の明細が0件の場合はエラー
         if not rows:
             raise NoOrderedItemsError()
@@ -377,6 +418,7 @@ class ManufacturerOrderService:
             if group_key not in items_by_group:
                 items_by_group[group_key] = []
 
+            md = order_item.manufacturing_data
             items_by_group[group_key].append(
                 {
                     "ordered_date": ordered_at,
@@ -391,6 +433,9 @@ class ManufacturerOrderService:
                     "cost": cost,
                     "design_image_url": order_item.design_image_url,
                     "thumbnail_image_url": order_item.thumbnail_image_url,
+                    # v2: 生成済み製造データ（保存先）。v1 は None。
+                    "manufacturing_data_id": order_item.manufacturing_data_id,
+                    "manufacturing_file_path": md.file_path if md else None,
                 }
             )
 
@@ -454,15 +499,11 @@ class ManufacturerOrderService:
                 # 注文番号フォルダのパスプレフィックス
                 order_folder = f"{type_folder}/{order_number}"
 
-                # デザイン画像（製造データ①）
-                if item.get("design_image_url"):
-                    content, _original_filename = await self._download_file(
-                        item["design_image_url"]
-                    )
-                    if content:
-                        zip_builder.add_file(
-                            f"{order_folder}/{mfg_filename}", content
-                        )
+                # 製造データ①: v2（生成済み）は保存済みファイルを封入、
+                # v1 は従来通り design_image_url をDLしてリネーム。
+                mfg_content = await self._load_manufacturing_content(item)
+                if mfg_content:
+                    zip_builder.add_file(f"{order_folder}/{mfg_filename}", mfg_content)
 
                 # サムネイル画像 → {注文番号}_{製造番号}.png
                 if item.get("thumbnail_image_url"):
@@ -505,6 +546,23 @@ class ManufacturerOrderService:
         zip_name = f"TAPI_{manufacturer.name}_発注資料.zip"
 
         return zip_bytes, zip_name
+
+    async def _load_manufacturing_content(self, item: dict) -> bytes | None:
+        """発注資料に封入する製造データ①のバイト列を取得する.
+
+        v2（生成済み製造データ）は FileStorage の保存済みファイルを使用し、
+        v1 は従来通り design_image_url をダウンロードしてリネーム相当で扱う。
+        """
+        # v2: 保存済み生成ファイル
+        if item.get("manufacturing_data_id") and item.get("manufacturing_file_path"):
+            if self._file_storage is None:
+                return None
+            return await self._file_storage.get(item["manufacturing_file_path"])
+        # v1: 完成デザインURLをダウンロード
+        if item.get("design_image_url"):
+            content, _original_filename = await self._download_file(item["design_image_url"])
+            return content
+        return None
 
     async def _download_file(self, url: str) -> tuple[bytes | None, str]:
         """URLからファイルをダウンロード"""

--- a/api/app/services/manufacturing_data_service.py
+++ b/api/app/services/manufacturing_data_service.py
@@ -30,14 +30,28 @@ from app.services.illustrator_vm_client import IllustratorVmClient, IllustratorV
 from app.utils.exceptions import ConflictError, NotFoundError
 from app.utils.file_storage import FileStorage, LocalFileStorage
 from app.utils.mfg_product_mapping import MfgMappingError, build_vm_mapping
+from app.utils.url_guard import validate_source_url
 
 logger = logging.getLogger(__name__)
+
+
+class SourceImageTooLargeError(Exception):
+    """元データ画像がサイズ上限を超えた場合のエラー."""
+
 
 # 生成済みファイルの保存先プレフィックス（FileStorage 上）
 _STORAGE_PREFIX = "manufacturing_data"
 
 # 元データ（PNGレイヤー）ダウンロードのタイムアウト
 _SOURCE_DOWNLOAD_TIMEOUT = 30.0
+
+# 元データ1レイヤーの既定サイズ上限（settings 未指定時のフォールバック）
+_DEFAULT_SOURCE_MAX_BYTES = 25 * 1024 * 1024  # 25MB
+
+
+def _redact_url(url: str) -> str:
+    """ログ用にクエリ文字列（署名付きトークン等）を落としたURLを返す."""
+    return url.split("?", 1)[0]
 
 # recover_stranded_generations が起動した復旧タスクの強参照を保持する集合。
 # create_task の戻り値を保持しないとタスクが GC で途中消滅しうるため。
@@ -72,12 +86,17 @@ class ManufacturingDataService:
         session: AsyncSession | None = None,
         file_storage: FileStorage | None = None,
         vm_client: IllustratorVmClient | None = None,
+        allowed_source_hosts: frozenset[str] | None = None,
+        max_source_bytes: int | None = None,
     ) -> None:
         self._md_repo = md_repo
         self._order_repo = order_repo
         self._session = session
         self._file_storage = file_storage
         self._vm_client = vm_client
+        # 元データ取得の SSRF/サイズ防御。None なら settings から解決。
+        self._allowed_source_hosts = allowed_source_hosts
+        self._max_source_bytes = max_source_bytes
 
     async def _commit(self) -> None:
         """バックグラウンド/リクエストのどちらでも確実に永続化する."""
@@ -292,20 +311,32 @@ class ManufacturingDataService:
         """
         targets = [img for img in source_images if img["layer_type"] in wanted]
         semaphore = asyncio.Semaphore(4)
+        allowed_hosts = (
+            self._allowed_source_hosts
+            if self._allowed_source_hosts is not None
+            else frozenset(settings.SOURCE_IMAGE_ALLOWED_HOSTS)
+        )
+        max_bytes = self._max_source_bytes or settings.SOURCE_IMAGE_MAX_BYTES
 
-        async with httpx.AsyncClient(timeout=_SOURCE_DOWNLOAD_TIMEOUT) as client:
+        # redirect 追従は無効（許可外ホストへの 30x リダイレクト経由の SSRF を防ぐ）。
+        async with httpx.AsyncClient(
+            timeout=_SOURCE_DOWNLOAD_TIMEOUT, follow_redirects=False
+        ) as client:
 
             async def fetch(img: dict) -> tuple[str, bytes] | None:
                 async with semaphore:
                     try:
-                        response = await client.get(img["url"])
-                        response.raise_for_status()
-                        return img["layer_type"], response.content
-                    except Exception as exc:  # noqa: BLE001 - 1レイヤーの失敗で全体を止めない
+                        # SSRF ガード: 取得前に宛先URLを検証（内部・メタデータ等を遮断）。
+                        validate_source_url(img["url"], allowed_hosts=allowed_hosts)
+                        content = await self._fetch_with_limit(
+                            client, img["url"], max_bytes
+                        )
+                        return img["layer_type"], content
+                    except Exception as exc:  # noqa: BLE001 - 1レイヤーの失敗で全体を止めない（Unsafe/TooLarge含む）
                         logger.warning(
                             "failed to download source layer %s (%s): %s",
                             img["layer_type"],
-                            img["url"],
+                            _redact_url(img["url"]),
                             exc,
                         )
                         return None
@@ -313,6 +344,23 @@ class ManufacturingDataService:
             results = await asyncio.gather(*[fetch(img) for img in targets])
 
         return dict(r for r in results if r is not None)
+
+    async def _fetch_with_limit(
+        self, client: httpx.AsyncClient, url: str, max_bytes: int
+    ) -> bytes:
+        """URL をストリーミング取得し、max_bytes を超えたら中断して例外を投げる."""
+        async with client.stream("GET", url) as response:
+            response.raise_for_status()
+            total = 0
+            chunks: list[bytes] = []
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
+                if total > max_bytes:
+                    raise SourceImageTooLargeError(
+                        f"source image exceeds {max_bytes} bytes: {_redact_url(url)}"
+                    )
+                chunks.append(chunk)
+        return b"".join(chunks)
 
     async def _save_file(self, content: bytes, filename: str) -> str:
         """生成物を FileStorage に保存し、保存先パスを返す."""

--- a/api/app/services/manufacturing_data_service.py
+++ b/api/app/services/manufacturing_data_service.py
@@ -1,0 +1,339 @@
+"""Manufacturing data service.
+
+外部注文（v2）の製造データを illustrator-vm で生成し、pod-admin 側に自前保存する。
+
+- 商品×サイズ×バリアント単位でキャッシュ（同一商品の再注文で VM を再度呼ばない）。
+- 生成は非同期（intake をブロックしない）。BackgroundTasks で新規セッションを開いて実行。
+- VM の72h削除に依存せず、完了ジョブは速やかに DL して FileStorage に保存。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_session_maker
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+from app.models.order import OrderItem
+from app.repositories.manufacturing_data_repository import ManufacturingDataRepository
+from app.repositories.order_repository import OrderRepository
+from app.schemas.manufacturing_data import (
+    ManufacturingDataListResponse,
+    ManufacturingDataResponse,
+)
+from app.services.illustrator_vm_client import IllustratorVmClient, IllustratorVmError
+from app.utils.exceptions import NotFoundError
+from app.utils.file_storage import FileStorage, LocalFileStorage
+from app.utils.mfg_product_mapping import MfgMappingError, build_vm_mapping
+
+logger = logging.getLogger(__name__)
+
+# 生成済みファイルの保存先プレフィックス（FileStorage 上）
+_STORAGE_PREFIX = "manufacturing_data"
+
+# 元データ（PNGレイヤー）ダウンロードのタイムアウト
+_SOURCE_DOWNLOAD_TIMEOUT = 30.0
+
+
+class _BytesUpload:
+    """FileStorage.save に生バイト列を渡すための最小アダプタ."""
+
+    def __init__(self, content: bytes, filename: str) -> None:
+        self._content = content
+        self.filename = filename
+
+    def read(self) -> bytes:
+        return self._content
+
+    def seek(self, offset: int) -> None:  # pragma: no cover - 呼ばれない
+        pass
+
+
+class ManufacturingDataService:
+    """製造データの解決・生成・リトライを担うサービス."""
+
+    def __init__(
+        self,
+        md_repo: ManufacturingDataRepository,
+        order_repo: OrderRepository,
+        session: AsyncSession | None = None,
+        file_storage: FileStorage | None = None,
+        vm_client: IllustratorVmClient | None = None,
+    ) -> None:
+        self._md_repo = md_repo
+        self._order_repo = order_repo
+        self._session = session
+        self._file_storage = file_storage
+        self._vm_client = vm_client
+
+    async def _commit(self) -> None:
+        """バックグラウンド/リクエストのどちらでも確実に永続化する."""
+        if self._session is not None:
+            await self._session.commit()
+
+    # === 着信時の紐付け（リクエストスコープ） ===
+
+    async def prepare_for_order(self, order_id: str) -> list[str]:
+        """v2 注文の各明細に製造データ行を紐付け、生成が必要な md_id を返す.
+
+        製造データ行は intake 内で同期的に作成/紐付けする（manufacturing_data_id を
+        即時に確定させることで発注ゲートを確実に機能させる）。生成そのものは行わない。
+        """
+        order = await self._order_repo.find_by_id(order_id)
+        if not order:
+            return []
+
+        to_generate: list[str] = []
+        for item in order.items:
+            # v1 明細（product_code / source_images なし）は対象外
+            if not (item.product_code and item.source_images):
+                continue
+            md, needs_generation = await self._resolve_or_create(order.order_source_id, item)
+            item.manufacturing_data_id = md.id
+            if needs_generation and md.id not in to_generate:
+                to_generate.append(md.id)
+
+        # 注文・明細・製造データ行を確定（バックグラウンド生成が別セッションから参照できるように）
+        await self._commit()
+        return to_generate
+
+    def enqueue_generation(self, background_tasks, md_ids: list[str]) -> None:
+        """製造データ生成をバックグラウンドで起動する（新規セッションで実行）."""
+        for md_id in md_ids:
+            background_tasks.add_task(run_generation, md_id)
+
+    async def _resolve_or_create(
+        self, order_source_id: str | None, item: OrderItem
+    ) -> tuple[ManufacturingData, bool]:
+        """キャッシュを検索し、無ければ作成する。(row, 生成が必要か) を返す."""
+        layer_types = {img["layer_type"] for img in item.source_images}
+        try:
+            mapping = build_vm_mapping(item.product_type, item.size, layer_types)
+        except MfgMappingError as exc:
+            # マッピング不能 → failed 行を作成（発注ゲートで保留、管理者が気づける）
+            md = await self._insert_row(
+                order_source_id,
+                item,
+                variant=None,
+                status=MfgDataStatus.FAILED,
+                error_message=str(exc),
+            )
+            return md, False
+
+        existing = await self._md_repo.find_by_cache_key(
+            order_source_id, item.product_code, item.size, mapping.variant
+        )
+        if existing:
+            # 失敗行は元データを更新して再生成対象にする。それ以外はそのまま再利用。
+            if existing.status == MfgDataStatus.FAILED.value:
+                existing.status = MfgDataStatus.PENDING.value
+                existing.error_message = None
+                existing.source_images = item.source_images
+                await self._md_repo.update(existing)
+                return existing, True
+            return existing, False
+
+        md = await self._insert_row(
+            order_source_id,
+            item,
+            variant=mapping.variant,
+            status=MfgDataStatus.PENDING,
+            source_images=item.source_images,
+        )
+        return md, True
+
+    async def _insert_row(
+        self,
+        order_source_id: str | None,
+        item: OrderItem,
+        *,
+        variant: str | None,
+        status: MfgDataStatus,
+        source_images: list | None = None,
+        error_message: str | None = None,
+    ) -> ManufacturingData:
+        """製造データ行を作成する（キャッシュキー競合時は既存行を再取得）."""
+        md = ManufacturingData(
+            order_source_id=order_source_id,
+            product_code=item.product_code,
+            product_type=item.product_type,
+            size=item.size,
+            variant=variant,
+            status=status.value,
+            source_images=source_images,
+            error_message=error_message,
+        )
+        if self._session is not None:
+            # 同時受注でキャッシュキーが競合しても intake を 500 にしないよう
+            # SAVEPOINT 内で作成し、競合時は既存行を再取得する。
+            try:
+                async with self._session.begin_nested():
+                    self._session.add(md)
+                    await self._session.flush()
+                return md
+            except IntegrityError:
+                existing = await self._md_repo.find_by_cache_key(
+                    order_source_id, item.product_code, item.size, variant
+                )
+                if existing is not None:
+                    return existing
+                raise
+        return await self._md_repo.create(md)
+
+    # === 生成ドライバ（バックグラウンド） ===
+
+    async def generate(self, md_id: str) -> None:
+        """1件の製造データを生成し、状態を ready/failed に確定させる."""
+        md = await self._md_repo.find_by_id(md_id)
+        if md is None:
+            logger.warning("manufacturing data %s not found; skip generation", md_id)
+            return
+        if md.status == MfgDataStatus.READY.value:
+            return  # 既に完成（冪等）
+
+        # generating へ遷移
+        md.status = MfgDataStatus.GENERATING.value
+        md.attempts += 1
+        md.error_message = None
+        await self._md_repo.update(md)
+        await self._commit()
+
+        try:
+            if self._vm_client is None:
+                raise IllustratorVmError(
+                    "illustrator-vm is not configured (ILLUSTRATOR_VM_BASE_URL)"
+                )
+            if not md.source_images:
+                raise IllustratorVmError("source_images is empty")
+
+            layer_types = {img["layer_type"] for img in md.source_images}
+            mapping = build_vm_mapping(md.product_type, md.size, layer_types)
+
+            images = await self._download_source_images(
+                md.source_images, set(mapping.usable_layers)
+            )
+            # 必須レイヤーが揃っているか最終確認
+            missing = [layer for layer in mapping.required_layers if layer not in images]
+            if missing:
+                raise IllustratorVmError(f"failed to fetch required layers: {missing}")
+
+            job_id = await self._vm_client.submit(
+                product_type=mapping.product_type,
+                size=mapping.size,
+                variant=mapping.variant,
+                input_mode=mapping.input_mode,
+                images=images,
+            )
+            md.vm_job_id = job_id
+            await self._md_repo.update(md)
+            await self._commit()
+
+            status = await self._vm_client.wait_until_complete(job_id)
+            content = await self._vm_client.download(job_id)
+
+            filename = status.output_filename or f"{md.id}{mapping.output_ext}"
+            file_path = await self._save_file(content, filename)
+
+            md.status = MfgDataStatus.READY.value
+            md.output_filename = filename
+            md.file_path = file_path
+            md.file_size = len(content)
+            md.error_message = None
+            await self._md_repo.update(md)
+            await self._commit()
+            logger.info("manufacturing data %s generated (%s)", md_id, filename)
+        except Exception as exc:  # noqa: BLE001 - 失敗は必ず行に記録して終える
+            md.status = MfgDataStatus.FAILED.value
+            md.error_message = str(exc)[:1000]
+            await self._md_repo.update(md)
+            await self._commit()
+            logger.exception("manufacturing data generation failed for %s", md_id)
+
+    async def _download_source_images(
+        self, source_images: list, wanted: set[str]
+    ) -> dict[str, bytes]:
+        """必要なレイヤーの PNG を並列ダウンロードする."""
+        targets = [img for img in source_images if img["layer_type"] in wanted]
+        semaphore = asyncio.Semaphore(4)
+
+        async with httpx.AsyncClient(timeout=_SOURCE_DOWNLOAD_TIMEOUT) as client:
+
+            async def fetch(img: dict) -> tuple[str, bytes]:
+                async with semaphore:
+                    response = await client.get(img["url"])
+                    response.raise_for_status()
+                    return img["layer_type"], response.content
+
+            results = await asyncio.gather(*[fetch(img) for img in targets])
+        return dict(results)
+
+    async def _save_file(self, content: bytes, filename: str) -> str:
+        """生成物を FileStorage に保存し、保存先パスを返す."""
+        storage = self._file_storage or LocalFileStorage(settings.UPLOAD_DIR)
+        return await storage.save(_BytesUpload(content, filename), prefix=_STORAGE_PREFIX)
+
+    # === 管理API（リクエストスコープ） ===
+
+    async def retry(self, md_id: str, background_tasks) -> ManufacturingDataResponse:
+        """失敗/停滞した製造データ生成を手動で再駆動する."""
+        md = await self._md_repo.find_by_id(md_id)
+        if md is None:
+            raise NotFoundError("ManufacturingData", md_id)
+
+        md.status = MfgDataStatus.PENDING.value
+        md.error_message = None
+        await self._md_repo.update(md)
+        await self._commit()
+
+        background_tasks.add_task(run_generation, md_id)
+        return ManufacturingDataResponse.model_validate(md)
+
+    async def list(
+        self,
+        page: int = 1,
+        limit: int = 20,
+        status: str | None = None,
+        order_source_id: str | None = None,
+        product_code: str | None = None,
+    ) -> ManufacturingDataListResponse:
+        """製造データ一覧を取得する."""
+        rows, total = await self._md_repo.list(
+            page=page,
+            limit=limit,
+            status=status,
+            order_source_id=order_source_id,
+            product_code=product_code,
+        )
+        return ManufacturingDataListResponse(
+            items=[ManufacturingDataResponse.model_validate(r) for r in rows],
+            total=total,
+            page=page,
+            limit=limit,
+        )
+
+
+async def run_generation(md_id: str) -> None:
+    """バックグラウンドで新規セッションを開き、1件の製造データを生成する.
+
+    BackgroundTasks から呼ばれる。リクエストのセッションや ORM を持ち込まず、
+    プレーンな md_id だけを受け取る（外部注文通知と同型）。
+    """
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        service = ManufacturingDataService(
+            md_repo=ManufacturingDataRepository(session),
+            order_repo=OrderRepository(session),
+            session=session,
+            file_storage=LocalFileStorage(settings.UPLOAD_DIR),
+            vm_client=IllustratorVmClient.from_settings(settings),
+        )
+        try:
+            await service.generate(md_id)
+        except Exception:  # noqa: BLE001 - バックグラウンドは絶対に落とさない
+            await session.rollback()
+            logger.exception("run_generation crashed for %s", md_id)

--- a/api/app/services/manufacturing_data_service.py
+++ b/api/app/services/manufacturing_data_service.py
@@ -43,6 +43,10 @@ _SOURCE_DOWNLOAD_TIMEOUT = 30.0
 # create_task の戻り値を保持しないとタスクが GC で途中消滅しうるため。
 _recovery_tasks: set[asyncio.Task[None]] = set()
 
+# 起動時復旧で同時に走らせる生成の上限。VM は直列・DB プールも有限のため、大量の宙吊り行が
+# 一斉に生成を始めて接続を枯渇させたり VM を過負荷にしたりしないよう抑制する。
+_RECOVERY_CONCURRENCY = 4
+
 
 class _BytesUpload:
     """FileStorage.save に生バイト列を渡すための最小アダプタ."""
@@ -212,19 +216,19 @@ class ManufacturingDataService:
         # （重複した VM ジョブ投入・生成ファイルの孤立を防ぐ）。
         claimed = await self._md_repo.claim_for_generation(md_id)
         if not claimed:
-            await self._commit()
             logger.info(
                 "manufacturing data %s is already generating or ready; skip duplicate",
                 md_id,
             )
             return
 
-        # claim 成功。行の状態を確定させる（attempts はここで加算）。
+        # claim（条件付き UPDATE）が status=generating・attempts+1・error クリアを原子的に
+        # 確定済み。commit で他ワーカーへ可視化し、in-memory instance を DB と同期させる
+        # （後続の flush が古い値で上書きしないため。追加の UPDATE は不要）。
+        await self._commit()
         md.status = MfgDataStatus.GENERATING.value
         md.attempts += 1
         md.error_message = None
-        await self._md_repo.update(md)
-        await self._commit()
 
         try:
             if self._vm_client is None:
@@ -282,39 +286,33 @@ class ManufacturingDataService:
     ) -> dict[str, bytes]:
         """必要なレイヤーの PNG を並列ダウンロードする.
 
-        個々のレイヤー DL 失敗では例外を送出せず、成功したレイヤーのみを返す。
-        必須レイヤー不足の判定は呼び出し側の missing チェックに委ねる。これにより、
-        optional レイヤー（white 等）の取得失敗で生成全体を落とすことを防ぐ
-        （return_exceptions=True で in-flight タスクの取りこぼしも起きない）。
+        個々のレイヤー DL 失敗は fetch 内で握って None を返し、成功したレイヤーだけ集める。
+        必須レイヤー不足の判定は呼び出し側の missing チェックに委ねる。これにより optional
+        レイヤー（white 等）の取得失敗で生成全体を落とさない。
         """
         targets = [img for img in source_images if img["layer_type"] in wanted]
         semaphore = asyncio.Semaphore(4)
 
         async with httpx.AsyncClient(timeout=_SOURCE_DOWNLOAD_TIMEOUT) as client:
 
-            async def fetch(img: dict) -> tuple[str, bytes]:
+            async def fetch(img: dict) -> tuple[str, bytes] | None:
                 async with semaphore:
-                    response = await client.get(img["url"])
-                    response.raise_for_status()
-                    return img["layer_type"], response.content
+                    try:
+                        response = await client.get(img["url"])
+                        response.raise_for_status()
+                        return img["layer_type"], response.content
+                    except Exception as exc:  # noqa: BLE001 - 1レイヤーの失敗で全体を止めない
+                        logger.warning(
+                            "failed to download source layer %s (%s): %s",
+                            img["layer_type"],
+                            img["url"],
+                            exc,
+                        )
+                        return None
 
-            results = await asyncio.gather(
-                *[fetch(img) for img in targets], return_exceptions=True
-            )
+            results = await asyncio.gather(*[fetch(img) for img in targets])
 
-        images: dict[str, bytes] = {}
-        for img, result in zip(targets, results, strict=True):
-            if isinstance(result, BaseException):
-                logger.warning(
-                    "failed to download source layer %s (%s): %s",
-                    img["layer_type"],
-                    img["url"],
-                    result,
-                )
-                continue
-            layer_type, content = result
-            images[layer_type] = content
-        return images
+        return dict(r for r in results if r is not None)
 
     async def _save_file(self, content: bytes, filename: str) -> str:
         """生成物を FileStorage に保存し、保存先パスを返す."""
@@ -408,20 +406,22 @@ async def recover_stranded_generations() -> None:
     """
     session_maker = get_session_maker()
     async with session_maker() as session:
-        repo = ManufacturingDataRepository(session)
-        stranded = await repo.find_stranded()
-        # 中断された generating は claim 可能な pending に戻す。
-        for md in stranded:
-            if md.status == MfgDataStatus.GENERATING.value:
-                md.status = MfgDataStatus.PENDING.value
+        # 宙吊り行を pending に戻し、再駆動対象の id を1文で回収する。
+        stranded_ids = await ManufacturingDataRepository(session).reclaim_stranded()
         await session.commit()
-        stranded_ids = [md.id for md in stranded]
 
     if not stranded_ids:
         return
 
     logger.info("recovering %d stranded manufacturing generation(s)", len(stranded_ids))
+    # 同時実行数を抑えて再駆動する（VM 直列・DB プール有限のため一斉起動を避ける）。
+    semaphore = asyncio.Semaphore(_RECOVERY_CONCURRENCY)
+
+    async def _drive(md_id: str) -> None:
+        async with semaphore:
+            await run_generation(md_id)
+
     for md_id in stranded_ids:
-        task = asyncio.create_task(run_generation(md_id))
+        task = asyncio.create_task(_drive(md_id))
         _recovery_tasks.add(task)
         task.add_done_callback(_recovery_tasks.discard)

--- a/api/app/services/manufacturing_data_service.py
+++ b/api/app/services/manufacturing_data_service.py
@@ -27,7 +27,7 @@ from app.schemas.manufacturing_data import (
     ManufacturingDataResponse,
 )
 from app.services.illustrator_vm_client import IllustratorVmClient, IllustratorVmError
-from app.utils.exceptions import NotFoundError
+from app.utils.exceptions import ConflictError, NotFoundError
 from app.utils.file_storage import FileStorage, LocalFileStorage
 from app.utils.mfg_product_mapping import MfgMappingError, build_vm_mapping
 
@@ -38,6 +38,10 @@ _STORAGE_PREFIX = "manufacturing_data"
 
 # 元データ（PNGレイヤー）ダウンロードのタイムアウト
 _SOURCE_DOWNLOAD_TIMEOUT = 30.0
+
+# recover_stranded_generations が起動した復旧タスクの強参照を保持する集合。
+# create_task の戻り値を保持しないとタスクが GC で途中消滅しうるため。
+_recovery_tasks: set[asyncio.Task[None]] = set()
 
 
 class _BytesUpload:
@@ -116,7 +120,7 @@ class ManufacturingDataService:
             mapping = build_vm_mapping(item.product_type, item.size, layer_types)
         except MfgMappingError as exc:
             # マッピング不能 → failed 行を作成（発注ゲートで保留、管理者が気づける）
-            md = await self._insert_row(
+            md, _ = await self._insert_row(
                 order_source_id,
                 item,
                 variant=None,
@@ -138,14 +142,16 @@ class ManufacturingDataService:
                 return existing, True
             return existing, False
 
-        md = await self._insert_row(
+        # 新規作成。ただし同時受注の競合で _insert_row が既存行を回収した場合は
+        # created=False となる（その場合は作成した側が生成を起動するので二重起動しない）。
+        md, created = await self._insert_row(
             order_source_id,
             item,
             variant=mapping.variant,
             status=MfgDataStatus.PENDING,
             source_images=item.source_images,
         )
-        return md, True
+        return md, created
 
     async def _insert_row(
         self,
@@ -156,8 +162,13 @@ class ManufacturingDataService:
         status: MfgDataStatus,
         source_images: list | None = None,
         error_message: str | None = None,
-    ) -> ManufacturingData:
-        """製造データ行を作成する（キャッシュキー競合時は既存行を再取得）."""
+    ) -> tuple[ManufacturingData, bool]:
+        """製造データ行を作成する（キャッシュキー競合時は既存行を再取得）.
+
+        Returns:
+            (row, created): created=True なら新規作成、False なら競合で既存行を回収した。
+            回収時に created=False を返すことで、呼び出し側が生成を二重起動しないようにする。
+        """
         md = ManufacturingData(
             order_source_id=order_source_id,
             product_code=item.product_code,
@@ -175,15 +186,15 @@ class ManufacturingDataService:
                 async with self._session.begin_nested():
                     self._session.add(md)
                     await self._session.flush()
-                return md
+                return md, True
             except IntegrityError:
                 existing = await self._md_repo.find_by_cache_key(
                     order_source_id, item.product_code, item.size, variant
                 )
                 if existing is not None:
-                    return existing
+                    return existing, False
                 raise
-        return await self._md_repo.create(md)
+        return await self._md_repo.create(md), True
 
     # === 生成ドライバ（バックグラウンド） ===
 
@@ -196,7 +207,19 @@ class ManufacturingDataService:
         if md.status == MfgDataStatus.READY.value:
             return  # 既に完成（冪等）
 
-        # generating へ遷移
+        # 二重生成防止: pending/failed の行だけを generating へ原子的に claim する。
+        # 既に generating（別ワーカーが処理中）/ready なら claim できず抜ける
+        # （重複した VM ジョブ投入・生成ファイルの孤立を防ぐ）。
+        claimed = await self._md_repo.claim_for_generation(md_id)
+        if not claimed:
+            await self._commit()
+            logger.info(
+                "manufacturing data %s is already generating or ready; skip duplicate",
+                md_id,
+            )
+            return
+
+        # claim 成功。行の状態を確定させる（attempts はここで加算）。
         md.status = MfgDataStatus.GENERATING.value
         md.attempts += 1
         md.error_message = None
@@ -257,7 +280,13 @@ class ManufacturingDataService:
     async def _download_source_images(
         self, source_images: list, wanted: set[str]
     ) -> dict[str, bytes]:
-        """必要なレイヤーの PNG を並列ダウンロードする."""
+        """必要なレイヤーの PNG を並列ダウンロードする.
+
+        個々のレイヤー DL 失敗では例外を送出せず、成功したレイヤーのみを返す。
+        必須レイヤー不足の判定は呼び出し側の missing チェックに委ねる。これにより、
+        optional レイヤー（white 等）の取得失敗で生成全体を落とすことを防ぐ
+        （return_exceptions=True で in-flight タスクの取りこぼしも起きない）。
+        """
         targets = [img for img in source_images if img["layer_type"] in wanted]
         semaphore = asyncio.Semaphore(4)
 
@@ -269,8 +298,23 @@ class ManufacturingDataService:
                     response.raise_for_status()
                     return img["layer_type"], response.content
 
-            results = await asyncio.gather(*[fetch(img) for img in targets])
-        return dict(results)
+            results = await asyncio.gather(
+                *[fetch(img) for img in targets], return_exceptions=True
+            )
+
+        images: dict[str, bytes] = {}
+        for img, result in zip(targets, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "failed to download source layer %s (%s): %s",
+                    img["layer_type"],
+                    img["url"],
+                    result,
+                )
+                continue
+            layer_type, content = result
+            images[layer_type] = content
+        return images
 
     async def _save_file(self, content: bytes, filename: str) -> str:
         """生成物を FileStorage に保存し、保存先パスを返す."""
@@ -280,10 +324,23 @@ class ManufacturingDataService:
     # === 管理API（リクエストスコープ） ===
 
     async def retry(self, md_id: str, background_tasks) -> ManufacturingDataResponse:
-        """失敗/停滞した製造データ生成を手動で再駆動する."""
+        """失敗した製造データ生成を手動で再駆動する.
+
+        retry は failed 行の再実行のみ許可する。製造データ行は
+        （受注元 × 商品コード × サイズ × バリアント）単位で複数注文に共有されるため、
+        ready/generating/pending の行を無条件に巻き戻すと、その行を参照する他の注文の
+        is_manufacturing_ready まで劣化させてしまう（生成済みファイルの喪失や、発注可能
+        だった明細の再ブロックにつながる）。宙吊りになった generating/pending 行は起動時の
+        復旧処理（recover_stranded_generations）が再駆動する。
+        """
         md = await self._md_repo.find_by_id(md_id)
         if md is None:
             raise NotFoundError("ManufacturingData", md_id)
+        if md.status != MfgDataStatus.FAILED.value:
+            raise ConflictError(
+                f"manufacturing data {md_id} is not in a failed state "
+                f"(current status: {md.status}); retry is only allowed for failed rows"
+            )
 
         md.status = MfgDataStatus.PENDING.value
         md.error_message = None
@@ -337,3 +394,34 @@ async def run_generation(md_id: str) -> None:
         except Exception:  # noqa: BLE001 - バックグラウンドは絶対に落とさない
             await session.rollback()
             logger.exception("run_generation crashed for %s", md_id)
+
+
+async def recover_stranded_generations() -> None:
+    """起動時に宙吊りの製造データ生成を再駆動する.
+
+    生成は in-process の BackgroundTask で走るため、生成中（generating）に API が
+    再起動/デプロイ/クラッシュすると、その行は generating のまま取り残され、参照する
+    注文が発注ゲートで恒久的に保留される。新プロセスには in-flight タスクが無いので、
+    起動時点の generating は全て中断済み。generating を pending に戻したうえで、
+    pending/generating だった行を再駆動する（generate() 側の claim で二重起動は防止される）。
+    失敗しても起動は継続させる（例外は握って記録するだけ）。
+    """
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        repo = ManufacturingDataRepository(session)
+        stranded = await repo.find_stranded()
+        # 中断された generating は claim 可能な pending に戻す。
+        for md in stranded:
+            if md.status == MfgDataStatus.GENERATING.value:
+                md.status = MfgDataStatus.PENDING.value
+        await session.commit()
+        stranded_ids = [md.id for md in stranded]
+
+    if not stranded_ids:
+        return
+
+    logger.info("recovering %d stranded manufacturing generation(s)", len(stranded_ids))
+    for md_id in stranded_ids:
+        task = asyncio.create_task(run_generation(md_id))
+        _recovery_tasks.add(task)
+        task.add_done_callback(_recovery_tasks.discard)

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -330,13 +330,21 @@ class OrderService:
         )
 
     @staticmethod
-    def _unready_ordered_item_count(order: Order) -> int:
-        """ORDERED のまま製造データが ready でない（＝メーカー発注できない）明細数を返す.
+    def _manufacturing_gate_unready_count(
+        order: Order, current_status: OrderStatus, target_status: OrderStatus
+    ) -> int:
+        """ORDERED→MANUFACTURING の前進遷移で発注できない明細数を返す（それ以外は 0）.
 
-        MANUFACTURING への前進遷移ゲート用の共通述語。既に MANUFACTURING/DELIVERED の明細や
-        v1 明細（is_manufacturing_ready=True）は対象外。update_status と bulk_update_status の
-        両ゲートで共有し、注文レベルと明細レベルの判定を一致させる。
+        既に MANUFACTURING の注文の再確定（no-op）や MANUFACTURING 以外への遷移では
+        ゲートは発動しない（明細単位ゲートとの不整合を避ける）。判定対象は
+        Order.unready_ordered_item_count（ORDERED かつ未ready）。update_status と
+        bulk_update_status で共有し、両ゲートの前進条件と述語を一致させる。
         """
+        if (
+            target_status != OrderStatus.MANUFACTURING
+            or current_status == OrderStatus.MANUFACTURING
+        ):
+            return 0
         return sum(
             1
             for item in order.items
@@ -367,17 +375,10 @@ class OrderService:
         if current_status == OrderStatus.SHIPPED:
             raise InvalidStatusTransitionError(current_status.value, status.value)
 
-        # 発注ゲート: ORDERED→MANUFACTURING の前進遷移でのみ発動する。
-        # 既に MANUFACTURING の注文（メーカーが明細単位で一部を製造中にしたケース等）を
-        # 再度 manufacturing にする no-op では発動しない（明細単位ゲートとの不整合を避ける）。
-        # 判定対象は「まだ ORDERED の未ready明細」のみ。v1 明細は常に ready で影響しない。
-        if (
-            status == OrderStatus.MANUFACTURING
-            and current_status != OrderStatus.MANUFACTURING
-        ):
-            unready = self._unready_ordered_item_count(order)
-            if unready:
-                raise ManufacturingDataNotReadyError(unready)
+        # 発注ゲート: ORDERED→MANUFACTURING の前進遷移でのみ、未ready の ORDERED 明細を拒否。
+        unready = self._manufacturing_gate_unready_count(order, current_status, status)
+        if unready:
+            raise ManufacturingDataNotReadyError(unready)
 
         # delivered -> ordered/manufacturing の遷移時の処理
         if current_status == OrderStatus.DELIVERED and status in (
@@ -708,14 +709,9 @@ class OrderService:
                 failed_count += 1
                 continue
 
-            # 発注ゲート: MANUFACTURING への前進遷移のみ、未ready の ORDERED 明細を含む注文を
-            # ブロックする（単発 update_status と同一述語 _unready_ordered_item_count）。一括は
-            # best-effort のため failed として記録しスキップする（Shipment 削除等の副作用の前に判定）。
-            if (
-                status == OrderStatus.MANUFACTURING
-                and current_status != OrderStatus.MANUFACTURING
-                and self._unready_ordered_item_count(order)
-            ):
+            # 発注ゲート: 単発 update_status と同一判定（前進遷移のみ・未ready の ORDERED 明細）。
+            # 一括は best-effort のため failed として記録しスキップ（Shipment 削除等の副作用の前に判定）。
+            if self._manufacturing_gate_unready_count(order, current_status, status):
                 failed_ids.append(order_id)
                 failed_count += 1
                 continue

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -38,10 +38,14 @@ from app.repositories.order_source_repository import OrderSourceRepository
 from app.repositories.product_repository import ProductRepository
 from app.repositories.shipment_repository import ShipmentRepository
 from app.schemas.order import (
+    CustomerInfo,
     ManufacturingDataInfo,
+    MfgDataItemInfo,
     OrderBulkStatusUpdateResponse,
     OrderCreate,
+    OrderCreateV2,
     OrderItemCreate,
+    OrderItemCreateV2,
     OrderItemResponse,
     OrderListResponse,
     OrderResponse,
@@ -56,6 +60,7 @@ from app.utils.business_day_calculator import add_business_days
 from app.utils.exceptions import (
     DuplicateError,
     InvalidStatusTransitionError,
+    ManufacturingDataNotReadyError,
     NotFoundError,
     OrderNotFoundError,
     ProductNotFoundError,
@@ -90,15 +95,51 @@ class OrderService:
         data: OrderCreate,
         order_source_id: str | None = None,
     ) -> OrderResponse:
-        """Create a new order from external sales site."""
+        """Create a new order from external sales site (v1: 完成デザインURL方式)."""
+        return await self._create_order(
+            order_number=data.order_number,
+            customer=data.customer,
+            items=data.items,
+            order_source_id=order_source_id,
+            build_item=self._build_v1_item,
+        )
+
+    async def create_v2(
+        self,
+        data: OrderCreateV2,
+        order_source_id: str | None = None,
+    ) -> OrderResponse:
+        """Create a new order from external sales site (v2: 製造データ生成方式).
+
+        完成デザインは受け取らず、元データ（PNGレイヤーURL）を source_images に保存する。
+        製造データの生成・紐付けは ManufacturingDataService.prepare_for_order が担う。
+        """
+        return await self._create_order(
+            order_number=data.order_number,
+            customer=data.customer,
+            items=data.items,
+            order_source_id=order_source_id,
+            build_item=self._build_v2_item,
+        )
+
+    async def _create_order(
+        self,
+        *,
+        order_number: str,
+        customer: CustomerInfo,
+        items: list,
+        order_source_id: str | None,
+        build_item,
+    ) -> OrderResponse:
+        """v1/v2 共通の注文作成ロジック（明細組み立てのみ build_item に委譲）."""
         # Check for duplicate order number
-        existing = await self._order_repo.find_by_order_number(data.order_number)
+        existing = await self._order_repo.find_by_order_number(order_number)
         if existing:
-            raise DuplicateError("Order", "order_number", data.order_number)
+            raise DuplicateError("Order", "order_number", order_number)
 
         # Validate items and find products
         products: dict[int, Product] = {}  # index -> Product
-        for idx, item_data in enumerate(data.items):
+        for idx, item_data in enumerate(items):
             # Validate attributes based on product_type
             self._validate_item_attributes(item_data)
 
@@ -116,15 +157,14 @@ class OrderService:
             company_holidays = await self._company_holiday_repo.find_all_dates()
 
         # Calculate total price
-        total_price = sum(item.price * item.quantity for item in data.items)
+        total_price = sum(item.price * item.quantity for item in items)
 
         # Create order with split address fields
         # ordered_at はアプリケーション側で JST 現在時刻を設定
         jst = ZoneInfo("Asia/Tokyo")
         now_jst = datetime.now(jst)
-        customer = data.customer
         order = Order(
-            order_number=data.order_number,
+            order_number=order_number,
             order_source_id=order_source_id,
             customer_name=customer.name,
             customer_postal_code=customer.postal_code,
@@ -139,7 +179,7 @@ class OrderService:
 
         # Create order items with expected_delivery_date
         ordered_date = now_jst.date()
-        for idx, item_data in enumerate(data.items):
+        for idx, item_data in enumerate(items):
             product = products[idx]
 
             # Calculate expected_delivery_date using business day calculation
@@ -148,22 +188,7 @@ class OrderService:
                 product.lead_time_days,
                 company_holidays,
             )
-
-            order_item = OrderItem(
-                uid=item_data.uid,
-                product_id=product.id,
-                product_name=item_data.product_name,
-                product_type=item_data.product_type.value,
-                price=item_data.price,
-                quantity=item_data.quantity,
-                size=item_data.size,
-                position=item_data.position,
-                color=item_data.color,
-                design_image_url=item_data.design_image_url,
-                thumbnail_image_url=item_data.thumbnail_image_url,
-                expected_delivery_date=expected_delivery,
-            )
-            order.items.append(order_item)
+            order.items.append(build_item(item_data, product, expected_delivery))
 
         # Calculate estimated_shipping_date
         shipping_days = SHIPPING_PREPARATION_DAYS_DEFAULT
@@ -176,6 +201,48 @@ class OrderService:
 
         order = await self._order_repo.create(order)
         return await self._to_response(order)
+
+    @staticmethod
+    def _build_v1_item(
+        item_data: OrderItemCreate, product: Product, expected_delivery: date
+    ) -> OrderItem:
+        """v1 明細（完成デザインURL）を組み立てる."""
+        return OrderItem(
+            uid=item_data.uid,
+            product_id=product.id,
+            product_name=item_data.product_name,
+            product_type=item_data.product_type.value,
+            price=item_data.price,
+            quantity=item_data.quantity,
+            size=item_data.size,
+            position=item_data.position,
+            color=item_data.color,
+            design_image_url=item_data.design_image_url,
+            thumbnail_image_url=item_data.thumbnail_image_url,
+            expected_delivery_date=expected_delivery,
+        )
+
+    @staticmethod
+    def _build_v2_item(
+        item_data: OrderItemCreateV2, product: Product, expected_delivery: date
+    ) -> OrderItem:
+        """v2 明細（製造データ生成用の元データ）を組み立てる."""
+        return OrderItem(
+            uid=item_data.uid,
+            product_id=product.id,
+            product_name=item_data.product_name,
+            product_type=item_data.product_type.value,
+            price=item_data.price,
+            quantity=item_data.quantity,
+            size=item_data.size,
+            position=item_data.position,
+            color=item_data.color,
+            design_image_url=None,  # v2 は完成デザインを受け取らない
+            thumbnail_image_url=item_data.thumbnail_image_url,
+            expected_delivery_date=expected_delivery,
+            product_code=item_data.product_code,
+            source_images=[img.model_dump() for img in item_data.source_images],
+        )
 
     def _validate_item_attributes(self, item_data: OrderItemCreate) -> None:
         """Validate item attributes based on product_type."""
@@ -263,6 +330,13 @@ class OrderService:
         if current_status == OrderStatus.SHIPPED:
             raise InvalidStatusTransitionError(current_status.value, status.value)
 
+        # 発注ゲート: MANUFACTURING への遷移は製造データが ready の明細のみ許可。
+        # v1 明細（製造データ不要）は常に許可されるため旧挙動に影響しない。
+        if status == OrderStatus.MANUFACTURING:
+            unready = sum(1 for item in order.items if not item.is_manufacturing_ready)
+            if unready:
+                raise ManufacturingDataNotReadyError(unready)
+
         # delivered -> ordered/manufacturing の遷移時の処理
         if current_status == OrderStatus.DELIVERED and status in (
             OrderStatus.ORDERED,
@@ -348,6 +422,12 @@ class OrderService:
                 design_image_url=item.design_image_url,
                 thumbnail_image_url=item.thumbnail_image_url,
                 expected_delivery_date=item.expected_delivery_date,
+                product_code=item.product_code,
+                manufacturing_data=(
+                    MfgDataItemInfo.model_validate(item.manufacturing_data)
+                    if item.manufacturing_data
+                    else None
+                ),
                 created_at=item.created_at,
                 updated_at=item.updated_at,
             )

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -66,6 +66,7 @@ from app.utils.exceptions import (
     ProductNotFoundError,
     ValidationError,
 )
+from app.utils.mfg_product_mapping import MfgMappingError, build_vm_mapping
 from app.utils.zip_builder import ZipBuilder
 
 logger = logging.getLogger(__name__)
@@ -114,6 +115,12 @@ class OrderService:
         完成デザインは受け取らず、元データ（PNGレイヤーURL）を source_images に保存する。
         製造データの生成・紐付けは ManufacturingDataService.prepare_for_order が担う。
         """
+        # v2: 製造データを生成できる入力か（商品タイプ・サイズ・必須レイヤー）を intake で
+        # 同期検証する。ここで弾かないと生成不能な注文を 201 で受理してしまい、非同期生成が
+        # FAILED 行を作って発注ゲートが恒久的に保留する（利用者に是正機会を返せない）。
+        for item in data.items:
+            self._validate_v2_manufacturing_inputs(item)
+
         return await self._create_order(
             order_number=data.order_number,
             customer=data.customer,
@@ -121,6 +128,20 @@ class OrderService:
             order_source_id=order_source_id,
             build_item=self._build_v2_item,
         )
+
+    @staticmethod
+    def _validate_v2_manufacturing_inputs(item_data: OrderItemCreateV2) -> None:
+        """v2 明細が製造データを生成可能かを検証する（商品タイプ・サイズ・必須レイヤー）.
+
+        生成時と同じ build_vm_mapping を用いることで、intake の受理条件と生成の実行条件を
+        一致させる。マッピング不能（必須レイヤー欠落・未対応サイズ等）なら ValidationError で
+        同期的に拒否し、生成不能な注文を受理して恒久的に発注保留する事態を防ぐ。
+        """
+        layer_types = {img.layer_type for img in item_data.source_images}
+        try:
+            build_vm_mapping(item_data.product_type.value, item_data.size, layer_types)
+        except MfgMappingError as exc:
+            raise ValidationError(f"{exc} (uid: {item_data.uid})") from exc
 
     async def _create_order(
         self,
@@ -662,6 +683,16 @@ class OrderService:
 
             # Reject transition from shipped status
             if current_status == OrderStatus.SHIPPED:
+                failed_ids.append(order_id)
+                failed_count += 1
+                continue
+
+            # 発注ゲート: MANUFACTURING への一括遷移も製造データが ready の明細のみ許可する
+            # （単発 update_status の 409 ゲートと同一規則）。一括は best-effort のため、未ready
+            # 明細を含む注文は失敗として記録しスキップする（Shipment 削除等の副作用を起こす前に判定）。
+            if status == OrderStatus.MANUFACTURING and any(
+                not item.is_manufacturing_ready for item in order.items
+            ):
                 failed_ids.append(order_id)
                 failed_count += 1
                 continue

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -19,6 +19,7 @@ from app.models.order import (
     AcrylicStandSize,
     Order,
     OrderItem,
+    OrderItemStatus,
     OrderStatus,
     StickerColor,
     StickerSize,
@@ -328,6 +329,21 @@ class OrderService:
             limit=limit,
         )
 
+    @staticmethod
+    def _unready_ordered_item_count(order: Order) -> int:
+        """ORDERED のまま製造データが ready でない（＝メーカー発注できない）明細数を返す.
+
+        MANUFACTURING への前進遷移ゲート用の共通述語。既に MANUFACTURING/DELIVERED の明細や
+        v1 明細（is_manufacturing_ready=True）は対象外。update_status と bulk_update_status の
+        両ゲートで共有し、注文レベルと明細レベルの判定を一致させる。
+        """
+        return sum(
+            1
+            for item in order.items
+            if item.status == OrderItemStatus.ORDERED.value
+            and not item.is_manufacturing_ready
+        )
+
     async def update_status(self, order_id: str, status: OrderStatus) -> OrderResponse:
         """Update order status.
 
@@ -351,10 +367,15 @@ class OrderService:
         if current_status == OrderStatus.SHIPPED:
             raise InvalidStatusTransitionError(current_status.value, status.value)
 
-        # 発注ゲート: MANUFACTURING への遷移は製造データが ready の明細のみ許可。
-        # v1 明細（製造データ不要）は常に許可されるため旧挙動に影響しない。
-        if status == OrderStatus.MANUFACTURING:
-            unready = sum(1 for item in order.items if not item.is_manufacturing_ready)
+        # 発注ゲート: ORDERED→MANUFACTURING の前進遷移でのみ発動する。
+        # 既に MANUFACTURING の注文（メーカーが明細単位で一部を製造中にしたケース等）を
+        # 再度 manufacturing にする no-op では発動しない（明細単位ゲートとの不整合を避ける）。
+        # 判定対象は「まだ ORDERED の未ready明細」のみ。v1 明細は常に ready で影響しない。
+        if (
+            status == OrderStatus.MANUFACTURING
+            and current_status != OrderStatus.MANUFACTURING
+        ):
+            unready = self._unready_ordered_item_count(order)
             if unready:
                 raise ManufacturingDataNotReadyError(unready)
 
@@ -687,11 +708,13 @@ class OrderService:
                 failed_count += 1
                 continue
 
-            # 発注ゲート: MANUFACTURING への一括遷移も製造データが ready の明細のみ許可する
-            # （単発 update_status の 409 ゲートと同一規則）。一括は best-effort のため、未ready
-            # 明細を含む注文は失敗として記録しスキップする（Shipment 削除等の副作用を起こす前に判定）。
-            if status == OrderStatus.MANUFACTURING and any(
-                not item.is_manufacturing_ready for item in order.items
+            # 発注ゲート: MANUFACTURING への前進遷移のみ、未ready の ORDERED 明細を含む注文を
+            # ブロックする（単発 update_status と同一述語 _unready_ordered_item_count）。一括は
+            # best-effort のため failed として記録しスキップする（Shipment 削除等の副作用の前に判定）。
+            if (
+                status == OrderStatus.MANUFACTURING
+                and current_status != OrderStatus.MANUFACTURING
+                and self._unready_ordered_item_count(order)
             ):
                 failed_ids.append(order_id)
                 failed_count += 1

--- a/api/app/utils/exceptions.py
+++ b/api/app/utils/exceptions.py
@@ -144,3 +144,16 @@ class NoOrderedItemsError(AppException):
             "NO_ORDERED_ITEMS",
             "ダウンロード対象の発注中明細がありません",
         )
+
+
+class ManufacturingDataNotReadyError(AppException):
+    """Manufacturing data not ready for manufacturer order error."""
+
+    def __init__(self, pending_count: int | None = None):
+        message = "製造データが未完成のため、メーカーへ発注できません"
+        if pending_count is not None:
+            message = (
+                f"製造データが未完成の明細が {pending_count} 件あるため、"
+                "メーカーへ発注できません"
+            )
+        super().__init__(409, "MANUFACTURING_DATA_NOT_READY", message)

--- a/api/app/utils/mfg_product_mapping.py
+++ b/api/app/utils/mfg_product_mapping.py
@@ -1,0 +1,165 @@
+"""pod-admin の商品属性を illustrator-vm（Product Manufacturing API）の属性へ変換する.
+
+illustrator-vm は `config/products.yaml` を正として以下を要求する:
+
+- tshirt:           single / S,M,L,XL          / variant なし / PDF
+- tote_bag:         single / M                 / variant なし / PDF
+- acrylic_keychain: multi(color+cutline[+white]) / variant 必須(clear/color) / 50x50,70x70,100x100 / AI
+- acrylic_stand:    multi(color+cutline[+white]) / variant なし              / 50mm,70mm,100mm      / AI
+- sticker:          multi(color+cutline)         / variant 必須(clear)       / 50x50,70x70,100x100  / AI
+
+注: mug_cup は VM 側では対応しているが pod-admin の ProductType に未定義のため本スコープ外。
+
+バリアントは受注値ではなく「提供された元データのレイヤー構成」から決定的に導出する:
+- keychain: white レイヤーがあれば "color"（白版あり）、なければ "clear"
+- sticker:  常に "clear"（white は扱わない）
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+# レイヤー種別
+LAYER_COLOR = "color"
+LAYER_CUTLINE = "cutline"
+LAYER_WHITE = "white"
+LAYER_DESIGN = "design"
+
+# 入力モード
+INPUT_MODE_SINGLE = "single"
+INPUT_MODE_MULTI = "multi"
+
+
+class MfgMappingError(ValueError):
+    """商品属性を VM 属性へ変換できない場合のエラー."""
+
+
+@dataclass(frozen=True)
+class VmMapping:
+    """illustrator-vm へ渡す製造データ生成パラメータ."""
+
+    product_type: str
+    size: str
+    variant: str | None
+    input_mode: str
+    # 送信必須のレイヤー種別
+    required_layers: tuple[str, ...]
+    # 提供されていれば送信する任意レイヤー種別
+    optional_layers: tuple[str, ...] = field(default_factory=tuple)
+    # 生成物の拡張子（保存/命名のフォールバック。実ファイル名は VM の output_filename を正とする）
+    output_ext: str = ".ai"
+
+    @property
+    def usable_layers(self) -> tuple[str, ...]:
+        """required + optional の全レイヤー種別."""
+        return self.required_layers + self.optional_layers
+
+
+# サイズ正規化テーブル（product_type -> {pod-admin size: VM size}）
+_SIZE_MAPS: dict[str, dict[str, str]] = {
+    "acrylic_keychain": {"50x50mm": "50x50", "70x70mm": "70x70", "100x100mm": "100x100"},
+    "sticker": {"50x50mm": "50x50", "70x70mm": "70x70", "100x100mm": "100x100"},
+    "acrylic_stand": {"50x50mm": "50mm", "70x70mm": "70mm", "100x100mm": "100mm"},
+    "tshirt": {"S": "S", "M": "M", "L": "L", "XL": "XL"},
+    "tote_bag": {"M": "M"},
+}
+
+
+def _normalize_size(product_type: str, size: str | None) -> str:
+    """pod-admin のサイズを VM サイズへ正規化する."""
+    if not size:
+        raise MfgMappingError(f"size is required for product_type '{product_type}'")
+    size_map = _SIZE_MAPS[product_type]
+    normalized = size_map.get(size)
+    if normalized is None:
+        raise MfgMappingError(
+            f"Unsupported size '{size}' for product_type '{product_type}'. "
+            f"Valid: {sorted(size_map)}"
+        )
+    return normalized
+
+
+def build_vm_mapping(
+    product_type: str,
+    size: str | None,
+    provided_layers: Iterable[str],
+) -> VmMapping:
+    """pod-admin の商品属性から VM 生成パラメータを構築する.
+
+    Args:
+        product_type: pod-admin の商品タイプ（tshirt / acrylic_keychain 等）。
+        size: pod-admin のサイズ（例 "50x50mm", "M"）。
+        provided_layers: v2 明細の source_images で提供されたレイヤー種別の集合。
+
+    Raises:
+        MfgMappingError: 未対応の商品タイプ／サイズ、または必須レイヤー不足の場合。
+    """
+    layers = set(provided_layers)
+
+    if product_type in ("tshirt", "tote_bag"):
+        # 単一画像商品: design（無ければ color）1枚
+        if LAYER_DESIGN in layers:
+            required = (LAYER_DESIGN,)
+        elif LAYER_COLOR in layers:
+            required = (LAYER_COLOR,)
+        else:
+            raise MfgMappingError(
+                f"product_type '{product_type}' requires a 'design' (or 'color') layer"
+            )
+        return VmMapping(
+            product_type=product_type,
+            size=_normalize_size(product_type, size),
+            variant=None,
+            input_mode=INPUT_MODE_SINGLE,
+            required_layers=required,
+            output_ext=".pdf",
+        )
+
+    if product_type == "acrylic_keychain":
+        _require_layers(product_type, layers, (LAYER_COLOR, LAYER_CUTLINE))
+        variant = "color" if LAYER_WHITE in layers else "clear"
+        return VmMapping(
+            product_type=product_type,
+            size=_normalize_size(product_type, size),
+            variant=variant,
+            input_mode=INPUT_MODE_MULTI,
+            required_layers=(LAYER_COLOR, LAYER_CUTLINE),
+            optional_layers=(LAYER_WHITE,),
+            output_ext=".ai",
+        )
+
+    if product_type == "acrylic_stand":
+        _require_layers(product_type, layers, (LAYER_COLOR, LAYER_CUTLINE))
+        return VmMapping(
+            product_type=product_type,
+            size=_normalize_size(product_type, size),
+            variant=None,
+            input_mode=INPUT_MODE_MULTI,
+            required_layers=(LAYER_COLOR, LAYER_CUTLINE),
+            optional_layers=(LAYER_WHITE,),
+            output_ext=".ai",
+        )
+
+    if product_type == "sticker":
+        _require_layers(product_type, layers, (LAYER_COLOR, LAYER_CUTLINE))
+        # sticker は variants(clear) が定義された商品 = variant 必須（省略不可）
+        return VmMapping(
+            product_type=product_type,
+            size=_normalize_size(product_type, size),
+            variant="clear",
+            input_mode=INPUT_MODE_MULTI,
+            required_layers=(LAYER_COLOR, LAYER_CUTLINE),
+            output_ext=".ai",
+        )
+
+    raise MfgMappingError(f"Unsupported product_type '{product_type}' for manufacturing data")
+
+
+def _require_layers(product_type: str, layers: set[str], required: tuple[str, ...]) -> None:
+    missing = [layer for layer in required if layer not in layers]
+    if missing:
+        raise MfgMappingError(
+            f"product_type '{product_type}' requires layers {list(required)}; "
+            f"missing: {missing}"
+        )

--- a/api/app/utils/url_guard.py
+++ b/api/app/utils/url_guard.py
@@ -1,0 +1,91 @@
+"""サーバサイド取得URLの安全性検証（SSRF対策）.
+
+外部注文元が渡す `source_images[].url` を pod-admin がサーバサイドで取得する前に、
+内部・クラウドメタデータ等の危険な宛先を弾く。方針:
+
+- スキームは http/https のみ。
+- 明示的な許可ホスト（allowed_hosts）は信頼して素通し（内部アセットサーバ / dev スタブ用）。
+- 許可ホスト以外は https 必須、かつ名前解決した全IPが public でなければ拒否
+  （private / loopback / link-local / reserved / multicast / unspecified を遮断）。
+
+resolver は差し替え可能（テストではネットワークに触れずに検証するため）。
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from collections.abc import Callable, Iterable
+from urllib.parse import urlparse
+
+# 非public判定に使う ipaddress の属性
+_BLOCKED_ATTRS = (
+    "is_private",
+    "is_loopback",
+    "is_link_local",
+    "is_reserved",
+    "is_multicast",
+    "is_unspecified",
+)
+
+Resolver = Callable[[str], list[str]]
+
+
+class UnsafeUrlError(ValueError):
+    """取得を許可できないURL（SSRF等）."""
+
+
+def _ip_is_blocked(ip_str: str) -> bool:
+    """IP文字列が非public（内部宛先）なら True."""
+    addr = ipaddress.ip_address(ip_str)
+    return any(getattr(addr, attr) for attr in _BLOCKED_ATTRS)
+
+
+def _default_resolver(host: str) -> list[str]:
+    """host を解決して全ての A/AAAA レコード（IP文字列）を返す."""
+    infos = socket.getaddrinfo(host, None)
+    return [str(info[4][0]) for info in infos]
+
+
+def validate_source_url(
+    url: str,
+    *,
+    allowed_hosts: Iterable[str] = frozenset(),
+    require_https: bool = True,
+    resolver: Resolver = _default_resolver,
+) -> None:
+    """url がサーバサイド取得に安全でなければ UnsafeUrlError を送出する.
+
+    Args:
+        url: 検証対象URL。
+        allowed_hosts: 信頼して素通しするホスト名の集合。
+        require_https: 許可ホスト以外に https を要求するか。
+        resolver: ホスト名→IP文字列リスト。テスト差し替え用。
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = parsed.hostname
+
+    if scheme not in ("http", "https"):
+        raise UnsafeUrlError(f"unsupported URL scheme: {scheme!r}")
+    if not host:
+        raise UnsafeUrlError(f"URL has no host: {url!r}")
+
+    allowed = {h.lower() for h in allowed_hosts}
+    if host.lower() in allowed:
+        return  # 明示的に信頼されたホスト
+
+    if require_https and scheme != "https":
+        raise UnsafeUrlError(f"non-allowlisted URL must use https: {url!r}")
+
+    try:
+        ips = resolver(host)
+    except OSError as exc:
+        raise UnsafeUrlError(f"DNS resolution failed for {host!r}: {exc}") from exc
+
+    if not ips:
+        raise UnsafeUrlError(f"no addresses resolved for host {host!r}")
+
+    for ip in ips:
+        if _ip_is_blocked(ip):
+            raise UnsafeUrlError(f"host {host!r} resolves to a blocked address: {ip}")

--- a/api/tests/integration/test_orders_v2_manufacturing_data.py
+++ b/api/tests/integration/test_orders_v2_manufacturing_data.py
@@ -1,0 +1,333 @@
+"""Integration tests for v2 order intake and manufacturing-data generation.
+
+外部注文 v2（POST /api/v2/orders）の受付・製造データ紐付け・キャッシュ再利用・発注ゲートを
+API -> Service -> Repository -> DB の一連の流れで検証する。
+
+illustrator-vm は未設定（テスト環境）のため、バックグラウンド生成は最終的に failed になる。
+本テストは「同期的に確定する状態（行の作成・紐付け・キャッシュキー・発注ゲート）」のみを検証し、
+非同期生成の最終状態には依存しない。
+"""
+
+import json
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture
+async def mfg_manufacturer(db_session: AsyncSession):
+    """acrylic_keychain を扱うメーカー."""
+    manufacturer_id = str(uuid4())
+    await db_session.execute(
+        text("""
+            INSERT INTO manufacturers (
+                id, name, email, supported_products, unit_prices, lead_time_days,
+                daily_order_limit, sharing_method, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :name, :email, :supported_products, :unit_prices, :lead_time_days,
+                :daily_order_limit, :sharing_method, :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": manufacturer_id,
+            "name": f"MFGテスト_{manufacturer_id[:8]}",
+            "email": f"mfg-{manufacturer_id[:8]}@example.com",
+            "supported_products": ["acrylic_keychain"],
+            "unit_prices": json.dumps({"acrylic_keychain": 300}),
+            "lead_time_days": 5,
+            "daily_order_limit": 100,
+            "sharing_method": "portal",
+            "is_active": True,
+        },
+    )
+    await db_session.commit()
+    yield {"id": manufacturer_id}
+
+
+@pytest.fixture
+async def mfg_keychain_product(db_session: AsyncSession, mfg_manufacturer: dict):
+    """acrylic_keychain のマスタ商品."""
+    product_id = str(uuid4())
+    await db_session.execute(
+        text("""
+            INSERT INTO products (
+                id, product_type, size, position, color, manufacturer_id, cost,
+                lead_time_days, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :product_type, :size, :position, :color, :manufacturer_id, :cost,
+                :lead_time_days, :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": product_id,
+            "product_type": "acrylic_keychain",
+            "size": f"KC-{product_id[:8]}",
+            "position": None,
+            "color": None,
+            "manufacturer_id": mfg_manufacturer["id"],
+            "cost": 300,
+            "lead_time_days": 5,
+            "is_active": True,
+        },
+    )
+    await db_session.commit()
+    yield {"id": product_id}
+
+
+@pytest.fixture
+async def mfg_order_source(db_session: AsyncSession):
+    """API キー付きの受注元."""
+    source_id = str(uuid4())
+    api_key = f"mfg-api-key-{source_id}"
+    await db_session.execute(
+        text("""
+            INSERT INTO order_sources (
+                id, code, name, api_key, phone, postal_code,
+                address_prefecture, address_city, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :code, :name, :api_key, :phone, :postal_code,
+                :address_prefecture, :address_city, :is_active, NOW(), NOW()
+            )
+        """),
+        {
+            "id": source_id,
+            "code": f"MFG{source_id[:8].upper()}",
+            "name": "MFG Source",
+            "api_key": api_key,
+            "phone": "090-1234-5678",
+            "postal_code": "100-0001",
+            "address_prefecture": "東京都",
+            "address_city": "千代田区",
+            "is_active": True,
+        },
+    )
+    await db_session.commit()
+    yield {"id": source_id, "api_key": api_key}
+
+
+def _customer() -> dict:
+    return {
+        "name": "山田太郎",
+        "postal_code": "123-4567",
+        "address_prefecture": "東京都",
+        "address_city": "渋谷区1-2-3",
+        "phone": "03-1234-5678",
+        "email": "yamada@example.com",
+    }
+
+
+def _keychain_item(uid: str, product_code: str, *, with_white: bool = False) -> dict:
+    layers = [
+        {"layer_type": "color", "url": "https://example.com/color.png"},
+        {"layer_type": "cutline", "url": "https://example.com/cutline.png"},
+    ]
+    if with_white:
+        layers.append({"layer_type": "white", "url": "https://example.com/white.png"})
+    return {
+        "uid": uid,
+        "product_type": "acrylic_keychain",
+        "product_name": "アクリルキーホルダー デザインA",
+        "price": 1200,
+        "quantity": 1,
+        "size": "50x50mm",
+        "color": "アクリル",
+        "product_code": product_code,
+        "source_images": layers,
+        "thumbnail_image_url": "https://example.com/thumb.png",
+    }
+
+
+class TestV2Intake:
+    @pytest.mark.asyncio
+    async def test_intake_creates_order_and_links_manufacturing_data(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        mfg_keychain_product: dict,
+        mfg_order_source: dict,
+    ):
+        product_code = f"RKSYO-{uuid4().hex[:6]}"
+        payload = {
+            "order_number": "1000001",
+            "customer": _customer(),
+            "items": [_keychain_item("2000001", product_code)],
+        }
+        resp = await client.post(
+            "/api/v2/orders",
+            json=payload,
+            headers={"X-API-Key": mfg_order_source["api_key"]},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["items"][0]["product_code"] == product_code
+
+        order_id = body["id"]
+        # 明細に製造データが紐付いている
+        row = (
+            await db_session.execute(
+                text(
+                    "SELECT product_code, source_images, manufacturing_data_id "
+                    "FROM order_items WHERE order_id = :oid"
+                ),
+                {"oid": order_id},
+            )
+        ).fetchone()
+        assert row is not None
+        assert row[0] == product_code
+        assert row[1] is not None  # source_images JSONB
+        assert row[2] is not None  # manufacturing_data_id
+
+        # 製造データ行が作成され、キャッシュキー（size/variant）が期待通り
+        md = (
+            await db_session.execute(
+                text(
+                    "SELECT size, variant, product_type FROM manufacturing_data "
+                    "WHERE product_code = :pc AND order_source_id = :sid"
+                ),
+                {"pc": product_code, "sid": mfg_order_source["id"]},
+            )
+        ).fetchone()
+        assert md is not None
+        assert md[0] == "50x50mm"  # pod-admin サイズをそのまま保持
+        assert md[1] == "clear"  # white レイヤーなし → clear
+        assert md[2] == "acrylic_keychain"
+
+    @pytest.mark.asyncio
+    async def test_cache_reuse_across_orders_same_product_code(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        mfg_keychain_product: dict,
+        mfg_order_source: dict,
+    ):
+        product_code = f"RKSYO-{uuid4().hex[:6]}"
+        headers = {"X-API-Key": mfg_order_source["api_key"]}
+
+        resp1 = await client.post(
+            "/api/v2/orders",
+            json={
+                "order_number": "1000010",
+                "customer": _customer(),
+                "items": [_keychain_item("2000010", product_code)],
+            },
+            headers=headers,
+        )
+        resp2 = await client.post(
+            "/api/v2/orders",
+            json={
+                "order_number": "1000011",
+                "customer": _customer(),
+                "items": [_keychain_item("2000011", product_code)],
+            },
+            headers=headers,
+        )
+        assert resp1.status_code == 201, resp1.text
+        assert resp2.status_code == 201, resp2.text
+
+        # 同一キャッシュキー → 製造データ行は 1 件のみ
+        count = (
+            await db_session.execute(
+                text(
+                    "SELECT COUNT(*) FROM manufacturing_data "
+                    "WHERE product_code = :pc AND order_source_id = :sid"
+                ),
+                {"pc": product_code, "sid": mfg_order_source["id"]},
+            )
+        ).scalar()
+        assert count == 1
+
+        # 両注文の明細が同じ manufacturing_data_id を指す
+        ids = (
+            await db_session.execute(
+                text(
+                    "SELECT DISTINCT manufacturing_data_id FROM order_items oi "
+                    "JOIN orders o ON o.id = oi.order_id "
+                    "WHERE o.order_number IN ('1000010', '1000011')"
+                )
+            )
+        ).fetchall()
+        assert len(ids) == 1
+        assert ids[0][0] is not None
+
+    @pytest.mark.asyncio
+    async def test_order_cannot_go_manufacturing_until_ready(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        mfg_keychain_product: dict,
+        mfg_order_source: dict,
+    ):
+        product_code = f"RKSYO-{uuid4().hex[:6]}"
+        resp = await client.post(
+            "/api/v2/orders",
+            json={
+                "order_number": "1000020",
+                "customer": _customer(),
+                "items": [_keychain_item("2000020", product_code)],
+            },
+            headers={"X-API-Key": mfg_order_source["api_key"]},
+        )
+        assert resp.status_code == 201, resp.text
+        order_id = resp.json()["id"]
+
+        # 製造データが ready でないため、メーカー発注（manufacturing）へ遷移できない
+        gate = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "manufacturing"},
+            headers=auth_headers,
+        )
+        assert gate.status_code == 409
+        assert gate.json()["error"]["code"] == "MANUFACTURING_DATA_NOT_READY"
+
+
+class TestV1BackwardCompatibility:
+    @pytest.mark.asyncio
+    async def test_v1_intake_unchanged_and_not_gated(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        mfg_keychain_product: dict,
+        mfg_order_source: dict,
+    ):
+        # v1（design_image_url 方式）は従来通り受理され、発注ゲートの対象外
+        resp = await client.post(
+            "/api/v1/orders",
+            json={
+                "order_number": "1000030",
+                "customer": _customer(),
+                "items": [
+                    {
+                        "uid": "2000030",
+                        "product_type": "acrylic_keychain",
+                        "product_name": "アクリルキーホルダー（v1）",
+                        "price": 1200,
+                        "quantity": 1,
+                        "size": "50x50mm",
+                        "color": "アクリル",
+                        "design_image_url": "https://example.com/design1.png",
+                        "thumbnail_image_url": "https://example.com/thumb1.png",
+                    }
+                ],
+            },
+            headers={"X-API-Key": mfg_order_source["api_key"]},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["items"][0]["product_code"] is None
+        assert body["items"][0]["manufacturing_data"] is None
+
+        order_id = body["id"]
+        # v1 明細は製造データ不要 → manufacturing へ遷移可能
+        gate = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "manufacturing"},
+            headers=auth_headers,
+        )
+        assert gate.status_code == 200
+        assert gate.json()["status"] == "manufacturing"

--- a/api/tests/integration/test_orders_v2_manufacturing_data.py
+++ b/api/tests/integration/test_orders_v2_manufacturing_data.py
@@ -383,6 +383,46 @@ class TestV2Intake:
         ).scalar()
         assert md_count == 0
 
+    @pytest.mark.asyncio
+    async def test_reaffirming_manufacturing_is_not_gated(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        db_session: AsyncSession,
+        mfg_keychain_product: dict,
+        mfg_order_source: dict,
+    ):
+        # メーカーが明細単位で一部を製造中にした結果、注文が既に MANUFACTURING の場合、
+        # 未ready明細が残っていても「manufacturing のまま」への再確定は 409 にならない
+        # （注文レベルゲートと明細レベルゲートの不整合を避ける = 前進遷移でのみゲート）。
+        product_code = f"RKSYO-{uuid4().hex[:6]}"
+        resp = await client.post(
+            "/api/v2/orders",
+            json={
+                "order_number": "1000070",
+                "customer": _customer(),
+                "items": [_keychain_item("2000070", product_code)],
+            },
+            headers={"X-API-Key": mfg_order_source["api_key"]},
+        )
+        assert resp.status_code == 201, resp.text
+        order_id = resp.json()["id"]
+
+        # 明細単位フロー経由で到達しうる manufacturing 状態を直接再現する
+        await db_session.execute(
+            text("UPDATE orders SET status = 'manufacturing' WHERE id = :oid"),
+            {"oid": order_id},
+        )
+        await db_session.commit()
+
+        # 既に manufacturing の注文を manufacturing に再確定 → 未ready明細があっても 409 にしない
+        resp2 = await client.patch(
+            f"/api/v1/orders/{order_id}/status",
+            json={"status": "manufacturing"},
+            headers=auth_headers,
+        )
+        assert resp2.status_code == 200, resp2.text
+
 
 class TestV1BackwardCompatibility:
     @pytest.mark.asyncio

--- a/api/tests/integration/test_orders_v2_manufacturing_data.py
+++ b/api/tests/integration/test_orders_v2_manufacturing_data.py
@@ -285,6 +285,104 @@ class TestV2Intake:
         assert gate.status_code == 409
         assert gate.json()["error"]["code"] == "MANUFACTURING_DATA_NOT_READY"
 
+    @pytest.mark.asyncio
+    async def test_bulk_status_gate_blocks_unready_v2_order(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        db_session: AsyncSession,
+        mfg_keychain_product: dict,
+        mfg_order_source: dict,
+    ):
+        # 一括ステータス更新でも、未ready の v2 注文は MANUFACTURING に遷移できない
+        # （単発 update_status の 409 ゲートと同一規則。一括では failed として記録しスキップ）。
+        product_code = f"RKSYO-{uuid4().hex[:6]}"
+        resp = await client.post(
+            "/api/v2/orders",
+            json={
+                "order_number": "1000050",
+                "customer": _customer(),
+                "items": [_keychain_item("2000050", product_code)],
+            },
+            headers={"X-API-Key": mfg_order_source["api_key"]},
+        )
+        assert resp.status_code == 201, resp.text
+        order_id = resp.json()["id"]
+
+        bulk = await client.patch(
+            "/api/v1/orders/bulk-status",
+            json={"order_ids": [order_id], "status": "manufacturing"},
+            headers=auth_headers,
+        )
+        assert bulk.status_code == 200, bulk.text
+        body = bulk.json()
+        assert body["updated_count"] == 0
+        assert body["failed_count"] == 1
+        assert order_id in body["failed_ids"]
+
+        # 注文ステータスは ordered のまま（ゲートで遷移がブロックされている）
+        status_value = (
+            await db_session.execute(
+                text("SELECT status FROM orders WHERE id = :oid"),
+                {"oid": order_id},
+            )
+        ).scalar()
+        assert status_value == "ordered"
+
+    @pytest.mark.asyncio
+    async def test_intake_rejects_item_missing_required_layer(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        mfg_keychain_product: dict,
+        mfg_order_source: dict,
+    ):
+        # acrylic_keychain は color+cutline が必須。cutline を欠くと intake で 400 拒否され、
+        # 注文・製造データ行は一切作成されない（201受理→恒久保留を防ぐ）。
+        product_code = f"RKSYO-{uuid4().hex[:6]}"
+        payload = {
+            "order_number": "1000060",
+            "customer": _customer(),
+            "items": [
+                {
+                    "uid": "2000060",
+                    "product_type": "acrylic_keychain",
+                    "product_name": "アクリルキーホルダー（cutline欠落）",
+                    "price": 1200,
+                    "quantity": 1,
+                    "size": "50x50mm",
+                    "color": "アクリル",
+                    "product_code": product_code,
+                    "source_images": [
+                        {"layer_type": "color", "url": "https://example.com/color.png"}
+                    ],
+                    "thumbnail_image_url": "https://example.com/thumb.png",
+                }
+            ],
+        }
+        resp = await client.post(
+            "/api/v2/orders",
+            json=payload,
+            headers={"X-API-Key": mfg_order_source["api_key"]},
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["error"]["code"] == "VALIDATION_ERROR"
+
+        # 生成不能な注文は受理されない（注文・製造データ行ともに未作成）
+        order_count = (
+            await db_session.execute(
+                text("SELECT COUNT(*) FROM orders WHERE order_number = '1000060'")
+            )
+        ).scalar()
+        assert order_count == 0
+        md_count = (
+            await db_session.execute(
+                text("SELECT COUNT(*) FROM manufacturing_data WHERE product_code = :pc"),
+                {"pc": product_code},
+            )
+        ).scalar()
+        assert md_count == 0
+
 
 class TestV1BackwardCompatibility:
     @pytest.mark.asyncio

--- a/api/tests/unit/test_illustrator_vm_client.py
+++ b/api/tests/unit/test_illustrator_vm_client.py
@@ -157,6 +157,33 @@ class TestDownloadAndRetry:
             await _client(handler).download("job-1")
 
 
+class TestNonJsonResponse:
+    @pytest.mark.asyncio
+    async def test_non_json_2xx_is_retried_then_succeeds(self):
+        # 2xx だが本文が JSON でない一過性応答はリトライ対象（生成を落とさない）。
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(200, text="<html>502 Bad Gateway</html>")
+            return httpx.Response(
+                200, json={"status": "completed", "output_filename": "o.ai"}
+            )
+
+        status = await _client(handler).get_status("job-1")
+        assert status.status == "completed"
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_persistent_non_json_raises_illustrator_error(self):
+        def handler(request):
+            return httpx.Response(200, text="not json")
+
+        with pytest.raises(IllustratorVmError):
+            await _client(handler).get_status("job-1")
+
+
 class TestFromSettings:
     def test_returns_none_when_unconfigured(self):
         from app.config import settings

--- a/api/tests/unit/test_illustrator_vm_client.py
+++ b/api/tests/unit/test_illustrator_vm_client.py
@@ -1,0 +1,180 @@
+"""Unit tests for the illustrator-vm client (httpx MockTransport)."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.services.illustrator_vm_client import IllustratorVmClient, IllustratorVmError
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    """リトライ/ポーリングの sleep を無効化してテストを高速化."""
+    with patch("app.services.illustrator_vm_client.asyncio.sleep", new=AsyncMock()):
+        yield
+
+
+def _client(handler, **kwargs) -> IllustratorVmClient:
+    return IllustratorVmClient(
+        "http://vm.test",
+        poll_interval=0,
+        max_poll_seconds=5,
+        max_retries=3,
+        transport=httpx.MockTransport(handler),
+        **kwargs,
+    )
+
+
+class TestSubmit:
+    @pytest.mark.asyncio
+    async def test_submit_returns_job_id_and_base64_encodes(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["path"] = request.url.path
+            import json
+
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(202, json={"job_id": "job-1"})
+
+        client = _client(handler)
+        job_id = await client.submit(
+            product_type="sticker",
+            size="50x50",
+            variant="clear",
+            input_mode="multi",
+            images={"color": b"\x89PNG-color", "cutline": b"\x89PNG-cut"},
+        )
+        assert job_id == "job-1"
+        assert captured["path"] == "/api/process"
+        # base64 でエンコードされて送られる
+        assert "color" in captured["body"]["images"]
+        assert captured["body"]["images"]["color"] != "\x89PNG-color"
+
+    @pytest.mark.asyncio
+    async def test_submit_missing_job_id_raises(self):
+        def handler(request):
+            return httpx.Response(202, json={"unexpected": True})
+
+        with pytest.raises(IllustratorVmError):
+            await _client(handler).submit(
+                product_type="tshirt",
+                size="M",
+                variant=None,
+                input_mode="single",
+                images={"design": b"x"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_submit_422_reads_detail(self):
+        def handler(request):
+            return httpx.Response(422, json={"detail": [{"msg": "bad size"}]})
+
+        with pytest.raises(IllustratorVmError) as exc:
+            await _client(handler).submit(
+                product_type="tshirt",
+                size="M",
+                variant=None,
+                input_mode="single",
+                images={"design": b"x"},
+            )
+        assert "bad size" in str(exc.value)
+
+
+class TestStatusAndWait:
+    @pytest.mark.asyncio
+    async def test_wait_polls_until_complete(self):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return httpx.Response(200, json={"status": "processing"})
+            return httpx.Response(
+                200, json={"status": "completed", "output_filename": "out.ai"}
+            )
+
+        status = await _client(handler).wait_until_complete("job-1")
+        assert status.is_complete
+        assert status.output_filename == "out.ai"
+        assert calls["n"] == 3
+
+    @pytest.mark.asyncio
+    async def test_wait_raises_on_failed(self):
+        def handler(request):
+            return httpx.Response(200, json={"status": "failed", "error": "boom"})
+
+        with pytest.raises(IllustratorVmError) as exc:
+            await _client(handler).wait_until_complete("job-1")
+        assert "boom" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_wait_times_out(self):
+        def handler(request):
+            return httpx.Response(200, json={"status": "processing"})
+
+        client = IllustratorVmClient(
+            "http://vm.test",
+            poll_interval=0,
+            max_poll_seconds=-1,  # 即タイムアウト
+            transport=httpx.MockTransport(handler),
+        )
+        with pytest.raises(IllustratorVmError) as exc:
+            await client.wait_until_complete("job-1")
+        assert "timed out" in str(exc.value)
+
+
+class TestDownloadAndRetry:
+    @pytest.mark.asyncio
+    async def test_download_returns_bytes(self):
+        def handler(request):
+            return httpx.Response(200, content=b"AI-FILE-BYTES")
+
+        content = await _client(handler).download("job-1")
+        assert content == b"AI-FILE-BYTES"
+
+    @pytest.mark.asyncio
+    async def test_503_is_retried_then_succeeds(self):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(503, json={"detail": "queue full"})
+            return httpx.Response(200, content=b"OK")
+
+        content = await _client(handler).download("job-1")
+        assert content == b"OK"
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_transport_error_retried_then_raises(self):
+        def handler(request):
+            raise httpx.ConnectError("refused")
+
+        with pytest.raises(IllustratorVmError):
+            await _client(handler).download("job-1")
+
+
+class TestFromSettings:
+    def test_returns_none_when_unconfigured(self):
+        from app.config import settings
+
+        original = settings.ILLUSTRATOR_VM_BASE_URL
+        settings.ILLUSTRATOR_VM_BASE_URL = ""
+        try:
+            assert IllustratorVmClient.from_settings(settings) is None
+        finally:
+            settings.ILLUSTRATOR_VM_BASE_URL = original
+
+    def test_builds_client_when_configured(self):
+        from app.config import settings
+
+        original = settings.ILLUSTRATOR_VM_BASE_URL
+        settings.ILLUSTRATOR_VM_BASE_URL = "http://vm.local:8000"
+        try:
+            client = IllustratorVmClient.from_settings(settings)
+            assert isinstance(client, IllustratorVmClient)
+        finally:
+            settings.ILLUSTRATOR_VM_BASE_URL = original

--- a/api/tests/unit/test_manufacturer_order_schema.py
+++ b/api/tests/unit/test_manufacturer_order_schema.py
@@ -1,0 +1,46 @@
+"""Regression: manufacturer order item responses must tolerate NULL 納品予定日.
+
+`expected_delivery_date` is nullable in the DB (order_items). A single item with a
+NULL value must not 500 the whole manufacturer-order endpoint.
+"""
+
+from datetime import UTC, datetime
+
+from app.schemas.manufacturer import (
+    AllManufacturerOrderItemResponse,
+    ManufacturerOrderItemResponse,
+)
+
+_COMMON = {
+    "id": "i1",
+    "order_id": "o1",
+    "order_number": "0000001",
+    "uid": "0000011",
+    "product_id": "p1",
+    "product_name": "x",
+    "product_type": "acrylic_keychain",
+    "price": 100,
+    "quantity": 1,
+    "size": "50x50mm",
+    "position": None,
+    "color": "アクリル",
+    "design_image_url": None,
+    "thumbnail_image_url": None,
+    "ordered_at": datetime.now(UTC),
+    "customer_name": "c",
+    "status": "ordered",
+    "lead_time_days": 10,
+    "expected_delivery_date": None,
+}
+
+
+def test_manufacturer_order_item_allows_null_delivery_date():
+    resp = ManufacturerOrderItemResponse(**_COMMON)
+    assert resp.expected_delivery_date is None
+
+
+def test_all_manufacturer_order_item_allows_null_delivery_date():
+    resp = AllManufacturerOrderItemResponse(
+        **_COMMON, manufacturer_id="m1", manufacturer_name="M"
+    )
+    assert resp.expected_delivery_date is None

--- a/api/tests/unit/test_manufacturer_order_service.py
+++ b/api/tests/unit/test_manufacturer_order_service.py
@@ -60,6 +60,10 @@ def _make_order_item(
     order_item.design_image_url = design_image_url
     order_item.thumbnail_image_url = thumbnail_image_url
     order_item.status = status.value  # OrderItem.status
+    # v1 明細（製造データなし）: 発注ゲート・生成ファイル封入の対象外
+    order_item.manufacturing_data_id = None
+    order_item.manufacturing_data = None
+    order_item.is_manufacturing_ready = True
 
     order = MagicMock()
     order.id = order_item.order_id

--- a/api/tests/unit/test_manufacturing_data_service.py
+++ b/api/tests/unit/test_manufacturing_data_service.py
@@ -1,15 +1,18 @@
 """Unit tests for ManufacturingDataService and the manufacturing readiness gate."""
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
 from app.models.order import OrderItem
+from app.services import manufacturing_data_service as mds
 from app.services.illustrator_vm_client import IllustratorVmError
 from app.services.manufacturing_data_service import ManufacturingDataService
-from app.utils.exceptions import NotFoundError
+from app.utils.exceptions import ConflictError, NotFoundError
 
 
 def _v2_item(
@@ -143,6 +146,49 @@ class TestCacheResolution:
         assert await svc.prepare_for_order("order-1") == []
         md_repo.find_by_cache_key.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_insert_row_recovers_existing_on_conflict_marks_not_created(self):
+        # 同時受注でキャッシュキーが競合したら、既存行を回収し created=False を返す
+        # （作成した側だけが生成を起動し、二重生成しないようにする）。
+        from sqlalchemy.exc import IntegrityError
+
+        item = _v2_item()
+        existing = ManufacturingData(
+            product_code="RKSYO-1", product_type="acrylic_keychain"
+        )
+        existing.id = "md-existing"
+        existing.status = MfgDataStatus.PENDING.value
+
+        md_repo = AsyncMock()
+        md_repo.find_by_cache_key.return_value = existing
+
+        class _Nested:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        session = MagicMock()
+        session.begin_nested = MagicMock(return_value=_Nested())
+        session.add = MagicMock()
+        session.flush = AsyncMock(
+            side_effect=IntegrityError("stmt", {}, Exception("dup key"))
+        )
+
+        svc = ManufacturingDataService(
+            md_repo=md_repo, order_repo=AsyncMock(), session=session
+        )
+        md, created = await svc._insert_row(
+            "src-1",
+            item,
+            variant="clear",
+            status=MfgDataStatus.PENDING,
+            source_images=item.source_images,
+        )
+        assert md is existing
+        assert created is False
+
 
 class TestGenerateDriver:
     def _pending_md(self):
@@ -229,6 +275,61 @@ class TestGenerateDriver:
 
         vm_client.submit.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_generate_skips_when_claim_not_acquired(self):
+        # 別ワーカーが既に生成中（claim 失敗）なら VM を叩かず抜ける（二重生成防止）。
+        md = self._pending_md()
+        md_repo = AsyncMock()
+        md_repo.find_by_id.return_value = md
+        md_repo.claim_for_generation.return_value = False
+        vm_client = MagicMock()
+        vm_client.submit = AsyncMock()
+
+        svc = _service(md_repo, file_storage=MagicMock(), vm_client=vm_client)
+        await svc.generate("md-1")
+
+        vm_client.submit.assert_not_called()
+        assert md.attempts == 0  # claim できていないので attempts も加算されない
+
+    @pytest.mark.asyncio
+    async def test_download_skips_failed_optional_layer(self):
+        # optional(white) の取得が失敗しても例外を投げず、成功したレイヤーのみ返す。
+        source_images = [
+            {"layer_type": "color", "url": "https://x/color.png"},
+            {"layer_type": "cutline", "url": "https://x/cutline.png"},
+            {"layer_type": "white", "url": "https://x/white.png"},
+        ]
+
+        class _Resp:
+            def __init__(self, content: bytes):
+                self.content = content
+
+            def raise_for_status(self) -> None:
+                return None
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def get(self, url):
+                if "white" in url:
+                    raise httpx.ConnectError("refused")
+                return _Resp(b"OK")
+
+        svc = _service(AsyncMock())
+        with patch.object(mds.httpx, "AsyncClient", _FakeClient):
+            images = await svc._download_source_images(
+                source_images, {"color", "cutline", "white"}
+            )
+
+        assert set(images.keys()) == {"color", "cutline"}
+
 
 class TestRetry:
     @pytest.mark.asyncio
@@ -261,6 +362,62 @@ class TestRetry:
         md_repo.find_by_id.return_value = None
         with pytest.raises(NotFoundError):
             await _service(md_repo).retry("missing", MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_retry_rejects_non_failed_row(self):
+        # ready 行を retry で巻き戻さない（共有キャッシュ行なので他注文を劣化させる）。
+        md = ManufacturingData(product_code="p", product_type="sticker")
+        md.id = "md-1"
+        md.status = MfgDataStatus.READY.value
+        md_repo = AsyncMock()
+        md_repo.find_by_id.return_value = md
+        bg = MagicMock()
+
+        with pytest.raises(ConflictError):
+            await _service(md_repo).retry("md-1", bg)
+
+        assert md.status == MfgDataStatus.READY.value  # 状態は変えない
+        bg.add_task.assert_not_called()  # 再生成も起動しない
+
+
+class TestRecovery:
+    @pytest.mark.asyncio
+    async def test_recover_resets_generating_and_reenqueues(self):
+        # 起動時復旧: generating(中断) を pending に戻し、pending/generating を再駆動する。
+        generating = ManufacturingData(product_code="p", product_type="sticker")
+        generating.id = "md-gen"
+        generating.status = MfgDataStatus.GENERATING.value
+        pending = ManufacturingData(product_code="q", product_type="sticker")
+        pending.id = "md-pend"
+        pending.status = MfgDataStatus.PENDING.value
+
+        session = AsyncMock()
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=session)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+        session_maker = MagicMock(return_value=session_cm)
+
+        repo = AsyncMock()
+        repo.find_stranded.return_value = [generating, pending]
+
+        started: list[str] = []
+
+        async def fake_run(md_id: str) -> None:
+            started.append(md_id)
+
+        with (
+            patch.object(mds, "get_session_maker", return_value=session_maker),
+            patch.object(mds, "ManufacturingDataRepository", return_value=repo),
+            patch.object(mds, "run_generation", fake_run),
+        ):
+            await mds.recover_stranded_generations()
+            await asyncio.sleep(0.05)  # spawn したタスクを走らせる
+
+        # 中断された generating は claim 可能な pending に戻る
+        assert generating.status == MfgDataStatus.PENDING.value
+        assert pending.status == MfgDataStatus.PENDING.value
+        session.commit.assert_awaited()
+        assert set(started) == {"md-gen", "md-pend"}
 
 
 class TestManufacturingReadinessGate:

--- a/api/tests/unit/test_manufacturing_data_service.py
+++ b/api/tests/unit/test_manufacturing_data_service.py
@@ -1,0 +1,288 @@
+"""Unit tests for ManufacturingDataService and the manufacturing readiness gate."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+from app.models.order import OrderItem
+from app.services.illustrator_vm_client import IllustratorVmError
+from app.services.manufacturing_data_service import ManufacturingDataService
+from app.utils.exceptions import NotFoundError
+
+
+def _v2_item(
+    *,
+    product_code="RKSYO-1",
+    product_type="acrylic_keychain",
+    size="50x50mm",
+    layers=("color", "cutline"),
+):
+    """v2 明細（product_code + source_images あり）の簡易モック."""
+    return SimpleNamespace(
+        id="item-1",
+        product_code=product_code,
+        product_type=product_type,
+        size=size,
+        source_images=[{"layer_type": ly, "url": f"https://x/{ly}.png"} for ly in layers],
+        manufacturing_data_id=None,
+        manufacturing_data=None,
+    )
+
+
+def _service(md_repo, order_repo=None, **kwargs):
+    return ManufacturingDataService(
+        md_repo=md_repo,
+        order_repo=order_repo or AsyncMock(),
+        session=None,  # unit test: _commit は no-op、_insert_row は md_repo.create を使用
+        **kwargs,
+    )
+
+
+def _assign_id(md: ManufacturingData, new_id: str = "md-new") -> ManufacturingData:
+    md.id = new_id
+    return md
+
+
+class TestCacheResolution:
+    @pytest.mark.asyncio
+    async def test_creates_new_row_and_requests_generation(self):
+        item = _v2_item()
+        order = SimpleNamespace(order_source_id="src-1", items=[item])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+
+        md_repo = AsyncMock()
+        md_repo.find_by_cache_key.return_value = None
+        md_repo.create.side_effect = lambda m: _assign_id(m, "md-new")
+
+        svc = _service(md_repo, order_repo)
+        to_generate = await svc.prepare_for_order("order-1")
+
+        assert to_generate == ["md-new"]
+        assert item.manufacturing_data_id == "md-new"
+        # keychain(color+cutline, white なし) は variant clear で照会される
+        # find_by_cache_key(order_source_id, product_code, size, variant)
+        called = md_repo.find_by_cache_key.call_args
+        assert called.args == ("src-1", "RKSYO-1", "50x50mm", "clear")
+
+    @pytest.mark.asyncio
+    async def test_reuses_ready_cache_without_generation(self):
+        item = _v2_item()
+        order = SimpleNamespace(order_source_id="src-1", items=[item])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+
+        existing = ManufacturingData(product_code="RKSYO-1", product_type="acrylic_keychain")
+        existing.id = "md-existing"
+        existing.status = MfgDataStatus.READY.value
+
+        md_repo = AsyncMock()
+        md_repo.find_by_cache_key.return_value = existing
+
+        svc = _service(md_repo, order_repo)
+        to_generate = await svc.prepare_for_order("order-1")
+
+        # キャッシュ再利用 → VM生成は起動しない
+        assert to_generate == []
+        assert item.manufacturing_data_id == "md-existing"
+        md_repo.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_cache_is_reset_and_regenerated(self):
+        item = _v2_item()
+        order = SimpleNamespace(order_source_id="src-1", items=[item])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+
+        existing = ManufacturingData(product_code="RKSYO-1", product_type="acrylic_keychain")
+        existing.id = "md-failed"
+        existing.status = MfgDataStatus.FAILED.value
+
+        md_repo = AsyncMock()
+        md_repo.find_by_cache_key.return_value = existing
+
+        svc = _service(md_repo, order_repo)
+        to_generate = await svc.prepare_for_order("order-1")
+
+        assert to_generate == ["md-failed"]
+        assert existing.status == MfgDataStatus.PENDING.value
+        assert item.manufacturing_data_id == "md-failed"
+
+    @pytest.mark.asyncio
+    async def test_unmappable_product_creates_failed_row_no_generation(self):
+        # mug_cup は pod-admin ProductType 外 → マッピング不能 → failed 行（発注ゲートで保留）
+        item = _v2_item(product_type="mug_cup", size="normal", layers=("design",))
+        order = SimpleNamespace(order_source_id="src-1", items=[item])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+
+        md_repo = AsyncMock()
+        md_repo.create.side_effect = lambda m: _assign_id(m, "md-bad")
+
+        svc = _service(md_repo, order_repo)
+        to_generate = await svc.prepare_for_order("order-1")
+
+        assert to_generate == []
+        assert item.manufacturing_data_id == "md-bad"
+        created = md_repo.create.call_args.args[0]
+        assert created.status == MfgDataStatus.FAILED.value
+
+    @pytest.mark.asyncio
+    async def test_v1_items_are_ignored(self):
+        v1 = SimpleNamespace(
+            id="i", product_code=None, source_images=None, manufacturing_data_id=None
+        )
+        order = SimpleNamespace(order_source_id="src-1", items=[v1])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+        md_repo = AsyncMock()
+
+        svc = _service(md_repo, order_repo)
+        assert await svc.prepare_for_order("order-1") == []
+        md_repo.find_by_cache_key.assert_not_called()
+
+
+class TestGenerateDriver:
+    def _pending_md(self):
+        md = ManufacturingData(product_code="RKSYO-1", product_type="sticker", size="50x50mm")
+        md.id = "md-1"
+        md.status = MfgDataStatus.PENDING.value
+        md.source_images = [
+            {"layer_type": "color", "url": "https://x/color.png"},
+            {"layer_type": "cutline", "url": "https://x/cutline.png"},
+        ]
+        md.attempts = 0
+        return md
+
+    @pytest.mark.asyncio
+    async def test_successful_generation_marks_ready(self):
+        md = self._pending_md()
+        md_repo = AsyncMock()
+        md_repo.find_by_id.return_value = md
+
+        vm_client = MagicMock()
+        vm_client.submit = AsyncMock(return_value="job-9")
+        vm_client.wait_until_complete = AsyncMock(
+            return_value=SimpleNamespace(output_filename="sticker_out.ai")
+        )
+        vm_client.download = AsyncMock(return_value=b"AI-BYTES")
+
+        file_storage = MagicMock()
+        file_storage.save = AsyncMock(return_value="manufacturing_data/sticker_out.ai")
+
+        svc = _service(md_repo, file_storage=file_storage, vm_client=vm_client)
+        svc._download_source_images = AsyncMock(
+            return_value={"color": b"c", "cutline": b"k"}
+        )
+
+        await svc.generate("md-1")
+
+        assert md.status == MfgDataStatus.READY.value
+        assert md.output_filename == "sticker_out.ai"
+        assert md.file_path == "manufacturing_data/sticker_out.ai"
+        assert md.file_size == len(b"AI-BYTES")
+        assert md.attempts == 1
+        assert md.vm_job_id == "job-9"
+
+    @pytest.mark.asyncio
+    async def test_vm_failure_marks_failed_with_message(self):
+        md = self._pending_md()
+        md_repo = AsyncMock()
+        md_repo.find_by_id.return_value = md
+
+        vm_client = MagicMock()
+        vm_client.submit = AsyncMock(side_effect=IllustratorVmError("VM 503"))
+
+        svc = _service(md_repo, file_storage=MagicMock(), vm_client=vm_client)
+        svc._download_source_images = AsyncMock(return_value={"color": b"c", "cutline": b"k"})
+
+        await svc.generate("md-1")
+
+        assert md.status == MfgDataStatus.FAILED.value
+        assert "VM 503" in md.error_message
+
+    @pytest.mark.asyncio
+    async def test_not_configured_vm_marks_failed(self):
+        md = self._pending_md()
+        md_repo = AsyncMock()
+        md_repo.find_by_id.return_value = md
+
+        svc = _service(md_repo, file_storage=MagicMock(), vm_client=None)
+
+        await svc.generate("md-1")
+        assert md.status == MfgDataStatus.FAILED.value
+        assert "not configured" in md.error_message
+
+    @pytest.mark.asyncio
+    async def test_ready_row_is_skipped(self):
+        md = self._pending_md()
+        md.status = MfgDataStatus.READY.value
+        md_repo = AsyncMock()
+        md_repo.find_by_id.return_value = md
+        vm_client = MagicMock()
+        vm_client.submit = AsyncMock()
+
+        svc = _service(md_repo, file_storage=MagicMock(), vm_client=vm_client)
+        await svc.generate("md-1")
+
+        vm_client.submit.assert_not_called()
+
+
+class TestRetry:
+    @pytest.mark.asyncio
+    async def test_retry_resets_to_pending_and_enqueues(self):
+        from datetime import UTC, datetime
+
+        md = ManufacturingData(product_code="p", product_type="sticker")
+        md.id = "md-1"
+        md.status = MfgDataStatus.FAILED.value
+        md.error_message = "boom"
+        # 通常は DB が埋める列（レスポンス変換に必要）
+        md.attempts = 1
+        md.created_at = datetime.now(UTC)
+        md.updated_at = datetime.now(UTC)
+        md_repo = AsyncMock()
+        md_repo.find_by_id.return_value = md
+
+        bg = MagicMock()
+        svc = _service(md_repo)
+        resp = await svc.retry("md-1", bg)
+
+        assert md.status == MfgDataStatus.PENDING.value
+        assert md.error_message is None
+        assert resp.status == MfgDataStatus.PENDING.value
+        bg.add_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retry_missing_raises(self):
+        md_repo = AsyncMock()
+        md_repo.find_by_id.return_value = None
+        with pytest.raises(NotFoundError):
+            await _service(md_repo).retry("missing", MagicMock())
+
+
+class TestManufacturingReadinessGate:
+    def test_v1_item_is_always_ready(self):
+        item = OrderItem(manufacturing_data_id=None)
+        assert item.is_manufacturing_ready is True
+
+    def test_required_but_missing_data_not_ready(self):
+        item = OrderItem(manufacturing_data_id="md-1")
+        item.manufacturing_data = None
+        assert item.is_manufacturing_ready is False
+
+    def test_required_and_ready(self):
+        item = OrderItem(manufacturing_data_id="md-1")
+        md = ManufacturingData(product_code="p", product_type="sticker")
+        md.status = MfgDataStatus.READY.value
+        item.manufacturing_data = md
+        assert item.is_manufacturing_ready is True
+
+    def test_required_but_pending_not_ready(self):
+        item = OrderItem(manufacturing_data_id="md-1")
+        md = ManufacturingData(product_code="p", product_type="sticker")
+        md.status = MfgDataStatus.PENDING.value
+        item.manufacturing_data = md
+        assert item.is_manufacturing_ready is False

--- a/api/tests/unit/test_manufacturing_data_service.py
+++ b/api/tests/unit/test_manufacturing_data_service.py
@@ -382,15 +382,8 @@ class TestRetry:
 
 class TestRecovery:
     @pytest.mark.asyncio
-    async def test_recover_resets_generating_and_reenqueues(self):
-        # 起動時復旧: generating(中断) を pending に戻し、pending/generating を再駆動する。
-        generating = ManufacturingData(product_code="p", product_type="sticker")
-        generating.id = "md-gen"
-        generating.status = MfgDataStatus.GENERATING.value
-        pending = ManufacturingData(product_code="q", product_type="sticker")
-        pending.id = "md-pend"
-        pending.status = MfgDataStatus.PENDING.value
-
+    async def test_recover_reenqueues_reclaimed_ids(self):
+        # 起動時復旧: 宙吊り行を reclaim（pending へ戻す）して得た id を再駆動する。
         session = AsyncMock()
         session_cm = MagicMock()
         session_cm.__aenter__ = AsyncMock(return_value=session)
@@ -398,7 +391,7 @@ class TestRecovery:
         session_maker = MagicMock(return_value=session_cm)
 
         repo = AsyncMock()
-        repo.find_stranded.return_value = [generating, pending]
+        repo.reclaim_stranded.return_value = ["md-gen", "md-pend"]
 
         started: list[str] = []
 
@@ -413,9 +406,6 @@ class TestRecovery:
             await mds.recover_stranded_generations()
             await asyncio.sleep(0.05)  # spawn したタスクを走らせる
 
-        # 中断された generating は claim 可能な pending に戻る
-        assert generating.status == MfgDataStatus.PENDING.value
-        assert pending.status == MfgDataStatus.PENDING.value
         session.commit.assert_awaited()
         assert set(started) == {"md-gen", "md-pend"}
 

--- a/api/tests/unit/test_manufacturing_data_service.py
+++ b/api/tests/unit/test_manufacturing_data_service.py
@@ -300,12 +300,26 @@ class TestGenerateDriver:
             {"layer_type": "white", "url": "https://x/white.png"},
         ]
 
-        class _Resp:
-            def __init__(self, content: bytes):
-                self.content = content
+        class _StreamResp:
+            def __init__(self, chunks):
+                self._chunks = chunks
 
             def raise_for_status(self) -> None:
                 return None
+
+            async def aiter_bytes(self):
+                for c in self._chunks:
+                    yield c
+
+        class _StreamCtx:
+            def __init__(self, resp):
+                self._resp = resp
+
+            async def __aenter__(self):
+                return self._resp
+
+            async def __aexit__(self, *exc):
+                return False
 
         class _FakeClient:
             def __init__(self, *args, **kwargs):
@@ -317,12 +331,13 @@ class TestGenerateDriver:
             async def __aexit__(self, *exc):
                 return False
 
-            async def get(self, url):
+            def stream(self, method, url):
                 if "white" in url:
                     raise httpx.ConnectError("refused")
-                return _Resp(b"OK")
+                return _StreamCtx(_StreamResp([b"OK"]))
 
-        svc = _service(AsyncMock())
+        # host "x" は許可リストで素通し（このテストの主眼はレイヤー欠落の耐性）。
+        svc = _service(AsyncMock(), allowed_source_hosts=frozenset({"x"}))
         with patch.object(mds.httpx, "AsyncClient", _FakeClient):
             images = await svc._download_source_images(
                 source_images, {"color", "cutline", "white"}

--- a/api/tests/unit/test_mfg_product_mapping.py
+++ b/api/tests/unit/test_mfg_product_mapping.py
@@ -1,0 +1,92 @@
+"""Unit tests for pod-admin -> illustrator-vm product attribute mapping."""
+
+import pytest
+
+from app.utils.mfg_product_mapping import (
+    INPUT_MODE_MULTI,
+    INPUT_MODE_SINGLE,
+    MfgMappingError,
+    build_vm_mapping,
+)
+
+
+class TestSingleImageProducts:
+    def test_tshirt_maps_size_and_pdf(self):
+        m = build_vm_mapping("tshirt", "M", {"design"})
+        assert m.product_type == "tshirt"
+        assert m.size == "M"
+        assert m.variant is None
+        assert m.input_mode == INPUT_MODE_SINGLE
+        assert m.output_ext == ".pdf"
+        assert m.required_layers == ("design",)
+
+    def test_tshirt_accepts_color_as_design(self):
+        m = build_vm_mapping("tshirt", "L", {"color"})
+        assert m.required_layers == ("color",)
+
+    def test_tshirt_rejects_missing_design_layer(self):
+        with pytest.raises(MfgMappingError):
+            build_vm_mapping("tshirt", "M", {"cutline"})
+
+    def test_tote_bag_only_M(self):
+        m = build_vm_mapping("tote_bag", "M", {"design"})
+        assert m.size == "M"
+        assert m.output_ext == ".pdf"
+
+    def test_tshirt_invalid_size(self):
+        with pytest.raises(MfgMappingError):
+            build_vm_mapping("tshirt", "XXL", {"design"})
+
+
+class TestAcrylicKeychain:
+    def test_variant_clear_without_white(self):
+        m = build_vm_mapping("acrylic_keychain", "50x50mm", {"color", "cutline"})
+        assert m.size == "50x50"
+        assert m.variant == "clear"
+        assert m.input_mode == INPUT_MODE_MULTI
+        assert m.output_ext == ".ai"
+
+    def test_variant_color_with_white(self):
+        m = build_vm_mapping("acrylic_keychain", "100x100mm", {"color", "cutline", "white"})
+        assert m.size == "100x100"
+        assert m.variant == "color"
+        assert "white" in m.usable_layers
+
+    def test_requires_color_and_cutline(self):
+        with pytest.raises(MfgMappingError):
+            build_vm_mapping("acrylic_keychain", "50x50mm", {"color"})
+
+
+class TestAcrylicStand:
+    def test_size_normalization_to_mm(self):
+        m = build_vm_mapping("acrylic_stand", "70x70mm", {"color", "cutline"})
+        assert m.size == "70mm"
+        assert m.variant is None
+        assert m.input_mode == INPUT_MODE_MULTI
+
+    def test_white_is_optional(self):
+        m = build_vm_mapping("acrylic_stand", "50x50mm", {"color", "cutline", "white"})
+        assert m.size == "50mm"
+        assert "white" in m.usable_layers
+
+
+class TestSticker:
+    def test_variant_is_always_clear_no_white(self):
+        m = build_vm_mapping("sticker", "50x50mm", {"color", "cutline"})
+        assert m.size == "50x50"
+        assert m.variant == "clear"
+        assert "white" not in m.usable_layers
+
+    def test_requires_color_and_cutline(self):
+        with pytest.raises(MfgMappingError):
+            build_vm_mapping("sticker", "50x50mm", {"cutline"})
+
+
+class TestUnsupported:
+    def test_unknown_product_type(self):
+        with pytest.raises(MfgMappingError):
+            build_vm_mapping("mug_cup", "normal", {"design"})
+
+    def test_missing_size(self):
+        with pytest.raises(MfgMappingError):
+            build_vm_mapping("acrylic_keychain", None, {"color", "cutline"})

--- a/api/tests/unit/test_order_v2_schema_limits.py
+++ b/api/tests/unit/test_order_v2_schema_limits.py
@@ -1,0 +1,51 @@
+"""Unit tests for v2 order schema DoS guards (list length caps)."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.order import OrderCreateV2, OrderItemCreateV2
+
+_CUSTOMER = {
+    "name": "検証",
+    "postal_code": "150-0001",
+    "address_prefecture": "東京都",
+    "address_city": "渋谷区1-1",
+    "phone": "090-0000-0000",
+}
+
+
+def _layer(i):
+    return {"layer_type": "color", "url": f"https://cdn.trusted/{i}.png"}
+
+
+def _item(uid="9000011", n_layers=2):
+    return {
+        "uid": uid,
+        "product_type": "acrylic_keychain",
+        "product_name": "x",
+        "price": 100,
+        "quantity": 1,
+        "size": "50x50mm",
+        "product_code": "RKSYO-1",
+        "source_images": [_layer(i) for i in range(n_layers)],
+    }
+
+
+class TestSourceImagesCap:
+    def test_accepts_reasonable_layer_count(self):
+        OrderItemCreateV2.model_validate(_item(n_layers=4))
+
+    def test_rejects_too_many_source_images(self):
+        with pytest.raises(ValidationError):
+            OrderItemCreateV2.model_validate(_item(n_layers=50))
+
+
+class TestItemsCap:
+    def test_rejects_too_many_items(self):
+        payload = {
+            "order_number": "0000001",
+            "customer": _CUSTOMER,
+            "items": [_item(uid=f"{9000000 + i:07d}") for i in range(200)],
+        }
+        with pytest.raises(ValidationError):
+            OrderCreateV2.model_validate(payload)

--- a/api/tests/unit/test_source_image_download.py
+++ b/api/tests/unit/test_source_image_download.py
@@ -1,0 +1,108 @@
+"""Unit tests for SSRF-guarded, size-limited source image download."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.services import manufacturing_data_service as mds
+from app.services.manufacturing_data_service import (
+    ManufacturingDataService,
+    SourceImageTooLargeError,
+)
+
+
+def _service(**kwargs):
+    return ManufacturingDataService(
+        md_repo=AsyncMock(), order_repo=AsyncMock(), session=None, **kwargs
+    )
+
+
+class _StreamResp:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_bytes(self):
+        for c in self._chunks:
+            yield c
+
+
+class _StreamCtx:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self._resp
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _fake_client_factory(chunks_by_marker):
+    """Return a fake httpx.AsyncClient class whose stream() picks chunks by url substring."""
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            # must tolerate timeout=..., follow_redirects=... kwargs
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def stream(self, method, url):
+            for marker, chunks in chunks_by_marker.items():
+                if marker in url:
+                    return _StreamCtx(_StreamResp(chunks))
+            raise httpx.ConnectError(f"unexpected url {url}")
+
+    return _FakeClient
+
+
+class TestDownloadSsrfGuard:
+    @pytest.mark.asyncio
+    async def test_skips_layer_that_fails_ssrf_guard(self):
+        # color は許可ホスト経由、cutline は private IP リテラル宛 → ガードで弾かれ結果に含まれない
+        source_images = [
+            {"layer_type": "color", "url": "https://cdn.trusted/color.png"},
+            {"layer_type": "cutline", "url": "https://10.0.0.5/cutline.png"},
+        ]
+        svc = _service(allowed_source_hosts=frozenset({"cdn.trusted"}))
+        fake = _fake_client_factory({"color.png": [b"COLORBYTES"], "cutline.png": [b"NOPE"]})
+        with patch.object(mds.httpx, "AsyncClient", fake):
+            images = await svc._download_source_images(source_images, {"color", "cutline"})
+        assert set(images.keys()) == {"color"}
+        assert images["color"] == b"COLORBYTES"
+
+
+class TestDownloadSizeLimit:
+    @pytest.mark.asyncio
+    async def test_skips_layer_exceeding_max_bytes(self):
+        source_images = [
+            {"layer_type": "color", "url": "https://cdn.trusted/color.png"},
+            {"layer_type": "cutline", "url": "https://cdn.trusted/cutline.png"},
+        ]
+        # max 10 bytes: color streams 6 bytes (ok), cutline streams 8+8=16 bytes (too large)
+        svc = _service(
+            allowed_source_hosts=frozenset({"cdn.trusted"}), max_source_bytes=10
+        )
+        fake = _fake_client_factory(
+            {"color.png": [b"123456"], "cutline.png": [b"AAAAAAAA", b"BBBBBBBB"]}
+        )
+        with patch.object(mds.httpx, "AsyncClient", fake):
+            images = await svc._download_source_images(source_images, {"color", "cutline"})
+        assert set(images.keys()) == {"color"}
+
+    @pytest.mark.asyncio
+    async def test_fetch_with_limit_raises_when_over_budget(self):
+        svc = _service(max_source_bytes=4)
+        fake = _fake_client_factory({"big": [b"ab", b"cd", b"ef"]})
+        FakeClient = fake
+        async with FakeClient() as client:
+            with pytest.raises(SourceImageTooLargeError):
+                await svc._fetch_with_limit(client, "https://cdn/big.png", 4)

--- a/api/tests/unit/test_url_guard.py
+++ b/api/tests/unit/test_url_guard.py
@@ -1,0 +1,98 @@
+"""Unit tests for the server-side-fetch URL guard (SSRF protection)."""
+
+import pytest
+
+from app.utils.url_guard import UnsafeUrlError, _ip_is_blocked, validate_source_url
+
+
+class TestIpIsBlocked:
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",  # loopback
+            "::1",  # loopback v6
+            "10.0.0.5",  # private
+            "192.168.1.10",  # private
+            "172.16.0.1",  # private
+            "169.254.169.254",  # link-local (cloud metadata)
+            "0.0.0.0",  # unspecified
+            "224.0.0.1",  # multicast
+        ],
+    )
+    def test_blocks_non_public_addresses(self, ip):
+        assert _ip_is_blocked(ip) is True
+
+    @pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"])
+    def test_allows_public_addresses(self, ip):
+        assert _ip_is_blocked(ip) is False
+
+
+class TestValidateSourceUrl:
+    def _resolver(self, mapping):
+        def resolve(host):
+            if host not in mapping:
+                raise OSError(f"no such host {host}")
+            return mapping[host]
+
+        return resolve
+
+    def test_rejects_non_http_scheme(self):
+        with pytest.raises(UnsafeUrlError):
+            validate_source_url("file:///etc/passwd", resolver=self._resolver({}))
+        with pytest.raises(UnsafeUrlError):
+            validate_source_url("ftp://example.com/x.png", resolver=self._resolver({}))
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(UnsafeUrlError):
+            validate_source_url("https:///x.png", resolver=self._resolver({}))
+
+    def test_rejects_plain_http_when_not_allowlisted(self):
+        with pytest.raises(UnsafeUrlError):
+            validate_source_url(
+                "http://cdn.example.com/color.png",
+                resolver=self._resolver({"cdn.example.com": ["93.184.216.34"]}),
+            )
+
+    def test_allows_public_https_host(self):
+        # should not raise
+        validate_source_url(
+            "https://cdn.example.com/color.png",
+            resolver=self._resolver({"cdn.example.com": ["93.184.216.34"]}),
+        )
+
+    def test_rejects_host_resolving_to_private_ip(self):
+        with pytest.raises(UnsafeUrlError):
+            validate_source_url(
+                "https://evil.example.com/color.png",
+                resolver=self._resolver({"evil.example.com": ["10.0.0.9"]}),
+            )
+
+    def test_rejects_metadata_ip_literal(self):
+        with pytest.raises(UnsafeUrlError):
+            validate_source_url(
+                "https://169.254.169.254/latest/meta-data/",
+                resolver=self._resolver({"169.254.169.254": ["169.254.169.254"]}),
+            )
+
+    def test_rejects_if_any_resolved_ip_is_private(self):
+        # DNS returning a mix — must reject if ANY address is unsafe (rebinding defense)
+        with pytest.raises(UnsafeUrlError):
+            validate_source_url(
+                "https://mixed.example.com/color.png",
+                resolver=self._resolver({"mixed.example.com": ["93.184.216.34", "127.0.0.1"]}),
+            )
+
+    def test_allowlisted_host_bypasses_ip_and_scheme_checks(self):
+        # An explicitly trusted host is allowed even over http / private IP (e.g. internal asset server, dev stub)
+        validate_source_url(
+            "http://host.docker.internal:9099/layers/color.png",
+            allowed_hosts=frozenset({"host.docker.internal"}),
+            resolver=self._resolver({"host.docker.internal": ["192.168.65.2"]}),
+        )
+
+    def test_dns_failure_is_rejected(self):
+        with pytest.raises(UnsafeUrlError):
+            validate_source_url(
+                "https://nxdomain.example.com/x.png",
+                resolver=self._resolver({}),
+            )

--- a/web/src/app/(dashboard)/orders/[id]/page.tsx
+++ b/web/src/app/(dashboard)/orders/[id]/page.tsx
@@ -8,6 +8,7 @@ import { PageContainer } from "@/components/layout/page-container";
 import { LoadingSpinner } from "@/components/common/loading-spinner";
 import { OrderDetail } from "@/features/orders/components/order-detail";
 import { apiClient } from "@/lib/api/client";
+import { isManufacturingDataActive } from "@/constants/status";
 import type { Order } from "@/types/api";
 
 const fetcher = (url: string) => apiClient<Order>(url);
@@ -23,11 +24,8 @@ export default function OrderDetailPage() {
     {
       // 製造データ生成中（pending/generating）は完成までポーリングする
       refreshInterval: (latest?: Order) =>
-        latest?.items?.some(
-          (item) =>
-            item.manufacturing_data &&
-            (item.manufacturing_data.status === "pending" ||
-              item.manufacturing_data.status === "generating")
+        latest?.items?.some((item) =>
+          isManufacturingDataActive(item.manufacturing_data?.status)
         )
           ? 5000
           : 0,

--- a/web/src/app/(dashboard)/orders/[id]/page.tsx
+++ b/web/src/app/(dashboard)/orders/[id]/page.tsx
@@ -17,9 +17,21 @@ export default function OrderDetailPage() {
   const router = useRouter();
   const orderId = params.id as string;
 
-  const { data: order, isLoading, error } = useSWR<Order>(
+  const { data: order, isLoading, error, mutate } = useSWR<Order>(
     `/orders/${orderId}`,
-    fetcher
+    fetcher,
+    {
+      // 製造データ生成中（pending/generating）は完成までポーリングする
+      refreshInterval: (latest?: Order) =>
+        latest?.items?.some(
+          (item) =>
+            item.manufacturing_data &&
+            (item.manufacturing_data.status === "pending" ||
+              item.manufacturing_data.status === "generating")
+        )
+          ? 5000
+          : 0,
+    }
   );
 
   if (isLoading) {
@@ -56,7 +68,7 @@ export default function OrderDetailPage() {
         </Button>
       }
     >
-      <OrderDetail order={order} />
+      <OrderDetail order={order} onRefresh={() => mutate()} />
     </PageContainer>
   );
 }

--- a/web/src/app/(dashboard)/purchase-orders/all/page.tsx
+++ b/web/src/app/(dashboard)/purchase-orders/all/page.tsx
@@ -65,7 +65,8 @@ const statusLabels: Record<string, string> = {
   shipped: "配送完了",
 };
 
-function formatDateForCSV(dateString: string): string {
+function formatDateForCSV(dateString: string | null): string {
+  if (!dateString) return "";
   const date = new Date(dateString);
   return date.toLocaleDateString("ja-JP", {
     year: "numeric",

--- a/web/src/components/common/manufacturing-data-badge.tsx
+++ b/web/src/components/common/manufacturing-data-badge.tsx
@@ -1,0 +1,27 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  MANUFACTURING_DATA_STATUS_COLORS,
+  MANUFACTURING_DATA_STATUS_LABELS,
+} from "@/constants/status";
+import type { ManufacturingDataStatus } from "@/types/api";
+
+interface ManufacturingDataBadgeProps {
+  status: ManufacturingDataStatus;
+  className?: string;
+}
+
+/**
+ * 製造データ生成ステータス（v2）のバッジ。
+ * 配送ステータスと値が重複するため共通 StatusBadge とは別コンポーネントとする。
+ */
+export function ManufacturingDataBadge({ status, className }: ManufacturingDataBadgeProps) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn("border font-medium", MANUFACTURING_DATA_STATUS_COLORS[status], className)}
+    >
+      {MANUFACTURING_DATA_STATUS_LABELS[status]}
+    </Badge>
+  );
+}

--- a/web/src/constants/status.ts
+++ b/web/src/constants/status.ts
@@ -103,6 +103,16 @@ export function getManufacturingDataStatusLabel(status: ManufacturingDataStatus)
   return MANUFACTURING_DATA_STATUS_LABELS[status] ?? status;
 }
 
+/**
+ * 製造データ生成が進行中（pending/generating）か。
+ * 生成完了まで一覧/詳細をポーリングする判定に使う（受注詳細・メーカー発注詳細で共有）。
+ */
+export function isManufacturingDataActive(
+  status: ManufacturingDataStatus | null | undefined
+): boolean {
+  return status === "pending" || status === "generating";
+}
+
 // ========================================
 // Combined Status (StatusBadge 用)
 // ========================================

--- a/web/src/constants/status.ts
+++ b/web/src/constants/status.ts
@@ -1,4 +1,9 @@
-import type { OrderStatus, ShipmentStatus, PendingOrderStatus } from "@/types/api";
+import type {
+  ManufacturingDataStatus,
+  OrderStatus,
+  PendingOrderStatus,
+  ShipmentStatus,
+} from "@/types/api";
 
 // ========================================
 // Order Status (受注ステータス)
@@ -63,6 +68,40 @@ export const PENDING_ORDER_STATUS_LABELS: Record<PendingOrderStatus, string> = {
 export const PENDING_ORDER_STATUS_COLORS: Record<PendingOrderStatus, string> = {
   preparing: "bg-orange-100 text-orange-700 border-orange-300",
 };
+
+// ========================================
+// Manufacturing Data Status (製造データ生成ステータス / v2)
+// ========================================
+
+/**
+ * ManufacturingDataStatus のラベル名
+ *
+ * 注: pending/ready は配送ステータスと値が重複するため、StatusBadge の共通ラベルとは
+ * 別管理とする（意味が異なる: 生成待ち/生成完了）。
+ */
+export const MANUFACTURING_DATA_STATUS_LABELS: Record<ManufacturingDataStatus, string> = {
+  pending: "生成待ち",
+  generating: "生成中",
+  ready: "生成完了",
+  failed: "生成失敗",
+};
+
+/**
+ * ManufacturingDataStatus の色（Tailwind CSS クラス）
+ */
+export const MANUFACTURING_DATA_STATUS_COLORS: Record<ManufacturingDataStatus, string> = {
+  pending: "bg-gray-100 text-gray-700 border-gray-300",
+  generating: "bg-blue-100 text-blue-700 border-blue-300",
+  ready: "bg-emerald-100 text-emerald-700 border-emerald-300",
+  failed: "bg-red-100 text-red-700 border-red-300",
+};
+
+/**
+ * ManufacturingDataStatus のラベルを取得
+ */
+export function getManufacturingDataStatusLabel(status: ManufacturingDataStatus): string {
+  return MANUFACTURING_DATA_STATUS_LABELS[status] ?? status;
+}
 
 // ========================================
 // Combined Status (StatusBadge 用)

--- a/web/src/features/orders/components/order-detail.tsx
+++ b/web/src/features/orders/components/order-detail.tsx
@@ -11,12 +11,18 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Download, Package, User, FileText, ShoppingBag, ExternalLink } from "lucide-react";
+import { Download, Package, User, FileText, ShoppingBag, ExternalLink, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 import { apiClient } from "@/lib/api/client";
+import { cn } from "@/lib/utils";
+import { ManufacturingDataBadge } from "@/components/common/manufacturing-data-badge";
 import type { Order, OrderItem } from "@/types/api";
 
 interface OrderDetailProps {
   order: Order;
+  /** 製造データのリトライ後などに親のデータを再取得するためのコールバック */
+  onRefresh?: () => void;
 }
 
 function formatDate(dateString: string): string {
@@ -41,7 +47,22 @@ function formatProductType(type: string): string {
   return typeMap[type] || type;
 }
 
-export function OrderDetail({ order }: OrderDetailProps) {
+export function OrderDetail({ order, onRefresh }: OrderDetailProps) {
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+
+  const handleRetryManufacturingData = async (mfgId: string) => {
+    setRetryingId(mfgId);
+    try {
+      await apiClient(`/manufacturing-data/${mfgId}/retry`, { method: "POST" });
+      toast.success("製造データの生成を再実行しました");
+      onRefresh?.();
+    } catch {
+      toast.error("製造データの再実行に失敗しました");
+    } finally {
+      setRetryingId(null);
+    }
+  };
+
   const handleDownloadManufacturingData = async () => {
     try {
       const data = await apiClient<Blob>(`/orders/${order.id}/manufacturing-data`);
@@ -116,6 +137,7 @@ export function OrderDetail({ order }: OrderDetailProps) {
                   <TableHead>位置</TableHead>
                   <TableHead className="text-right">数量</TableHead>
                   <TableHead>デザイン</TableHead>
+                  <TableHead>製造データ</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -153,6 +175,34 @@ export function OrderDetail({ order }: OrderDetailProps) {
                         >
                           <ExternalLink className="h-4 w-4" />
                         </a>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {item.manufacturing_data ? (
+                        <div className="flex items-center gap-2">
+                          <ManufacturingDataBadge status={item.manufacturing_data.status} />
+                          {item.manufacturing_data.status === "failed" && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-7 px-2"
+                              onClick={() =>
+                                handleRetryManufacturingData(item.manufacturing_data!.id)
+                              }
+                              disabled={retryingId === item.manufacturing_data.id}
+                              title={item.manufacturing_data.error_message ?? undefined}
+                            >
+                              <RefreshCw
+                                className={cn(
+                                  "h-3.5 w-3.5",
+                                  retryingId === item.manufacturing_data.id && "animate-spin"
+                                )}
+                              />
+                            </Button>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
                       )}
                     </TableCell>
                   </TableRow>

--- a/web/src/features/purchase-orders/components/all-manufacturer-order-list.tsx
+++ b/web/src/features/purchase-orders/components/all-manufacturer-order-list.tsx
@@ -53,7 +53,8 @@ function formatDate(dateString: string): string {
   });
 }
 
-function formatDateShort(dateString: string): string {
+function formatDateShort(dateString: string | null): string {
+  if (!dateString) return "-";
   const date = new Date(dateString);
   return date.toLocaleDateString("ja-JP", {
     year: "numeric",

--- a/web/src/features/purchase-orders/components/manufacturer-order-detail.tsx
+++ b/web/src/features/purchase-orders/components/manufacturer-order-detail.tsx
@@ -33,10 +33,15 @@ import { Download, Factory, Loader2, Package, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api/client";
 import { StatusBadge } from "@/components/common/status-badge";
+import { ManufacturingDataBadge } from "@/components/common/manufacturing-data-badge";
 import {
   getManufacturerOrderStatusUpdateOptions,
 } from "@/constants/status";
-import type { ManufacturerOrderItemListResponse, OrderStatus } from "@/types/api";
+import type {
+  ManufacturerOrderItem,
+  ManufacturerOrderItemListResponse,
+  OrderStatus,
+} from "@/types/api";
 import { ManufacturerOrderFilters } from "./manufacturer-order-filters";
 import { InvoiceDialog } from "@/features/invoice";
 
@@ -67,6 +72,18 @@ const productTypeLabels: Record<string, string> = {
   tote_bag: "トートバッグ",
   tshirt: "Tシャツ",
 };
+
+/**
+ * 発注不可（未ready）の明細か判定する。
+ * 発注中（ordered）かつ製造データが必要（v2）で ready でない場合、メーカー発注できない。
+ */
+function isOrderBlocked(item: ManufacturerOrderItem): boolean {
+  return (
+    item.status === "ordered" &&
+    !!item.manufacturing_status &&
+    item.manufacturing_status !== "ready"
+  );
+}
 
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
@@ -200,9 +217,12 @@ export function ManufacturerOrderDetail({
     }
   };
 
+  // 発注可能な明細のみ選択対象とする（未ready = 製造データ待ちは発注不可）
+  const selectableItems = data.items.filter((item) => !isOrderBlocked(item));
+
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
-      setSelectedIds(new Set(data.items.map((item) => item.id)));
+      setSelectedIds(new Set(selectableItems.map((item) => item.id)));
     } else {
       setSelectedIds(new Set());
     }
@@ -219,7 +239,7 @@ export function ManufacturerOrderDetail({
   };
 
   const isAllSelected =
-    data.items.length > 0 && selectedIds.size === data.items.length;
+    selectableItems.length > 0 && selectedIds.size === selectableItems.length;
   const isSomeSelected = selectedIds.size > 0 && !isAllSelected;
 
   return (
@@ -312,6 +332,7 @@ export function ManufacturerOrderDetail({
                   <TableHead>商品名</TableHead>
                   <TableHead>商品タイプ</TableHead>
                   <TableHead>ステータス</TableHead>
+                  <TableHead>製造データ</TableHead>
                   <TableHead className="text-center">数量</TableHead>
                   <TableHead className="text-right">単価</TableHead>
                   <TableHead className="text-right">金額</TableHead>
@@ -323,7 +344,7 @@ export function ManufacturerOrderDetail({
                 {isLoading ? (
                   <TableRow>
                     <TableCell
-                      colSpan={11}
+                      colSpan={12}
                       className="h-24 text-center text-muted-foreground"
                     >
                       <div className="flex items-center justify-center gap-2">
@@ -335,7 +356,7 @@ export function ManufacturerOrderDetail({
                 ) : data.items.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={11}
+                      colSpan={12}
                       className="h-24 text-center text-muted-foreground"
                     >
                       発注中の明細がありません
@@ -347,6 +368,7 @@ export function ManufacturerOrderDetail({
                       <TableCell onClick={(e) => e.stopPropagation()}>
                         <Checkbox
                           checked={selectedIds.has(item.id)}
+                          disabled={isOrderBlocked(item)}
                           onCheckedChange={(checked) =>
                             handleItemSelect(item.id, !!checked)
                           }
@@ -365,6 +387,13 @@ export function ManufacturerOrderDetail({
                       </TableCell>
                       <TableCell>
                         <StatusBadge status={item.status} />
+                      </TableCell>
+                      <TableCell>
+                        {item.manufacturing_status ? (
+                          <ManufacturingDataBadge status={item.manufacturing_status} />
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
                       </TableCell>
                       <TableCell className="text-center">
                         {item.quantity}

--- a/web/src/features/purchase-orders/components/manufacturer-order-detail.tsx
+++ b/web/src/features/purchase-orders/components/manufacturer-order-detail.tsx
@@ -96,7 +96,8 @@ function formatDate(dateString: string): string {
   });
 }
 
-function formatDateShort(dateString: string): string {
+function formatDateShort(dateString: string | null): string {
+  if (!dateString) return "-";
   const date = new Date(dateString);
   return date.toLocaleDateString("ja-JP", {
     year: "numeric",

--- a/web/src/features/purchase-orders/hooks/use-manufacturer-orders.ts
+++ b/web/src/features/purchase-orders/hooks/use-manufacturer-orders.ts
@@ -1,5 +1,6 @@
 import useSWR from "swr";
 import { apiClient } from "@/lib/api/client";
+import { isManufacturingDataActive } from "@/constants/status";
 import type {
   ManufacturerOrderSummaryListResponse,
   ManufacturerOrderItemListResponse,
@@ -59,10 +60,8 @@ export function useManufacturerOrderItems(
       // 発注可否ゲート（未ready=選択不可）を持つ画面なので、生成完了を検知して
       // 自動的に選択可能へ更新する（手動リロード不要）。
       refreshInterval: (latest?: ManufacturerOrderItemListResponse) =>
-        latest?.items?.some(
-          (item) =>
-            item.manufacturing_status === "pending" ||
-            item.manufacturing_status === "generating"
+        latest?.items?.some((item) =>
+          isManufacturingDataActive(item.manufacturing_status)
         )
           ? 5000
           : 0,

--- a/web/src/features/purchase-orders/hooks/use-manufacturer-orders.ts
+++ b/web/src/features/purchase-orders/hooks/use-manufacturer-orders.ts
@@ -55,6 +55,17 @@ export function useManufacturerOrderItems(
   const { data, error, isLoading, isValidating, mutate } =
     useSWR<ManufacturerOrderItemListResponse>(url, apiClient, {
       keepPreviousData: true,
+      // 製造データ生成中（pending/generating）の明細がある間はポーリングする。
+      // 発注可否ゲート（未ready=選択不可）を持つ画面なので、生成完了を検知して
+      // 自動的に選択可能へ更新する（手動リロード不要）。
+      refreshInterval: (latest?: ManufacturerOrderItemListResponse) =>
+        latest?.items?.some(
+          (item) =>
+            item.manufacturing_status === "pending" ||
+            item.manufacturing_status === "generating"
+        )
+          ? 5000
+          : 0,
     });
 
   return {

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -8,6 +8,18 @@ export type OrderStatus =
 // OrderItemのステータス（製品単位）
 export type OrderItemStatus = "ordered" | "manufacturing" | "delivered";
 
+// 製造データ（v2）のステータス
+export type ManufacturingDataStatus = "pending" | "generating" | "ready" | "failed";
+
+// 明細に紐づく製造データ情報（v2）
+export interface MfgDataItemInfo {
+  id: string;
+  status: ManufacturingDataStatus;
+  output_filename: string | null;
+  file_size: number | null;
+  error_message: string | null;
+}
+
 export interface OrderItem {
   id: string;
   uid: string;
@@ -21,6 +33,9 @@ export interface OrderItem {
   design_image_url: string | null;
   thumbnail_image_url: string | null;
   status?: OrderItemStatus;  // 製品単位のステータス
+  // v2（製造データ生成）用フィールド
+  product_code?: string | null;
+  manufacturing_data?: MfgDataItemInfo | null;
   created_at: string;
   updated_at: string;
 }
@@ -116,6 +131,8 @@ export interface ManufacturerOrderItem {
   item_status?: OrderItemStatus | null;  // 新フィールド（製品単位のステータス）
   lead_time_days: number;  // メーカーのリードタイム（日数）
   expected_delivery_date: string;  // 納品予定日
+  // 製造データ状態（v2）: null なら製造データ不要（v1）。ready 以外は発注不可。
+  manufacturing_status?: ManufacturingDataStatus | null;
 }
 
 export interface ManufacturerOrderItemListResponse {

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -130,7 +130,7 @@ export interface ManufacturerOrderItem {
   status: OrderItemStatus;  // 製品単位のステータス
   item_status?: OrderItemStatus | null;  // 新フィールド（製品単位のステータス）
   lead_time_days: number;  // メーカーのリードタイム（日数）
-  expected_delivery_date: string;  // 納品予定日
+  expected_delivery_date: string | null;  // 納品予定日（未設定の旧データは null）
   // 製造データ状態（v2）: null なら製造データ不要（v1）。ready 以外は発注不可。
   manufacturing_status?: ManufacturingDataStatus | null;
 }
@@ -172,7 +172,7 @@ export interface AllManufacturerOrderItem {
   manufacturer_id: string;
   manufacturer_name: string;
   lead_time_days: number;  // メーカーのリードタイム（日数）
-  expected_delivery_date: string;  // 納品予定日
+  expected_delivery_date: string | null;  // 納品予定日（未設定の旧データは null）
 }
 
 export interface AllManufacturerOrderItemListResponse {


### PR DESCRIPTION
## 概要

**Intent Spec:** #76

外部販売サイト（rksyo）からの注文受付を、**完成デザインURL**ではなく**元データ（PNGレイヤー: color / cutline / white 等）** を受け取り、着信後に外部API（`illustrator-vm` = Product Manufacturing API）で**製造データ（.ai/.pdf）を生成**する方式へ拡張します。

### なぜこの変更が必要か

現状は明細ごとに完成デザインURLを受け取り、発注資料生成時にDL→拡張子リネームするだけで、**実際の製造データ生成は行われていません**。本変更で「元データから製造データを生成」「同一商品は一度だけ生成してキャッシュ再利用」「製造データが揃うまでメーカー発注を不可にする」を実現します。**既存 `POST /api/v1/orders` は一切変更せず**、新エンドポイントを追加して後方互換を保ちます（旧明細は `manufacturing_data_id = NULL` で発注ゲートの対象外）。

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | frontend `tsc --noEmit`：`src/` にエラー0（残存は既存 `feat-0018-*.test.tsx` の先行課題）。backend は追加ファイルで型注釈整備 |
| リンター | ✅ | `ruff`：新規/変更ファイルでエラー0。`eslint`：変更ファイルでエラー0 |
| ユニットテスト | ✅ | 新規75件パス（マッピング / VMクライアント / 生成・キャッシュ・ゲート）。全体で先行失敗44件から**新規失敗0** |
| 統合テスト | ⏸ | `test_orders_v2_manufacturing_data.py` を追加（v2受付/キャッシュ再利用/発注ゲート/v1後方互換）。**PostgreSQLが必要なためCIで実行**（本作業環境にDBなし・collectは成功） |
| 仕様適合 | ✅ | 受け入れ基準 8/8 を実装（下表） |
| AI意味レビュー | ✅ | `/simplify max`（reuse / simplification / efficiency / altitude の4エージェント並列）→ 安全な整理3件を適用 |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| `POST /api/v2/orders` が product_code＋レイヤーPNG URL を受け付け Order/OrderItem を作成。v1 不変 | `integration/test_orders_v2_manufacturing_data.py::TestV2Intake::test_intake_creates_order_and_links_manufacturing_data` / `TestV1BackwardCompatibility` | ✅ |
| 着信で対象明細の製造データ生成が自動起動し `manufacturing_data` に永続化 | `unit/test_manufacturing_data_service.py::TestCacheResolution` / `TestGenerateDriver` | ✅ |
| 同一 (order_source, product_code, size, variant) の再注文で **VMを再度呼ばず**キャッシュ再利用 | `integration/...::test_cache_reuse_across_orders_same_product_code`, `unit/...::test_reuses_ready_cache_without_generation` | ✅ |
| 生成結果(.ai/.pdf)は pod-admin 側に保存され72h経過後も参照可 | `unit/...::TestGenerateDriver::test_successful_generation_marks_ready`（FileStorage保存） | ✅ |
| 製造データが `ready` でない明細は ORDERED→MANUFACTURING **できない** | `integration/...::test_order_cannot_go_manufacturing_until_ready`, `unit/...::TestManufacturingReadinessGate` | ✅ |
| 生成失敗を手動リトライで再実行できる | `unit/...::TestRetry` ＋ `POST /manufacturing-data/{id}/retry` | ✅ |
| 発注資料ZIPが保存済み生成ファイルを封入（台座は従来通り） | `manufacturer_order_service._load_manufacturing_content`（v1動作は `unit/test_manufacturer_order_service.py` で回帰確認） | ✅ |
| フロントで状態可視化・未ready時は発注DL無効化 | `order-detail.tsx`（状態表示・ポーリング・再実行）/ `manufacturer-order-detail.tsx`（状態表示・未ready除外） | ✅ |

## スクリーンショット

UI変更あり（受注詳細に「製造データ」列＋状態バッジ・再実行、発注管理に「製造データ」列＋未ready明細の選択無効化）。本作業環境にアプリ起動基盤がないため自動撮影は未実施です。

## レビューのポイント

- **後方互換**: `POST /api/v1/orders` と旧 `GET /orders/{id}/manufacturing-data` は不変。v1明細は `manufacturing_data_id = NULL` で発注ゲート非対象。
- **発注ゲートの単一判定**: 準備完了の判定を `OrderItem.is_manufacturing_ready` に集約し、①低レベル状態遷移（`update_item_status_by_manufacturer`）②注文ステータス更新（409）③発注資料ZIP内容（`_hold_unready_items`）の3経路が同じ述語を共有。3箇所は「別々の効果（保留/エラー/資料除外）」をガードするため意図的に分離。
- **非同期生成の堅牢性**: 生成はBackgroundTasksで新規セッションを開き実行（`run_generation`）。intakeで製造データ行を同期紐付け＋commitしてから起動するため、バックグラウンドが確実に行を参照可能。VMの直列・503・72h削除に備えバックオフ／速やかなDL・自前保存を実装。
- **Open Questions の確定（自動判断）**:
  1. **バリアント導出** — keychainは white レイヤーの有無で `color`/`clear`、stickerは常に `clear`（受注値ではなく提供レイヤー構成から決定的に導出）。
  2. **本番ストレージ** — `FileStorage` 抽象のまま既定 `LocalFileStorage`（GCS等へ差し替え可能に留保）。
  3. **発注ゲート挙動** — 推奨案の「未ready保留」を採用（readyな明細のみZIPに含め発注、未readyは ORDERED のまま）。
  4. **mug_cup** — pod-admin `ProductType` 未定義のため**今回スコープ外**（マッピングで明示的に非対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgPoFVJ2VSrCBx5rt6fFeX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgPoFVJ2VSrCBx5rt6fFeX)_