### PR TITLE
feat: 外部注文v2の製造データ生成・キャッシュ＋発注ゲート（バックエンド / Issue #76）

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -2,6 +2,7 @@
 PROJECT_NAME=POD Admin API
 VERSION=0.1.0
 API_V1_PREFIX=/api/v1
+API_V2_PREFIX=/api/v2
 DEBUG=false
 
 # Database
@@ -19,6 +20,18 @@ CORS_ORIGINS=["http://localhost:3000","https://pod-admin-beige.vercel.app"]
 # File Storage
 UPLOAD_DIR=uploads
 MAX_UPLOAD_SIZE=104857600
+
+# Storage backend ("local" or "gcs")
+STORAGE_BACKEND=local
+GCS_BUCKET=
+GCS_PROJECT=
+
+# illustrator-vm (Product Manufacturing API) — 空なら製造データ生成をスキップ
+ILLUSTRATOR_VM_URL=
+ILLUSTRATOR_VM_TIMEOUT=60
+ILLUSTRATOR_VM_POLL_INTERVAL=3
+ILLUSTRATOR_VM_POLL_TIMEOUT=360
+ILLUSTRATOR_VM_MAX_RETRIES=3
 
 # Email (SendGrid)
 SENDGRID_API_KEY=

--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -3,22 +3,23 @@
 import asyncio
 from logging.config import fileConfig
 
-from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
+from alembic import context
 from app.config import settings
 from app.models.base import Base
 
 # Import all models here to ensure they are registered with Base.metadata
 from app.models.chat_message import ChatAttachment, ChatMessage  # noqa: F401
+from app.models.company_holiday import CompanyHoliday  # noqa: F401
 from app.models.manufacturer import Manufacturer  # noqa: F401
+from app.models.manufacturing_data import ManufacturingData  # noqa: F401
 from app.models.order import Order, OrderItem  # noqa: F401
 from app.models.product import Product  # noqa: F401
 from app.models.shipment import Shipment, ShipmentItem  # noqa: F401
 from app.models.user import User  # noqa: F401
-from app.models.company_holiday import CompanyHoliday  # noqa: F401
 
 # Alembic Config object
 config = context.config

--- a/api/alembic/versions/add_manufacturing_data.py
+++ b/api/alembic/versions/add_manufacturing_data.py
@@ -1,0 +1,111 @@
+"""Add manufacturing_data table and order_items manufacturing fields.
+
+Revision ID: add_manufacturing_data
+Revises: add_ext_order_notif_settings
+Create Date: 2026-07-05
+
+外部注文(v2)の製造データ生成・キャッシュ用テーブル manufacturing_data を追加し、
+order_items に v2 用カラム（product_code / variant / source_images / manufacturing_data_id）を追加する。
+旧v1明細では新カラムは全て NULL となり、既存の発注挙動は不変。
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "add_manufacturing_data"
+down_revision = "add_ext_order_notif_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. manufacturing_data テーブル（製造データ生成キャッシュ）
+    op.create_table(
+        "manufacturing_data",
+        sa.Column("id", UUID(as_uuid=False), primary_key=True),
+        sa.Column("order_source_id", UUID(as_uuid=False), nullable=False),
+        sa.Column("product_code", sa.String(100), nullable=False),
+        sa.Column("product_type", sa.String(50), nullable=False),
+        sa.Column("size", sa.String(50), nullable=False),
+        sa.Column("variant", sa.String(50), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
+        sa.Column("source_images", JSONB, nullable=True),
+        sa.Column("vm_job_id", sa.String(100), nullable=True),
+        sa.Column("output_filename", sa.String(255), nullable=True),
+        sa.Column("file_path", sa.String(500), nullable=True),
+        sa.Column("file_size", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.String(1000), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["order_source_id"], ["order_sources.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_manufacturing_data_order_source_id",
+        "manufacturing_data",
+        ["order_source_id"],
+    )
+    op.create_index("ix_manufacturing_data_product_code", "manufacturing_data", ["product_code"])
+    op.create_index("ix_manufacturing_data_status", "manufacturing_data", ["status"])
+    # キャッシュキー: 受注元×商品×サイズ×バリアント。variant は NULL 可のため
+    # NULLS NOT DISTINCT (PostgreSQL 15+) で「バリアントなし」同士も一意に扱う。
+    op.create_index(
+        "uq_manufacturing_data_cache",
+        "manufacturing_data",
+        ["order_source_id", "product_code", "size", "variant"],
+        unique=True,
+        postgresql_nulls_not_distinct=True,
+    )
+
+    # 2. order_items に v2 用カラムを追加（旧明細は NULL）
+    op.add_column("order_items", sa.Column("product_code", sa.String(100), nullable=True))
+    op.add_column("order_items", sa.Column("variant", sa.String(50), nullable=True))
+    op.add_column("order_items", sa.Column("source_images", JSONB, nullable=True))
+    op.add_column(
+        "order_items",
+        sa.Column("manufacturing_data_id", UUID(as_uuid=False), nullable=True),
+    )
+    op.create_index("ix_order_items_product_code", "order_items", ["product_code"])
+    op.create_index(
+        "ix_order_items_manufacturing_data_id",
+        "order_items",
+        ["manufacturing_data_id"],
+    )
+    op.create_foreign_key(
+        "fk_order_items_manufacturing_data_id",
+        "order_items",
+        "manufacturing_data",
+        ["manufacturing_data_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_order_items_manufacturing_data_id", "order_items", type_="foreignkey")
+    op.drop_index("ix_order_items_manufacturing_data_id", table_name="order_items")
+    op.drop_index("ix_order_items_product_code", table_name="order_items")
+    op.drop_column("order_items", "manufacturing_data_id")
+    op.drop_column("order_items", "source_images")
+    op.drop_column("order_items", "variant")
+    op.drop_column("order_items", "product_code")
+
+    op.drop_index("uq_manufacturing_data_cache", table_name="manufacturing_data")
+    op.drop_index("ix_manufacturing_data_status", table_name="manufacturing_data")
+    op.drop_index("ix_manufacturing_data_product_code", table_name="manufacturing_data")
+    op.drop_index("ix_manufacturing_data_order_source_id", table_name="manufacturing_data")
+    op.drop_table("manufacturing_data")

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "POD Admin API"
     VERSION: str = "0.1.0"
     API_V1_PREFIX: str = "/api/v1"
+    API_V2_PREFIX: str = "/api/v2"
     DEBUG: bool = False
 
     # Database
@@ -45,6 +46,19 @@ class Settings(BaseSettings):
     # File Storage
     UPLOAD_DIR: str = "uploads"
     MAX_UPLOAD_SIZE: int = 100 * 1024 * 1024  # 100MB
+
+    # Storage backend ("local" ローカルFS / "gcs" Google Cloud Storage)
+    STORAGE_BACKEND: str = "local"
+    GCS_BUCKET: str = ""
+    GCS_PROJECT: str = ""
+
+    # illustrator-vm (Product Manufacturing API) 連携
+    # 空なら製造データ生成をスキップ（manufacturing_data は pending のまま）
+    ILLUSTRATOR_VM_URL: str = ""
+    ILLUSTRATOR_VM_TIMEOUT: float = 60.0
+    ILLUSTRATOR_VM_POLL_INTERVAL: float = 3.0
+    ILLUSTRATOR_VM_POLL_TIMEOUT: float = 360.0
+    ILLUSTRATOR_VM_MAX_RETRIES: int = 3
 
     # Email (SendGrid)
     SENDGRID_API_KEY: str = ""

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -14,6 +14,7 @@ from app.repositories.app_setting_repository import AppSettingRepository
 from app.repositories.chat_repository import ChatRepository
 from app.repositories.company_holiday_repository import CompanyHolidayRepository
 from app.repositories.manufacturer_repository import ManufacturerRepository
+from app.repositories.manufacturing_data_repository import ManufacturingDataRepository
 from app.repositories.order_repository import OrderRepository
 from app.repositories.order_source_repository import OrderSourceRepository
 from app.repositories.product_repository import ProductRepository
@@ -25,6 +26,7 @@ from app.services.dashboard_service import DashboardService
 from app.services.email_service import EmailService
 from app.services.external_order_notification import ExternalOrderNotificationService
 from app.services.external_service import ExternalService
+from app.services.illustrator_vm_client import IllustratorVmClient
 from app.services.invoice_service import InvoiceService
 from app.services.manufacturer_order_service import ManufacturerOrderService
 from app.services.manufacturer_portal_service import ManufacturerPortalService
@@ -35,7 +37,7 @@ from app.services.order_service import OrderService
 from app.services.product_service import ProductService
 from app.services.shipment_service import ShipmentService
 from app.utils.exceptions import ForbiddenError, UnauthorizedError
-from app.utils.file_storage import FileStorage, LocalFileStorage
+from app.utils.file_storage import FileStorage, LocalFileStorage, build_file_storage
 from app.utils.security import decode_token
 
 
@@ -108,6 +110,13 @@ def get_app_setting_repository(
 ) -> AppSettingRepository:
     """Get app setting repository."""
     return AppSettingRepository(db)
+
+
+def get_manufacturing_data_repository(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> ManufacturingDataRepository:
+    """Get manufacturing data repository."""
+    return ManufacturingDataRepository(db)
 
 
 # Service dependencies
@@ -209,9 +218,13 @@ def get_manufacturer_order_service(
     order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
     manufacturer_repo: Annotated[ManufacturerRepository, Depends(get_manufacturer_repository)],
     shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
+    mfg_repo: Annotated[ManufacturingDataRepository, Depends(get_manufacturing_data_repository)],
+    file_storage: Annotated[FileStorage, Depends(build_file_storage)],
 ) -> ManufacturerOrderService:
     """Get manufacturer order service."""
-    return ManufacturerOrderService(order_repo, manufacturer_repo, shipment_repo)
+    return ManufacturerOrderService(
+        order_repo, manufacturer_repo, shipment_repo, mfg_repo, file_storage
+    )
 
 
 def get_manufacturer_portal_service(
@@ -247,7 +260,13 @@ def get_invoice_service(
 # File storage dependency
 def get_file_storage() -> FileStorage:
     """Get file storage."""
-    return LocalFileStorage(settings.UPLOAD_DIR)
+    return build_file_storage()
+
+
+# illustrator-vm client dependency
+def get_illustrator_vm_client() -> IllustratorVmClient | None:
+    """Get illustrator-vm client (None if ILLUSTRATOR_VM_URL not configured)."""
+    return IllustratorVmClient.from_settings()
 
 
 # Authentication dependencies

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -13,10 +13,14 @@ from app.routers import (
     external,
     manufacturer_portal,
     manufacturers,
+    manufacturing_data,
     orders,
+    orders_v2,
     products,
-    settings as settings_router,
     shipments,
+)
+from app.routers import (
+    settings as settings_router,
 )
 from app.utils.exceptions import AppException
 
@@ -74,12 +78,16 @@ app.include_router(products.router, prefix=settings.API_V1_PREFIX)
 app.include_router(manufacturers.router, prefix=settings.API_V1_PREFIX)
 app.include_router(manufacturer_portal.router, prefix=settings.API_V1_PREFIX)
 app.include_router(orders.router, prefix=settings.API_V1_PREFIX)
+app.include_router(manufacturing_data.router, prefix=settings.API_V1_PREFIX)
 app.include_router(shipments.router, prefix=settings.API_V1_PREFIX)
 app.include_router(chat.router, prefix=settings.API_V1_PREFIX)
 app.include_router(dashboard.router, prefix=settings.API_V1_PREFIX)
 app.include_router(external.router, prefix=settings.API_V1_PREFIX)
 app.include_router(settings_router.router, prefix=settings.API_V1_PREFIX)
 app.include_router(company_holidays.router, prefix=settings.API_V1_PREFIX)
+
+# v2 API (製造データ生成対応の外部注文受付)
+app.include_router(orders_v2.router, prefix=settings.API_V2_PREFIX)
 
 
 # Test endpoints for exception handling (only in debug mode)

--- a/api/app/models/manufacturing_data.py
+++ b/api/app/models/manufacturing_data.py
@@ -1,0 +1,89 @@
+"""Manufacturing data model - 製造データ生成キャッシュ.
+
+外部注文(v2)で受け取った元データ(PNGレイヤー)から illustrator-vm で生成した
+製造データ(.ai/.pdf)を、受注元×商品×サイズ×バリアント単位でキャッシュするテーブル。
+同一キーの再注文では VM を再実行せず、保存済みファイルを再利用する。
+"""
+
+from enum import Enum
+
+from sqlalchemy import ForeignKey, Index, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class MfgDataStatus(str, Enum):
+    """製造データ生成ステータス."""
+
+    PENDING = "pending"  # 生成待ち（未着手 / リトライ対象）
+    GENERATING = "generating"  # 生成中（illustrator-vm 実行中）
+    READY = "ready"  # 生成完了・ファイル保存済み
+    FAILED = "failed"  # 生成失敗（error_message 参照）
+
+
+class ManufacturingData(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    """製造データ生成キャッシュ - 受注元×商品×サイズ×バリアント単位で1行."""
+
+    __tablename__ = "manufacturing_data"
+
+    # 受注元（サイト単位でキャッシュを名前空間分離）
+    order_source_id: Mapped[str] = mapped_column(
+        ForeignKey("order_sources.id", ondelete="CASCADE"), index=True
+    )
+
+    # rksyo の商品識別子（キャッシュキー）
+    product_code: Mapped[str] = mapped_column(String(100), index=True)
+
+    # pod-admin / VM の商品タイプ
+    product_type: Mapped[str] = mapped_column(String(50))
+
+    # pod-admin サイズ文字列（例: "50x50mm"）
+    size: Mapped[str] = mapped_column(String(50))
+
+    # VM互換バリアント（clear / color 等）。バリアントなし商品は NULL
+    variant: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    # 生成ステータス
+    status: Mapped[str] = mapped_column(String(20), default=MfgDataStatus.PENDING.value, index=True)
+
+    # 生成に使用したレイヤーURL群 [{"layer_type": ..., "url": ...}]
+    source_images: Mapped[list[dict[str, str]] | None] = mapped_column(JSONB, nullable=True)
+
+    # illustrator-vm のジョブID（生成中の追跡用）
+    vm_job_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    # VM status 由来の出力ファイル名（二重拡張子回避のため status の値を正とする）
+    output_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # FileStorage 保存先（ローカル相対パス or GCSオブジェクトキー）
+    file_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    file_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # 直近の失敗理由
+    error_message: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+
+    # 生成試行回数
+    attempts: Mapped[int] = mapped_column(Integer, default=0)
+
+    __table_args__ = (
+        # キャッシュキー: 受注元×商品×サイズ×バリアント。
+        # variant は NULL 可のため NULLS NOT DISTINCT (PostgreSQL 15+) で
+        # 「バリアントなし」同士も一意に扱い、重複生成を防ぐ。
+        Index(
+            "uq_manufacturing_data_cache",
+            "order_source_id",
+            "product_code",
+            "size",
+            "variant",
+            unique=True,
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ManufacturingData(id={self.id}, product_code={self.product_code}, "
+            f"size={self.size}, variant={self.variant}, status={self.status})>"
+        )

--- a/api/app/models/order.py
+++ b/api/app/models/order.py
@@ -6,9 +6,14 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Date, DateTime, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, CustomerAddressMixin, TimestampMixin, UUIDPrimaryKeyMixin
+
+# ManufacturingData を runtime import して mapper registry に登録し、OrderItem.manufacturing_data
+# リレーションの名前解決を保証する（manufacturing_data は base のみ依存のため循環importにならない）。
+from app.models.manufacturing_data import ManufacturingData  # noqa: F401
 
 if TYPE_CHECKING:
     from app.models.order_source import OrderSource
@@ -199,12 +204,25 @@ class OrderItem(Base, UUIDPrimaryKeyMixin, TimestampMixin):
     design_image_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     thumbnail_image_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
 
+    # 外部注文(v2)用: 製造データ生成の元データ（旧v1明細は全て NULL）
+    # product_code=キャッシュキー(rksyo商品識別子) / variant=VM互換値(clear/color) /
+    # source_images=元データPNGレイヤーのURL群 [{"layer_type": ..., "url": ...}]
+    product_code: Mapped[str | None] = mapped_column(String(100), nullable=True, index=True)
+    variant: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    source_images: Mapped[list[dict[str, str]] | None] = mapped_column(JSONB, nullable=True)
+
+    # 生成済み製造データ（manufacturing_data キャッシュ行）への紐付け
+    manufacturing_data_id: Mapped[str | None] = mapped_column(
+        ForeignKey("manufacturing_data.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
     # メーカーからの納品予定日（注文作成時に営業日計算で算出、確定値）
     expected_delivery_date: Mapped[dt.date | None] = mapped_column(Date, nullable=True)
 
     # Relationships
     order: Mapped["Order"] = relationship(back_populates="items")
     product: Mapped["Product"] = relationship()  # 商品マスタへの参照
+    manufacturing_data: Mapped["ManufacturingData | None"] = relationship()
 
     def __repr__(self) -> str:
         return f"<OrderItem(id={self.id}, product_name={self.product_name}, quantity={self.quantity}, status={self.status})>"

--- a/api/app/repositories/manufacturing_data_repository.py
+++ b/api/app/repositories/manufacturing_data_repository.py
@@ -1,0 +1,120 @@
+"""Repository for ManufacturingData (製造データ生成キャッシュ)."""
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+from app.models.order import OrderItem
+
+
+class ManufacturingDataRepository:
+    """Repository for the manufacturing_data cache table."""
+
+    def __init__(self, db: AsyncSession):
+        self._db = db
+
+    async def create(self, md: ManufacturingData) -> ManufacturingData:
+        """Insert a new manufacturing_data row."""
+        self._db.add(md)
+        await self._db.flush()
+        await self._db.refresh(md)
+        return md
+
+    async def get_by_id(self, mfg_data_id: str) -> ManufacturingData | None:
+        """Fetch a single row by id."""
+        result = await self._db.execute(
+            select(ManufacturingData).where(ManufacturingData.id == mfg_data_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def find_by_cache_key(
+        self,
+        order_source_id: str,
+        product_code: str,
+        size: str,
+        variant: str | None,
+    ) -> ManufacturingData | None:
+        """Look up the cached row by (order_source, product_code, size, variant).
+
+        variant is NULLable; NULL is matched with IS NULL so「バリアントなし」商品も
+        一意に引ける（DB側は NULLS NOT DISTINCT の一意制約で重複を防止）。
+        """
+        query = select(ManufacturingData).where(
+            ManufacturingData.order_source_id == order_source_id,
+            ManufacturingData.product_code == product_code,
+            ManufacturingData.size == size,
+        )
+        if variant is None:
+            query = query.where(ManufacturingData.variant.is_(None))
+        else:
+            query = query.where(ManufacturingData.variant == variant)
+        result = await self._db.execute(query)
+        return result.scalar_one_or_none()
+
+    async def find_by_ids(self, ids: list[str]) -> list[ManufacturingData]:
+        """Fetch multiple rows by id (順不同)."""
+        if not ids:
+            return []
+        result = await self._db.execute(
+            select(ManufacturingData).where(ManufacturingData.id.in_(ids))
+        )
+        return list(result.scalars().all())
+
+    async def find_by_order_id(self, order_id: str) -> list[ManufacturingData]:
+        """Fetch manufacturing_data rows linked to an order's items."""
+        result = await self._db.execute(
+            select(ManufacturingData)
+            .join(OrderItem, OrderItem.manufacturing_data_id == ManufacturingData.id)
+            .where(OrderItem.order_id == order_id)
+        )
+        return list(result.scalars().unique().all())
+
+    async def list_recent(
+        self, limit: int = 100, status: str | None = None
+    ) -> list[ManufacturingData]:
+        """List rows (newest first), optionally filtered by status."""
+        query = select(ManufacturingData).order_by(ManufacturingData.created_at.desc())
+        if status is not None:
+            query = query.where(ManufacturingData.status == status)
+        query = query.limit(limit)
+        result = await self._db.execute(query)
+        return list(result.scalars().all())
+
+    async def claim_for_generation(self, mfg_data_id: str, *, allow_ready: bool = False) -> bool:
+        """原子的に status を generating へ遷移させ生成権を得る（多重生成防止）.
+
+        pending / failed（allow_ready なら ready も）からのみ claim 可能。RETURNING で
+        更新できたか判定し、True の場合のみ呼び出し側が生成を続行する。
+        """
+        claimable = [MfgDataStatus.PENDING.value, MfgDataStatus.FAILED.value]
+        if allow_ready:
+            claimable.append(MfgDataStatus.READY.value)
+        result = await self._db.execute(
+            update(ManufacturingData)
+            .where(
+                ManufacturingData.id == mfg_data_id,
+                ManufacturingData.status.in_(claimable),
+            )
+            .values(
+                status=MfgDataStatus.GENERATING.value,
+                attempts=ManufacturingData.attempts + 1,
+                error_message=None,
+            )
+            .returning(ManufacturingData.id)
+        )
+        await self._db.flush()
+        return result.scalar_one_or_none() is not None
+
+    async def reset_to_pending(self, mfg_data_id: str) -> ManufacturingData | None:
+        """行を pending へ戻す（手動リトライ用。generating スタックからの復旧も可能）."""
+        md = await self.get_by_id(mfg_data_id)
+        if md is None:
+            return None
+        md.status = MfgDataStatus.PENDING.value
+        md.error_message = None
+        await self._db.flush()
+        return md
+
+    async def flush(self) -> None:
+        """Flush pending changes (状態遷移を中間コミット前に反映するため)."""
+        await self._db.flush()

--- a/api/app/repositories/order_repository.py
+++ b/api/app/repositories/order_repository.py
@@ -471,6 +471,27 @@ class OrderRepository:
 
         return items, affected_order_ids
 
+    async def find_manufacturer_items(
+        self,
+        manufacturer_id: str,
+        order_item_ids: list[str] | None = None,
+        statuses: list[str] | None = None,
+    ) -> list[OrderItem]:
+        """メーカーに紐づく OrderItem を読み取り専用で取得（発注ゲートの ready 判定用）."""
+        from app.models.product import Product
+
+        query = (
+            select(OrderItem)
+            .join(Product, OrderItem.product_id == Product.id)
+            .where(Product.manufacturer_id == manufacturer_id)
+        )
+        if statuses:
+            query = query.where(OrderItem.status.in_(statuses))
+        if order_item_ids:
+            query = query.where(OrderItem.id.in_(order_item_ids))
+        result = await self._db.execute(query)
+        return list(result.scalars().all())
+
     async def check_all_items_delivered(self, order_id: str) -> bool:
         """指定されたOrderの全OrderItemがdeliveredかどうかを確認
 

--- a/api/app/routers/manufacturing_data.py
+++ b/api/app/routers/manufacturing_data.py
@@ -1,0 +1,67 @@
+"""Manufacturing data status & retry endpoints (admin)."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import (
+    get_current_admin,
+    get_db_session,
+    get_manufacturing_data_repository,
+)
+from app.models.user import User
+from app.repositories.manufacturing_data_repository import ManufacturingDataRepository
+from app.schemas.manufacturing_data import (
+    ManufacturingDataListResponse,
+    ManufacturingDataResponse,
+)
+from app.services.manufacturing_data_service import run_generate_manufacturing_data
+from app.utils.exceptions import NotFoundError
+
+router = APIRouter(prefix="/manufacturing-data", tags=["manufacturing-data"])
+
+
+@router.get("", response_model=ManufacturingDataListResponse)
+async def list_manufacturing_data(
+    repo: Annotated[ManufacturingDataRepository, Depends(get_manufacturing_data_repository)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+    order_id: str | None = None,
+    status: str | None = None,
+    limit: int = Query(100, ge=1, le=500),
+) -> ManufacturingDataListResponse:
+    """製造データ一覧（管理者）。order_id 指定でその注文分、status で絞り込み。"""
+    if order_id:
+        rows = await repo.find_by_order_id(order_id)
+        if status:
+            rows = [row for row in rows if row.status == status]
+    else:
+        rows = await repo.list_recent(limit=limit, status=status)
+    return ManufacturingDataListResponse(
+        items=[ManufacturingDataResponse.model_validate(row) for row in rows],
+        total=len(rows),
+    )
+
+
+@router.post("/{mfg_data_id}/retry", response_model=ManufacturingDataResponse)
+async def retry_manufacturing_data(
+    mfg_data_id: str,
+    background_tasks: BackgroundTasks,
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    repo: Annotated[ManufacturingDataRepository, Depends(get_manufacturing_data_repository)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ManufacturingDataResponse:
+    """失敗 / スタックした製造データ生成を手動リトライ（管理者）。
+
+    行を pending に戻し、生成をバックグラウンドで再実行する。API 再起動で generating の
+    まま残った行もこれで再駆動できる（pending 確定後にワーカーが claim するため）。
+    """
+    md = await repo.reset_to_pending(mfg_data_id)
+    if md is None:
+        raise NotFoundError("ManufacturingData", mfg_data_id)
+    # バックグラウンドの生成ワーカーが pending を確実に見えるよう、ここで確定させる
+    await session.commit()
+    # onupdate で更新された updated_at 等を再読込（model_validate 時の遅延ロードを回避）
+    await session.refresh(md)
+    background_tasks.add_task(run_generate_manufacturing_data, mfg_data_id)
+    return ManufacturingDataResponse.model_validate(md)

--- a/api/app/routers/orders_v2.py
+++ b/api/app/routers/orders_v2.py
@@ -1,0 +1,36 @@
+"""v2 order intake router (製造データ生成の元データを受け取る外部注文受付)."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, BackgroundTasks, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_db_session, get_order_service, verify_api_key
+from app.schemas.order import OrderResponse
+from app.schemas.order_v2 import OrderCreateV2
+from app.services.manufacturing_data_service import run_ensure_for_order
+from app.services.order_service import OrderService
+
+router = APIRouter(prefix="/orders", tags=["orders-v2"])
+
+
+@router.post("", response_model=OrderResponse, status_code=201)
+async def create_order_v2(
+    data: OrderCreateV2,
+    background_tasks: BackgroundTasks,
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    service: Annotated[OrderService, Depends(get_order_service)],
+    api_key_info: Annotated[tuple[str, str], Depends(verify_api_key)],
+) -> OrderResponse:
+    """外部販売サイト(v2)からの注文受付（API Key認証）。
+
+    完成データURLではなく元データ(PNGレイヤー)の source_images ＋ product_code /
+    variant を受け取り、Order/OrderItem を作成する。受付後、製造データ生成を
+    BackgroundTasks で非同期に起動する（intake HTTP はブロックしない）。
+    """
+    _, order_source_id = api_key_info
+    order = await service.create_v2(data, order_source_id=order_source_id)
+    # 製造データ生成タスクは独自セッションで注文を再読込するため、ここで確定させてから起動する
+    await session.commit()
+    background_tasks.add_task(run_ensure_for_order, order.id)
+    return order

--- a/api/app/schemas/manufacturing_data.py
+++ b/api/app/schemas/manufacturing_data.py
@@ -1,0 +1,34 @@
+"""Manufacturing data response schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ManufacturingDataResponse(BaseModel):
+    """製造データ生成キャッシュ行のレスポンス."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    order_source_id: str
+    product_code: str
+    product_type: str
+    size: str
+    variant: str | None
+    status: str
+    vm_job_id: str | None
+    output_filename: str | None
+    file_path: str | None
+    file_size: int | None
+    error_message: str | None
+    attempts: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ManufacturingDataListResponse(BaseModel):
+    """製造データ一覧レスポンス."""
+
+    items: list[ManufacturingDataResponse]
+    total: int

--- a/api/app/schemas/order_v2.py
+++ b/api/app/schemas/order_v2.py
@@ -1,0 +1,68 @@
+"""v2 order intake schemas.
+
+外部販売サイト(v2)からの注文受付用スキーマ。完成データURLではなく、製造データ生成の
+元データ(PNGレイヤーの source_images) と product_code / variant を受け取る。
+"""
+
+from pydantic import BaseModel, Field
+
+from app.models.product import ProductType
+from app.schemas.order import CustomerInfo
+
+
+class SourceImage(BaseModel):
+    """製造データ生成の元データ（レイヤー種別ごとのPNG URL）."""
+
+    layer_type: str = Field(
+        ...,
+        min_length=1,
+        max_length=20,
+        description="レイヤー種別 (color / cutline / white / design)",
+    )
+    url: str = Field(..., min_length=1, max_length=2048)
+
+
+class OrderItemCreateV2(BaseModel):
+    """v2 受注明細（製造データ生成の元データ付き）."""
+
+    uid: str = Field(
+        ...,
+        min_length=7,
+        max_length=7,
+        pattern=r"^\d{7}$",
+        description="製品番号（7桁数字）",
+        examples=["0000001"],
+    )
+    product_type: ProductType
+    product_name: str = Field(..., min_length=1, max_length=200)
+    price: int = Field(..., ge=0)
+    quantity: int = Field(1, ge=1)
+    size: str | None = Field(None, max_length=50)
+
+    # 製造データ生成用（新規）
+    product_code: str = Field(
+        ..., min_length=1, max_length=100, description="rksyo の商品識別子（キャッシュキー）"
+    )
+    variant: str | None = Field(
+        None, max_length=50, description="VM互換バリアント（keychain: clear/color, sticker: clear）"
+    )
+    source_images: list[SourceImage] = Field(
+        ..., min_length=1, description="元データPNGレイヤーのURL群"
+    )
+
+    thumbnail_image_url: str | None = Field(None, max_length=2048)
+
+
+class OrderCreateV2(BaseModel):
+    """v2 受注作成スキーマ."""
+
+    order_number: str = Field(
+        ...,
+        min_length=7,
+        max_length=7,
+        pattern=r"^\d{7}$",
+        description="受注番号（7桁数字）",
+        examples=["0000001"],
+    )
+    customer: CustomerInfo
+    items: list[OrderItemCreateV2] = Field(..., min_length=1)

--- a/api/app/services/illustrator_vm_client.py
+++ b/api/app/services/illustrator_vm_client.py
@@ -1,0 +1,218 @@
+"""Client for the illustrator-vm Product Manufacturing API.
+
+illustrator-vm は製造データ（.ai/.pdf）を生成する非同期ジョブ型API（認証なし）。
+    POST /api/process        -> 202 {job_id, status, ...}
+    GET  /api/status/{job_id} -> 200 {status, progress, output_filename, message, ...}
+    GET  /api/download/{job_id} -> 200 ファイルbytes
+直列処理（Illustrator 1インスタンス, 最大~300秒）・キュー超過で 503・完了は72hでGC。
+冪等性は呼び出し側の責務。出力ファイル名は status の output_filename を正とする。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# 生成完了とみなす/失敗とみなす status 値
+_STATUS_COMPLETED = "completed"
+_STATUS_FAILED = "failed"
+
+
+class IllustratorVmError(Exception):
+    """illustrator-vm 呼び出しに関するエラー（サービス層が捕捉して failed 記録に使う）."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class VmJobStatus:
+    """GET /api/status のレスポンス（必要フィールドのみ）."""
+
+    job_id: str
+    status: str
+    progress: int
+    message: str | None
+    output_filename: str | None
+
+    @property
+    def is_completed(self) -> bool:
+        return self.status == _STATUS_COMPLETED
+
+    @property
+    def is_failed(self) -> bool:
+        return self.status == _STATUS_FAILED
+
+
+class IllustratorVmClient:
+    """illustrator-vm への薄いHTTPクライアント（submit / status / download / 待機）."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 60.0,
+        poll_interval: float = 3.0,
+        poll_timeout: float = 360.0,
+        max_retries: int = 3,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._poll_interval = poll_interval
+        self._poll_timeout = poll_timeout
+        self._max_retries = max(0, max_retries)
+
+    @classmethod
+    def from_settings(cls) -> IllustratorVmClient | None:
+        """設定から生成。ILLUSTRATOR_VM_URL 未設定なら None（生成機能オフ）."""
+        from app.config import settings
+
+        if not settings.ILLUSTRATOR_VM_URL:
+            return None
+        return cls(
+            base_url=settings.ILLUSTRATOR_VM_URL,
+            timeout=settings.ILLUSTRATOR_VM_TIMEOUT,
+            poll_interval=settings.ILLUSTRATOR_VM_POLL_INTERVAL,
+            poll_timeout=settings.ILLUSTRATOR_VM_POLL_TIMEOUT,
+            max_retries=settings.ILLUSTRATOR_VM_MAX_RETRIES,
+        )
+
+    async def submit(
+        self,
+        *,
+        product_type: str,
+        vm_size: str,
+        variant: str | None,
+        input_mode: str,
+        order_id: str,
+        layers: dict[str, bytes],
+        filenames: dict[str, str] | None = None,
+    ) -> str:
+        """POST /api/process。ジョブを投入し job_id を返す。
+
+        layers は「レイヤー種別 -> PNG bytes」。single モードは design（無ければ唯一の
+        レイヤー）を image_data に、multi モードは images 配列に載せる。
+        """
+        names = filenames or {}
+        payload: dict[str, object] = {
+            "product_type": product_type,
+            "order_id": order_id,
+            "size": vm_size,
+        }
+        if variant:
+            payload["variant"] = variant
+
+        if input_mode == "single":
+            if not layers:
+                raise IllustratorVmError("single モードには元画像が1枚必要です")
+            design_bytes = layers.get("design") or next(iter(layers.values()))
+            payload["image_data"] = base64.b64encode(design_bytes).decode()
+            payload["image_filename"] = names.get("design", "design.png")
+        else:
+            payload["images"] = [
+                {
+                    "type": layer_type,
+                    "data": base64.b64encode(data).decode(),
+                    "filename": names.get(layer_type, f"{layer_type}.png"),
+                }
+                for layer_type, data in layers.items()
+            ]
+
+        response = await self._request_with_retry("POST", "/api/process", json=payload)
+        data = response.json()
+        job_id = data.get("job_id")
+        if not job_id:
+            raise IllustratorVmError("submit のレスポンスに job_id がありません")
+        return str(job_id)
+
+    async def get_status(self, job_id: str) -> VmJobStatus:
+        """GET /api/status/{job_id}。"""
+        response = await self._request_with_retry("GET", f"/api/status/{job_id}")
+        data = response.json()
+        return VmJobStatus(
+            job_id=str(data.get("job_id", job_id)),
+            status=str(data.get("status", "")),
+            progress=int(data.get("progress", 0) or 0),
+            message=data.get("message"),
+            output_filename=data.get("output_filename"),
+        )
+
+    async def download(self, job_id: str) -> bytes:
+        """GET /api/download/{job_id}。完成ファイルの bytes を返す。"""
+        response = await self._request_with_retry("GET", f"/api/download/{job_id}")
+        return response.content
+
+    async def wait_for_completion(self, job_id: str) -> VmJobStatus:
+        """completed になるまで status をポーリングする。
+
+        failed は IllustratorVmError、poll_timeout 超過も IllustratorVmError。
+        """
+        # poll_interval=0（テスト等）でも複数回ポーリングできるよう下限intervalで回数を決める
+        interval = self._poll_interval if self._poll_interval > 0 else 0.001
+        max_polls = max(1, int(self._poll_timeout / interval))
+        last_status: VmJobStatus | None = None
+        for attempt in range(max_polls):
+            status = await self.get_status(job_id)
+            last_status = status
+            if status.is_completed:
+                return status
+            if status.is_failed:
+                raise IllustratorVmError(
+                    f"illustrator-vm ジョブが失敗しました: {status.message or 'unknown error'}"
+                )
+            if attempt < max_polls - 1:
+                await asyncio.sleep(self._poll_interval)
+
+        raise IllustratorVmError(
+            f"illustrator-vm ジョブが {self._poll_timeout} 秒以内に完了しませんでした"
+            f"（最終status: {last_status.status if last_status else 'unknown'}）"
+        )
+
+    async def _request_with_retry(
+        self, method: str, path: str, *, json: dict[str, object] | None = None
+    ) -> httpx.Response:
+        """503/一時的な接続エラーはバックオフ再送。4xx は即エラー（入力不正）。"""
+        url = f"{self._base_url}{path}"
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                    response = await client.request(method, url, json=json)
+                if response.status_code == 503:
+                    last_exc = IllustratorVmError(
+                        "illustrator-vm がビジー状態です (503)", status_code=503
+                    )
+                elif response.status_code >= 400:
+                    raise IllustratorVmError(
+                        f"illustrator-vm がエラーを返しました ({response.status_code}): "
+                        f"{_extract_detail(response)}",
+                        status_code=response.status_code,
+                    )
+                else:
+                    return response
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                last_exc = exc
+
+            if attempt < self._max_retries:
+                await asyncio.sleep(self._poll_interval)
+
+        raise IllustratorVmError(f"illustrator-vm への {method} {path} が失敗しました: {last_exc}")
+
+
+def _extract_detail(response: httpx.Response) -> str:
+    """エラーレスポンスから detail を取り出す（illustrator-vm は error ではなく detail を使う）。"""
+    try:
+        body = response.json()
+    except Exception:
+        return response.text[:200]
+    if isinstance(body, dict) and "detail" in body:
+        return str(body["detail"])
+    return str(body)[:200]

--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -1,28 +1,39 @@
 """Manufacturer order service for managing orders by manufacturer."""
 
+import logging
 import os
 from datetime import date, datetime
+from typing import Any
 from urllib.parse import urlparse
 
 import httpx
 
-from app.models.order import Order, OrderItemStatus, OrderStatus
-from app.repositories.order_repository import OrderRepository
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+from app.models.order import Order, OrderItem, OrderItemStatus
 from app.repositories.manufacturer_repository import ManufacturerRepository
+from app.repositories.manufacturing_data_repository import ManufacturingDataRepository
+from app.repositories.order_repository import OrderRepository
 from app.repositories.shipment_repository import ShipmentRepository
 from app.schemas.manufacturer import (
+    AllManufacturerOrderItemListResponse,
+    AllManufacturerOrderItemResponse,
+    ManufacturerOrderItemListResponse,
+    ManufacturerOrderItemResponse,
+    ManufacturerOrderStatusUpdate,
     ManufacturerOrderSummary,
     ManufacturerOrderSummaryListResponse,
-    ManufacturerOrderItemResponse,
-    ManufacturerOrderItemListResponse,
-    ManufacturerOrderStatusUpdate,
-    AllManufacturerOrderItemResponse,
-    AllManufacturerOrderItemListResponse,
 )
-from app.utils.exceptions import NotFoundError, NoOrderedItemsError
+from app.utils.exceptions import (
+    ManufacturingDataNotReadyError,
+    NoOrderedItemsError,
+    NotFoundError,
+)
+from app.utils.file_storage import FileStorage
 from app.utils.order_list_generator import OrderListGenerator, get_product_type_name
 from app.utils.stand_file_config import load_stand_file
 from app.utils.zip_builder import ZipBuilder
+
+logger = logging.getLogger(__name__)
 
 
 class ManufacturerOrderService:
@@ -33,10 +44,14 @@ class ManufacturerOrderService:
         order_repo: OrderRepository,
         manufacturer_repo: ManufacturerRepository,
         shipment_repo: ShipmentRepository,
+        mfg_repo: ManufacturingDataRepository | None = None,
+        file_storage: FileStorage | None = None,
     ):
         self._order_repo = order_repo
         self._manufacturer_repo = manufacturer_repo
         self._shipment_repo = shipment_repo
+        self._mfg_repo = mfg_repo
+        self._file_storage = file_storage
         self._order_list_gen = OrderListGenerator()
 
     async def get_order_summary_list(
@@ -247,6 +262,10 @@ class ManufacturerOrderService:
         # Convert string status to OrderItemStatus enum
         new_status = OrderItemStatus(data.status)
 
+        # 製造中への遷移時は、製造データが未readyの明細を拒否（誤操作防止）
+        if new_status == OrderItemStatus.MANUFACTURING:
+            await self._assert_manufacturing_ready(manufacturer_id, data.order_item_ids)
+
         # OrderItem単位でステータス更新
         updated_items, affected_order_ids = await self._order_repo.update_item_status_by_manufacturer(
             manufacturer_id=manufacturer_id,
@@ -358,7 +377,18 @@ class ManufacturerOrderService:
         if not rows:
             raise NoOrderedItemsError()
 
-        # 発注中ステータスのorder_item_idsを記録（ステータス更新対象）
+        # 製造データが ready でない v2 明細は発注資料から除外し ORDERED のまま保留する
+        rows, held_count, mfg_content_by_item = await self._partition_by_readiness(rows)
+        if not rows:
+            raise NoOrderedItemsError()
+        if held_count:
+            logger.info(
+                "発注資料生成: 製造データ未readyの %d 明細を保留 (manufacturer=%s)",
+                held_count,
+                manufacturer_id,
+            )
+
+        # 発注中ステータスのorder_item_idsを記録（ステータス更新対象、保留分は含めない）
         # row[5]はitem_status
         ordered_item_ids = [
             row[0].id for row in rows if row[5] == OrderItemStatus.ORDERED.value
@@ -391,6 +421,7 @@ class ManufacturerOrderService:
                     "cost": cost,
                     "design_image_url": order_item.design_image_url,
                     "thumbnail_image_url": order_item.thumbnail_image_url,
+                    "mfg_content": mfg_content_by_item.get(order_item.id),
                 }
             )
 
@@ -454,15 +485,16 @@ class ManufacturerOrderService:
                 # 注文番号フォルダのパスプレフィックス
                 order_folder = f"{type_folder}/{order_number}"
 
-                # デザイン画像（製造データ①）
-                if item.get("design_image_url"):
+                # 製造データ①: v2は保存済み生成ファイルを封入、旧v1はdesign_image_urlをDL
+                mfg_content = item.get("mfg_content")
+                if mfg_content is not None:
+                    zip_builder.add_file(f"{order_folder}/{mfg_filename}", mfg_content)
+                elif item.get("design_image_url"):
                     content, _original_filename = await self._download_file(
                         item["design_image_url"]
                     )
                     if content:
-                        zip_builder.add_file(
-                            f"{order_folder}/{mfg_filename}", content
-                        )
+                        zip_builder.add_file(f"{order_folder}/{mfg_filename}", content)
 
                 # サムネイル画像 → {注文番号}_{製造番号}.png
                 if item.get("thumbnail_image_url"):
@@ -520,3 +552,78 @@ class ManufacturerOrderService:
         except Exception:
             pass
         return None, ""
+
+    def _is_mfg_item(self, order_item: OrderItem) -> bool:
+        """製造データ生成対象の v2 明細か（product_code か manufacturing_data_id を持つ）."""
+        return bool(order_item.product_code) or order_item.manufacturing_data_id is not None
+
+    async def _partition_by_readiness(
+        self, rows: list[tuple[Any, ...]]
+    ) -> tuple[list[tuple[Any, ...]], int, dict[str, bytes]]:
+        """rows を「発注可能」と「保留(未ready)」に分ける。
+
+        旧v1明細は常に発注可能。v2明細は ready かつ保存ファイルが存在する場合のみ発注可能で、
+        その生成ファイル bytes を返す。mfg_repo / file_storage 未設定時はゲート無効（全件発注可能）。
+        """
+        if self._mfg_repo is None or self._file_storage is None:
+            return list(rows), 0, {}
+
+        mfg_ids = [row[0].manufacturing_data_id for row in rows if row[0].manufacturing_data_id]
+        mfg_map: dict[str, ManufacturingData] = {}
+        if mfg_ids:
+            mfg_map = {md.id: md for md in await self._mfg_repo.find_by_ids(mfg_ids)}
+
+        includable: list[tuple[Any, ...]] = []
+        held_count = 0
+        content_by_item: dict[str, bytes] = {}
+        for row in rows:
+            order_item = row[0]
+            if not self._is_mfg_item(order_item):
+                includable.append(row)  # 旧v1明細はそのまま封入
+                continue
+            md = (
+                mfg_map.get(order_item.manufacturing_data_id)
+                if order_item.manufacturing_data_id
+                else None
+            )
+            content: bytes | None = None
+            if md is not None and md.status == MfgDataStatus.READY.value and md.file_path:
+                content = await self._file_storage.get(md.file_path)
+            if content is None:
+                held_count += 1  # 未ready or 保存ファイル消失 → 保留
+                continue
+            content_by_item[order_item.id] = content
+            includable.append(row)
+        return includable, held_count, content_by_item
+
+    async def _assert_manufacturing_ready(
+        self, manufacturer_id: str, order_item_ids: list[str] | None
+    ) -> None:
+        """→MANUFACTURING 対象に未ready の v2 明細があれば拒否する（管理者の誤操作防止）."""
+        if self._mfg_repo is None or self._file_storage is None:
+            return
+        candidates = await self._order_repo.find_manufacturer_items(
+            manufacturer_id,
+            order_item_ids=order_item_ids,
+            statuses=[OrderItemStatus.ORDERED.value, OrderItemStatus.DELIVERED.value],
+        )
+        mfg_items = [oi for oi in candidates if self._is_mfg_item(oi)]
+        if not mfg_items:
+            return
+        mfg_ids: list[str] = []
+        for oi in mfg_items:
+            if oi.manufacturing_data_id is not None:
+                mfg_ids.append(oi.manufacturing_data_id)
+        mfg_map: dict[str, ManufacturingData] = {}
+        if mfg_ids:
+            mfg_map = {md.id: md for md in await self._mfg_repo.find_by_ids(mfg_ids)}
+        not_ready: list[str] = []
+        for oi in mfg_items:
+            md = mfg_map.get(oi.manufacturing_data_id) if oi.manufacturing_data_id else None
+            ready = False
+            if md is not None and md.status == MfgDataStatus.READY.value and md.file_path:
+                ready = await self._file_storage.exists(md.file_path)
+            if not ready:
+                not_ready.append(oi.id)
+        if not_ready:
+            raise ManufacturingDataNotReadyError(not_ready)

--- a/api/app/services/manufacturing_data_service.py
+++ b/api/app/services/manufacturing_data_service.py
@@ -1,0 +1,236 @@
+"""Manufacturing data generation service.
+
+外部注文(v2)の各明細について製造データをキャッシュ解決し、必要なら illustrator-vm で
+生成して自前ストレージ(FileStorage)へ保存する。バックグラウンドワーカーから利用される。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session_maker
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+from app.models.order import OrderItem
+from app.repositories.manufacturing_data_repository import ManufacturingDataRepository
+from app.repositories.order_repository import OrderRepository
+from app.services.illustrator_vm_client import IllustratorVmClient
+from app.utils.exceptions import ValidationError
+from app.utils.file_storage import BytesUpload, FileStorage, build_file_storage
+from app.utils.mfg_product_mapping import resolve_vm_mapping, select_layers
+
+logger = logging.getLogger(__name__)
+
+_LAYER_DOWNLOAD_TIMEOUT = 60.0
+_MFG_STORAGE_PREFIX = "manufacturing"
+
+
+def is_generatable_item(item: OrderItem) -> bool:
+    """製造データ生成対象の v2 明細か（product_code とレイヤーURLを持つ）."""
+    return bool(item.product_code) and bool(item.source_images)
+
+
+class ManufacturingDataService:
+    """製造データのキャッシュ解決・生成ドライバ（バックグラウンドワーカーから利用）."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        mfg_repo: ManufacturingDataRepository,
+        order_repo: OrderRepository,
+        file_storage: FileStorage,
+        vm_client: IllustratorVmClient | None = None,
+    ) -> None:
+        self._session = session
+        self._mfg_repo = mfg_repo
+        self._order_repo = order_repo
+        self._file_storage = file_storage
+        self._vm_client = vm_client
+
+    async def ensure_for_order(self, order_id: str) -> None:
+        """注文の各 v2 明細について、製造データを解決（キャッシュ）＋必要なら生成する."""
+        order = await self._order_repo.find_by_id(order_id)
+        if order is None:
+            logger.warning("ensure_for_order: order not found: %s", order_id)
+            return
+        if order.order_source_id is None:
+            logger.warning("ensure_for_order: order %s has no order_source", order_id)
+            return
+
+        for item in order.items:
+            if not is_generatable_item(item):
+                continue
+            md = await self._resolve_or_create(order.order_source_id, item)
+            if md is None:
+                continue
+            item.manufacturing_data_id = md.id
+            await self._session.commit()
+            await self._maybe_generate(md)
+
+    async def generate_by_id(self, mfg_data_id: str) -> None:
+        """既存の manufacturing_data 行を（必要なら）生成する（手動リトライのワーカー用）."""
+        md = await self._mfg_repo.get_by_id(mfg_data_id)
+        if md is None:
+            logger.warning("generate_by_id: not found: %s", mfg_data_id)
+            return
+        await self._maybe_generate(md)
+
+    async def _resolve_or_create(
+        self, order_source_id: str, item: OrderItem
+    ) -> ManufacturingData | None:
+        product_code = item.product_code
+        size = item.size
+        if not product_code or not size:
+            return None
+        try:
+            mapping = resolve_vm_mapping(item.product_type, size, item.variant)
+        except ValidationError:
+            logger.exception(
+                "resolve_or_create: unsupported combo product_type=%s size=%s variant=%s",
+                item.product_type,
+                size,
+                item.variant,
+            )
+            return None
+
+        variant = mapping.variant
+        existing = await self._mfg_repo.find_by_cache_key(
+            order_source_id, product_code, size, variant
+        )
+        if existing is not None:
+            return existing
+
+        md = ManufacturingData(
+            order_source_id=order_source_id,
+            product_code=product_code,
+            product_type=item.product_type,
+            size=size,
+            variant=variant,
+            status=MfgDataStatus.PENDING.value,
+            source_images=item.source_images,
+        )
+        try:
+            return await self._mfg_repo.create(md)
+        except IntegrityError:
+            # 別注文が同時に同一キーを作成 → ロールバックして再取得（重複生成防止）
+            await self._session.rollback()
+            return await self._mfg_repo.find_by_cache_key(
+                order_source_id, product_code, size, variant
+            )
+
+    async def _maybe_generate(self, md: ManufacturingData) -> None:
+        # ready かつ保存ファイルが存在 → キャッシュ再利用（VM を呼ばない）
+        if (
+            md.status == MfgDataStatus.READY.value
+            and md.file_path
+            and await self._file_storage.exists(md.file_path)
+        ):
+            return
+        # ready だがファイル消失（GCS 180日ライフサイクル等）→ 再生成を許可
+        allow_ready_stale = md.status == MfgDataStatus.READY.value
+        await self._generate(md, allow_ready_stale=allow_ready_stale)
+
+    async def _generate(self, md: ManufacturingData, *, allow_ready_stale: bool = False) -> None:
+        if self._vm_client is None:
+            logger.info("ILLUSTRATOR_VM_URL 未設定のため製造データ生成をスキップ: %s", md.id)
+            return
+
+        # 原子的に claim（多重生成防止）。claim 失敗＝他ワーカーが処理中 or 既に ready。
+        claimed = await self._mfg_repo.claim_for_generation(md.id, allow_ready=allow_ready_stale)
+        await self._session.commit()
+        if not claimed:
+            return
+        await self._session.refresh(md)
+
+        try:
+            mapping = resolve_vm_mapping(md.product_type, md.size, md.variant)
+            layers = select_layers(md.product_type, md.source_images)
+            layer_bytes = await self._download_layers(layers)
+
+            job_id = await self._vm_client.submit(
+                product_type=md.product_type,
+                vm_size=mapping.vm_size,
+                variant=md.variant,
+                input_mode=mapping.input_mode,
+                order_id=md.product_code,  # VM の order_id は出力ファイル名にしか影響しない
+                layers=layer_bytes,
+            )
+            md.vm_job_id = job_id
+            await self._session.commit()
+
+            final_status = await self._vm_client.wait_for_completion(job_id)
+            content = await self._vm_client.download(job_id)
+            filename = final_status.output_filename or f"{md.product_code}.{mapping.output_format}"
+            path = await self._file_storage.save(
+                BytesUpload(content, filename), prefix=_MFG_STORAGE_PREFIX
+            )
+
+            md.output_filename = filename
+            md.file_path = path
+            md.file_size = len(content)
+            md.status = MfgDataStatus.READY.value
+            md.error_message = None
+            await self._session.commit()
+            logger.info("製造データ生成完了: %s -> %s", md.id, path)
+        except Exception as exc:
+            await self._mark_failed(md.id, exc)
+
+    async def _mark_failed(self, mfg_data_id: str, exc: Exception) -> None:
+        await self._session.rollback()
+        md = await self._mfg_repo.get_by_id(mfg_data_id)
+        if md is not None:
+            md.status = MfgDataStatus.FAILED.value
+            md.error_message = str(exc)[:1000]
+            await self._session.commit()
+        logger.exception("製造データ生成に失敗: %s", mfg_data_id)
+
+    async def _download_layers(self, layers: dict[str, str]) -> dict[str, bytes]:
+        async with httpx.AsyncClient(timeout=_LAYER_DOWNLOAD_TIMEOUT) as client:
+
+            async def fetch(layer_type: str, url: str) -> tuple[str, bytes]:
+                response = await client.get(url)
+                response.raise_for_status()
+                return layer_type, response.content
+
+            results: list[tuple[str, bytes]] = await asyncio.gather(
+                *[fetch(lt, url) for lt, url in layers.items()]
+            )
+        return dict(results)
+
+
+def _build_service(session: AsyncSession) -> ManufacturingDataService:
+    return ManufacturingDataService(
+        session=session,
+        mfg_repo=ManufacturingDataRepository(session),
+        order_repo=OrderRepository(session),
+        file_storage=build_file_storage(),
+        vm_client=IllustratorVmClient.from_settings(),
+    )
+
+
+async def run_ensure_for_order(order_id: str) -> None:
+    """BackgroundTasks 用: 独自セッションで ensure_for_order を実行する."""
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        try:
+            service = _build_service(session)
+            await service.ensure_for_order(order_id)
+        except Exception:
+            logger.exception("run_ensure_for_order failed: %s", order_id)
+            await session.rollback()
+
+
+async def run_generate_manufacturing_data(mfg_data_id: str) -> None:
+    """BackgroundTasks 用: 独自セッションで単一行の生成を実行する（手動リトライ）."""
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        try:
+            service = _build_service(session)
+            await service.generate_by_id(mfg_data_id)
+        except Exception:
+            logger.exception("run_generate_manufacturing_data failed: %s", mfg_data_id)
+            await session.rollback()

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -38,6 +38,7 @@ from app.repositories.order_source_repository import OrderSourceRepository
 from app.repositories.product_repository import ProductRepository
 from app.repositories.shipment_repository import ShipmentRepository
 from app.schemas.order import (
+    CustomerInfo,
     ManufacturingDataInfo,
     OrderBulkStatusUpdateResponse,
     OrderCreate,
@@ -47,6 +48,7 @@ from app.schemas.order import (
     OrderResponse,
     OrderShipmentInfo,
 )
+from app.schemas.order_v2 import OrderCreateV2
 from app.services.estimated_shipping_service import (
     SHIPPING_PREPARATION_DAYS_DEFAULT,
     calculate_estimated_shipping_date,
@@ -61,6 +63,7 @@ from app.utils.exceptions import (
     ProductNotFoundError,
     ValidationError,
 )
+from app.utils.mfg_product_mapping import validate_v2_item
 from app.utils.zip_builder import ZipBuilder
 
 logger = logging.getLogger(__name__)
@@ -122,19 +125,8 @@ class OrderService:
         # ordered_at はアプリケーション側で JST 現在時刻を設定
         jst = ZoneInfo("Asia/Tokyo")
         now_jst = datetime.now(jst)
-        customer = data.customer
-        order = Order(
-            order_number=data.order_number,
-            order_source_id=order_source_id,
-            customer_name=customer.name,
-            customer_postal_code=customer.postal_code,
-            customer_address_prefecture=customer.address_prefecture,
-            customer_address_city=customer.address_city,
-            customer_address_building=customer.address_building,
-            customer_phone=customer.phone,
-            customer_email=customer.email,
-            ordered_at=now_jst,
-            total_price=total_price,
+        order = self._build_order(
+            data.order_number, order_source_id, data.customer, total_price, now_jst
         )
 
         # Create order items with expected_delivery_date
@@ -165,7 +157,112 @@ class OrderService:
             )
             order.items.append(order_item)
 
-        # Calculate estimated_shipping_date
+        return await self._finalize_order(order, company_holidays)
+
+    async def create_v2(
+        self,
+        data: OrderCreateV2,
+        order_source_id: str | None = None,
+    ) -> OrderResponse:
+        """Create an order from external sales site (v2: 製造データ生成の元データ付き).
+
+        v1 の create と異なり、明細は完成データURLではなく元データ(PNGレイヤー)の
+        source_images と product_code / variant を受け取り、製造データ生成に備える。
+        属性検証は VM 契約（mfg_product_mapping）に基づく。
+        """
+        existing = await self._order_repo.find_by_order_number(data.order_number)
+        if existing:
+            raise DuplicateError("Order", "order_number", data.order_number)
+
+        products: dict[int, Product] = {}
+        variants: dict[int, str | None] = {}
+        layers_by_idx: dict[int, list[dict[str, str]]] = {}
+        for idx, item_data in enumerate(data.items):
+            source_images = [
+                {"layer_type": si.layer_type, "url": si.url} for si in item_data.source_images
+            ]
+            # product_type / size / variant / 必須レイヤーを検証し VM マッピングを得る
+            mapping = validate_v2_item(
+                item_data.product_type.value,
+                item_data.size,
+                item_data.variant,
+                source_images,
+            )
+            variants[idx] = mapping.variant
+            layers_by_idx[idx] = source_images
+
+            product = await self._product_repo.find_by_product_type(
+                product_type=item_data.product_type,
+            )
+            if not product:
+                raise ProductNotFoundError(item_data.product_type.value)
+            products[idx] = product
+
+        company_holidays: set[date] | None = None
+        if self._company_holiday_repo:
+            company_holidays = await self._company_holiday_repo.find_all_dates()
+
+        total_price = sum(item.price * item.quantity for item in data.items)
+
+        jst = ZoneInfo("Asia/Tokyo")
+        now_jst = datetime.now(jst)
+        order = self._build_order(
+            data.order_number, order_source_id, data.customer, total_price, now_jst
+        )
+
+        ordered_date = now_jst.date()
+        for idx, item_data in enumerate(data.items):
+            product = products[idx]
+            expected_delivery = add_business_days(
+                ordered_date,
+                product.lead_time_days,
+                company_holidays,
+            )
+            order_item = OrderItem(
+                uid=item_data.uid,
+                product_id=product.id,
+                product_name=item_data.product_name,
+                product_type=item_data.product_type.value,
+                price=item_data.price,
+                quantity=item_data.quantity,
+                size=item_data.size,
+                thumbnail_image_url=item_data.thumbnail_image_url,
+                product_code=item_data.product_code,
+                variant=variants[idx],
+                source_images=layers_by_idx[idx],
+                expected_delivery_date=expected_delivery,
+            )
+            order.items.append(order_item)
+
+        return await self._finalize_order(order, company_holidays)
+
+    def _build_order(
+        self,
+        order_number: str,
+        order_source_id: str | None,
+        customer: CustomerInfo,
+        total_price: int,
+        ordered_at: datetime,
+    ) -> Order:
+        """Order 本体（顧客情報付き）を組み立てる（v1/v2 共通）."""
+        return Order(
+            order_number=order_number,
+            order_source_id=order_source_id,
+            customer_name=customer.name,
+            customer_postal_code=customer.postal_code,
+            customer_address_prefecture=customer.address_prefecture,
+            customer_address_city=customer.address_city,
+            customer_address_building=customer.address_building,
+            customer_phone=customer.phone,
+            customer_email=customer.email,
+            ordered_at=ordered_at,
+            total_price=total_price,
+        )
+
+    async def _finalize_order(
+        self, order: Order, company_holidays: set[date] | None
+    ) -> OrderResponse:
+        """配送予定日を確定し Order を永続化してレスポンスを返す（v1/v2 共通）."""
         shipping_days = SHIPPING_PREPARATION_DAYS_DEFAULT
         if self._app_setting_repo:
             shipping_days = await get_shipping_preparation_days(self._app_setting_repo)
@@ -173,7 +270,6 @@ class OrderService:
         order.estimated_shipping_date = calculate_estimated_shipping_date(
             delivery_dates, shipping_days, company_holidays
         )
-
         order = await self._order_repo.create(order)
         return await self._to_response(order)
 

--- a/api/app/utils/exceptions.py
+++ b/api/app/utils/exceptions.py
@@ -138,9 +138,22 @@ class InvalidStatusTransitionError(AppException):
 class NoOrderedItemsError(AppException):
     """No ordered items available for download error."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             400,
             "NO_ORDERED_ITEMS",
             "ダウンロード対象の発注中明細がありません",
+        )
+
+
+class ManufacturingDataNotReadyError(AppException):
+    """Manufacturing data not ready for the given order items (409)."""
+
+    def __init__(self, order_item_ids: list[str] | None = None) -> None:
+        details = {"order_item_ids": order_item_ids} if order_item_ids else None
+        super().__init__(
+            409,
+            "MANUFACTURING_DATA_NOT_READY",
+            "製造データが未完成の明細があるため発注できません",
+            details,
         )

--- a/api/app/utils/file_storage.py
+++ b/api/app/utils/file_storage.py
@@ -1,9 +1,10 @@
 """File storage utilities."""
 
+import asyncio
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Protocol
+from typing import Any, Protocol, cast
 from uuid import uuid4
 
 import aiofiles
@@ -17,6 +18,39 @@ class UploadFile(Protocol):
 
     def read(self) -> bytes: ...
     def seek(self, offset: int) -> None: ...
+
+
+class BytesUpload:
+    """UploadFile プロトコル互換の bytes ラッパー.
+
+    生成済みの製造データなど、既に手元にある bytes を FileStorage.save() で保存する用。
+    """
+
+    def __init__(self, content: bytes, filename: str | None = None) -> None:
+        self._content = content
+        self.filename = filename
+
+    def read(self) -> bytes:
+        return self._content
+
+    def seek(self, offset: int) -> None:
+        return None
+
+
+def _generate_stored_filename(original_filename: str | None) -> str:
+    """拡張子を保持したユニークな保存ファイル名を生成する。"""
+    ext = os.path.splitext(original_filename)[1] if original_filename else ""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    unique_id = str(uuid4())[:8]
+    return f"{timestamp}_{unique_id}{ext}"
+
+
+async def _read_upload(file: UploadFile) -> bytes:
+    """UploadFile の内容を読む（Starlette の UploadFile.read() は coroutine なので両対応）。"""
+    result: Any = file.read()
+    if hasattr(result, "__await__"):
+        result = await result
+    return cast(bytes, result)
 
 
 class FileStorage(ABC):
@@ -55,14 +89,7 @@ class LocalFileStorage(FileStorage):
 
     def _generate_filename(self, original_filename: str | None) -> str:
         """Generate a unique filename preserving the extension."""
-        if original_filename:
-            _, ext = os.path.splitext(original_filename)
-        else:
-            ext = ""
-
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        unique_id = str(uuid4())[:8]
-        return f"{timestamp}_{unique_id}{ext}"
+        return _generate_stored_filename(original_filename)
 
     async def save(self, file: UploadFile, prefix: str = "") -> str:
         """Save a file and return the relative path."""
@@ -75,10 +102,7 @@ class LocalFileStorage(FileStorage):
         if dir_path:
             os.makedirs(dir_path, exist_ok=True)
 
-        # Read content (handle both sync and async)
-        content = file.read()
-        if hasattr(content, "__await__"):
-            content = await content
+        content = await _read_upload(file)
 
         # Write file
         async with aiofiles.open(full_path, "wb") as f:
@@ -108,3 +132,57 @@ class LocalFileStorage(FileStorage):
         """Check if a file exists."""
         full_path = self._get_full_path(path)
         return await aiofiles.os.path.exists(full_path)
+
+
+class GCSFileStorage(FileStorage):
+    """Google Cloud Storage backend（Cloud Run のディスク揮発を回避し永続保存する）.
+
+    google-cloud-storage は遅延importするため、STORAGE_BACKEND=local の環境では
+    パッケージ未導入でも本モジュールを読み込める。同期SDKは asyncio.to_thread で実行。
+    """
+
+    def __init__(self, bucket_name: str, project: str | None = None) -> None:
+        from google.cloud import storage  # type: ignore[attr-defined]
+
+        self.bucket_name = bucket_name
+        client = storage.Client(project=project) if project else storage.Client()
+        self._bucket = client.bucket(bucket_name)
+
+    async def save(self, file: UploadFile, prefix: str = "") -> str:
+        key = os.path.join(prefix, _generate_stored_filename(file.filename))
+        content = await _read_upload(file)
+        blob = self._bucket.blob(key)
+        await asyncio.to_thread(blob.upload_from_string, content)
+        return key
+
+    async def delete(self, path: str) -> bool:
+        from google.cloud.exceptions import NotFound
+
+        blob = self._bucket.blob(path)
+        try:
+            await asyncio.to_thread(blob.delete)
+            return True
+        except NotFound:
+            return False
+
+    async def get(self, path: str) -> bytes | None:
+        from google.cloud.exceptions import NotFound
+
+        blob = self._bucket.blob(path)
+        try:
+            return cast(bytes, await asyncio.to_thread(blob.download_as_bytes))
+        except NotFound:
+            return None
+
+    async def exists(self, path: str) -> bool:
+        blob = self._bucket.blob(path)
+        return bool(await asyncio.to_thread(blob.exists))
+
+
+def build_file_storage() -> FileStorage:
+    """設定に応じた FileStorage 実装を返す（DI とバックグラウンドワーカー共通のファクトリ）。"""
+    from app.config import settings
+
+    if settings.STORAGE_BACKEND == "gcs" and settings.GCS_BUCKET:
+        return GCSFileStorage(settings.GCS_BUCKET, project=settings.GCS_PROJECT or None)
+    return LocalFileStorage(settings.UPLOAD_DIR)

--- a/api/app/utils/mfg_product_mapping.py
+++ b/api/app/utils/mfg_product_mapping.py
@@ -1,0 +1,213 @@
+"""Product attribute mapping for illustrator-vm manufacturing data generation.
+
+pod-admin の (product_type, size, variant) を illustrator-vm が要求する
+(size id, variant, input_mode, required layers) へ決定的に変換する純粋ロジック。
+対象は5タイプ（tshirt / tote_bag / acrylic_keychain / acrylic_stand / sticker）。
+mug_cup は本Issueのスコープ外。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.utils.exceptions import ValidationError
+
+# レイヤー種別
+LAYER_COLOR = "color"
+LAYER_CUTLINE = "cutline"
+LAYER_WHITE = "white"
+LAYER_DESIGN = "design"
+
+# 単一画像商品で「デザイン」として扱えるレイヤー種別（design を正、color を別名として許容）
+_SINGLE_IMAGE_LAYERS = (LAYER_DESIGN, LAYER_COLOR)
+
+
+@dataclass(frozen=True)
+class _ProductMfgConfig:
+    """商品タイプごとの製造データ生成設定."""
+
+    input_mode: str  # "single" | "multi"
+    sizes: dict[str, str]  # pod-admin size -> VM size id
+    required_layers: tuple[str, ...]
+    optional_layers: tuple[str, ...]
+    allowed_variants: frozenset[str] | None  # None => バリアントなし商品
+    output_format: str  # "ai" | "pdf"
+
+
+_PRODUCT_MFG_CONFIG: dict[str, _ProductMfgConfig] = {
+    "tshirt": _ProductMfgConfig(
+        input_mode="single",
+        sizes={"S": "S", "M": "M", "L": "L", "XL": "XL"},
+        required_layers=(LAYER_DESIGN,),
+        optional_layers=(),
+        allowed_variants=None,
+        output_format="pdf",
+    ),
+    "tote_bag": _ProductMfgConfig(
+        input_mode="single",
+        sizes={"M": "M"},
+        required_layers=(LAYER_DESIGN,),
+        optional_layers=(),
+        allowed_variants=None,
+        output_format="pdf",
+    ),
+    "acrylic_keychain": _ProductMfgConfig(
+        input_mode="multi",
+        sizes={"50x50mm": "50x50", "70x70mm": "70x70", "100x100mm": "100x100"},
+        required_layers=(LAYER_COLOR, LAYER_CUTLINE),
+        optional_layers=(LAYER_WHITE,),
+        allowed_variants=frozenset({"clear", "color"}),
+        output_format="ai",
+    ),
+    "acrylic_stand": _ProductMfgConfig(
+        input_mode="multi",
+        sizes={"50x50mm": "50mm", "70x70mm": "70mm", "100x100mm": "100mm"},
+        required_layers=(LAYER_COLOR, LAYER_CUTLINE),
+        optional_layers=(LAYER_WHITE,),
+        allowed_variants=None,
+        output_format="ai",
+    ),
+    "sticker": _ProductMfgConfig(
+        input_mode="multi",
+        sizes={"50x50mm": "50x50", "70x70mm": "70x70", "100x100mm": "100x100"},
+        required_layers=(LAYER_COLOR, LAYER_CUTLINE),
+        optional_layers=(),
+        allowed_variants=frozenset({"clear"}),
+        output_format="ai",
+    ),
+}
+
+SUPPORTED_PRODUCT_TYPES = frozenset(_PRODUCT_MFG_CONFIG)
+
+
+@dataclass(frozen=True)
+class VmMapping:
+    """illustrator-vm へ渡す製造データ生成パラメータ."""
+
+    product_type: str
+    vm_size: str
+    variant: str | None
+    input_mode: str
+    required_layers: tuple[str, ...]
+    optional_layers: tuple[str, ...]
+    output_format: str
+
+
+def _get_config(product_type: str) -> _ProductMfgConfig:
+    config = _PRODUCT_MFG_CONFIG.get(product_type)
+    if config is None:
+        supported = ", ".join(sorted(_PRODUCT_MFG_CONFIG))
+        raise ValidationError(
+            f"product_type '{product_type}' は製造データ生成の対象外です（対象: {supported}）。"
+        )
+    return config
+
+
+def is_supported(product_type: str) -> bool:
+    """製造データ生成の対象商品タイプかどうか."""
+    return product_type in _PRODUCT_MFG_CONFIG
+
+
+def normalize_variant(product_type: str, variant: str | None) -> str | None:
+    """キャッシュキー / VM 用に variant を正規化・検証する.
+
+    - バリアント必須商品（keychain / sticker）: 許可値でなければ ValidationError。
+    - バリアントなし商品（tshirt / tote_bag / acrylic_stand）: 常に None（送られても無視）。
+    """
+    config = _get_config(product_type)
+    if config.allowed_variants is None:
+        return None
+    normalized = (variant or "").strip()
+    if normalized not in config.allowed_variants:
+        allowed = ", ".join(sorted(config.allowed_variants))
+        raise ValidationError(
+            f"product_type '{product_type}' には variant が必須です"
+            f"（許可値: {allowed}）。受信値: {variant!r}"
+        )
+    return normalized
+
+
+def resolve_vm_mapping(product_type: str, size: str | None, variant: str | None) -> VmMapping:
+    """(product_type, size, variant) を VM パラメータへ変換する。不正な組合せは ValidationError。"""
+    config = _get_config(product_type)
+
+    size_key = (size or "").strip()
+    vm_size = config.sizes.get(size_key)
+    if vm_size is None:
+        allowed = ", ".join(config.sizes)
+        raise ValidationError(
+            f"product_type '{product_type}' の size '{size}' は未対応です（許可値: {allowed}）。"
+        )
+
+    normalized_variant = normalize_variant(product_type, variant)
+
+    return VmMapping(
+        product_type=product_type,
+        vm_size=vm_size,
+        variant=normalized_variant,
+        input_mode=config.input_mode,
+        required_layers=config.required_layers,
+        optional_layers=config.optional_layers,
+        output_format=config.output_format,
+    )
+
+
+def select_layers(product_type: str, source_images: list[dict[str, str]] | None) -> dict[str, str]:
+    """source_images から VM に渡す「レイヤー種別 -> URL」辞書を組み立て・検証する。
+
+    - single 商品: design（無ければ color を別名として使用）1枚を {"design": url} で返す。
+    - multi 商品: required 全て（＋あれば optional）を {layer_type: url} で返す。
+    不足・未対応レイヤーがあれば ValidationError。
+    """
+    config = _get_config(product_type)
+    images = source_images or []
+
+    by_type: dict[str, str] = {}
+    for entry in images:
+        layer_type = (entry.get("layer_type") or "").strip()
+        url = (entry.get("url") or "").strip()
+        if layer_type and url:
+            by_type[layer_type] = url
+
+    if config.input_mode == "single":
+        for candidate in _SINGLE_IMAGE_LAYERS:
+            if candidate in by_type:
+                return {LAYER_DESIGN: by_type[candidate]}
+        raise ValidationError(
+            f"product_type '{product_type}' には元画像"
+            f"（{' または '.join(_SINGLE_IMAGE_LAYERS)}）が1枚必要です。"
+        )
+
+    valid_layers = set(config.required_layers) | set(config.optional_layers)
+    unknown = set(by_type) - valid_layers
+    if unknown:
+        raise ValidationError(
+            f"product_type '{product_type}' に未対応のレイヤーが含まれています: "
+            f"{', '.join(sorted(unknown))}"
+        )
+    missing = [layer for layer in config.required_layers if layer not in by_type]
+    if missing:
+        raise ValidationError(
+            f"product_type '{product_type}' に必要なレイヤーが不足しています: {', '.join(missing)}"
+        )
+
+    selected = {layer: by_type[layer] for layer in config.required_layers}
+    for layer in config.optional_layers:
+        if layer in by_type:
+            selected[layer] = by_type[layer]
+    return selected
+
+
+def validate_v2_item(
+    product_type: str,
+    size: str | None,
+    variant: str | None,
+    source_images: list[dict[str, str]] | None,
+) -> VmMapping:
+    """v2 明細の製造データ生成可能性を検証し、VM マッピングを返す（intake で使用）。
+
+    product_type / size / variant / 必須レイヤーのいずれかが不正なら ValidationError。
+    """
+    mapping = resolve_vm_mapping(product_type, size, variant)
+    select_layers(product_type, source_images)  # レイヤー検証（不正時に例外送出）
+    return mapping

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "sendgrid>=6.11.0",
     # Japanese holidays
     "jpholiday>=0.1.9",
+    "google-cloud-storage>=3.12.0",
 ]
 
 [project.optional-dependencies]

--- a/api/tests/integration/test_manufacturing_data_endpoints.py
+++ b/api/tests/integration/test_manufacturing_data_endpoints.py
@@ -1,0 +1,55 @@
+"""Integration tests for manufacturing-data status/retry endpoints (admin)."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+
+
+async def _make_md(db_session: AsyncSession, source_id: str, status: str) -> ManufacturingData:
+    md = ManufacturingData(
+        order_source_id=source_id,
+        product_code=f"PC-{uuid4().hex[:8]}",
+        product_type="acrylic_keychain",
+        size="50x50mm",
+        variant="clear",
+        status=status,
+        error_message="prev error" if status == MfgDataStatus.FAILED.value else None,
+    )
+    db_session.add(md)
+    await db_session.commit()
+    return md
+
+
+class TestManufacturingDataEndpoints:
+    @pytest.mark.asyncio
+    async def test_list_requires_admin(self, client):
+        resp = await client.get("/api/v1/manufacturing-data")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_list_returns_rows(self, client, db_session, auth_headers, test_order_source):
+        await _make_md(db_session, test_order_source["id"], MfgDataStatus.PENDING.value)
+        resp = await client.get("/api/v1/manufacturing-data?limit=10", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "items" in body
+        assert body["total"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_retry_resets_failed_to_pending(
+        self, client, db_session, auth_headers, test_order_source
+    ):
+        md = await _make_md(db_session, test_order_source["id"], MfgDataStatus.FAILED.value)
+        resp = await client.post(f"/api/v1/manufacturing-data/{md.id}/retry", headers=auth_headers)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_retry_404_for_unknown(self, client, auth_headers):
+        resp = await client.post(
+            f"/api/v1/manufacturing-data/{uuid4()}/retry", headers=auth_headers
+        )
+        assert resp.status_code == 404

--- a/api/tests/integration/test_manufacturing_data_repository.py
+++ b/api/tests/integration/test_manufacturing_data_repository.py
@@ -1,0 +1,50 @@
+"""Integration tests for ManufacturingDataRepository (cache key + NULLS NOT DISTINCT)."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+from app.repositories.manufacturing_data_repository import ManufacturingDataRepository
+
+
+def _md(order_source_id, *, product_code="PC", size="50x50mm", variant=None):
+    return ManufacturingData(
+        order_source_id=order_source_id,
+        product_code=product_code,
+        product_type="acrylic_keychain",
+        size=size,
+        variant=variant,
+        status=MfgDataStatus.PENDING.value,
+    )
+
+
+class TestCacheKey:
+    @pytest.mark.asyncio
+    async def test_find_by_cache_key_null_variant(self, db_session, test_order_source):
+        repo = ManufacturingDataRepository(db_session)
+        src = test_order_source["id"]
+        created = await repo.create(_md(src, product_code="PC-NULL", variant=None))
+        found = await repo.find_by_cache_key(src, "PC-NULL", "50x50mm", None)
+        assert found is not None
+        assert found.id == created.id
+
+    @pytest.mark.asyncio
+    async def test_find_by_cache_key_distinguishes_variant(self, db_session, test_order_source):
+        repo = ManufacturingDataRepository(db_session)
+        src = test_order_source["id"]
+        clear = await repo.create(_md(src, product_code="PC-VAR", variant="clear"))
+        color = await repo.create(_md(src, product_code="PC-VAR", variant="color"))
+
+        found_clear = await repo.find_by_cache_key(src, "PC-VAR", "50x50mm", "clear")
+        found_color = await repo.find_by_cache_key(src, "PC-VAR", "50x50mm", "color")
+        assert found_clear is not None and found_clear.id == clear.id
+        assert found_color is not None and found_color.id == color.id
+
+    @pytest.mark.asyncio
+    async def test_null_variant_second_insert_conflicts(self, db_session, test_order_source):
+        # NULLS NOT DISTINCT: 同一(source, code, size)で variant=NULL の2行目は一意制約違反
+        repo = ManufacturingDataRepository(db_session)
+        src = test_order_source["id"]
+        await repo.create(_md(src, product_code="PC-DUP", variant=None))
+        with pytest.raises(IntegrityError):
+            await repo.create(_md(src, product_code="PC-DUP", variant=None))

--- a/api/tests/integration/test_orders_v2_intake.py
+++ b/api/tests/integration/test_orders_v2_intake.py
@@ -1,0 +1,166 @@
+"""Integration test for POST /api/v2/orders (v2 intake + manufacturing_data auto-create)."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.manufacturer import Manufacturer
+from app.models.order_source import OrderSource
+from app.models.product import Product
+
+
+def _digits7() -> str:
+    return str(uuid4().int % 10_000_000).zfill(7)
+
+
+@pytest.fixture
+async def v2_setup(db_session: AsyncSession):
+    """acrylic_keychain の商品マスタ＋API Key付き受注元を用意する。
+
+    products は (product_type, size, position, color) に一意制約があり、DBは追加的
+    （テスト間でクリーンアップしない）ため、既存の acrylic_keychain 商品があれば再利用する。
+    """
+    existing_product = (
+        await db_session.execute(
+            text("SELECT id FROM products WHERE product_type = 'acrylic_keychain' LIMIT 1")
+        )
+    ).fetchone()
+    if existing_product is None:
+        manufacturer = Manufacturer(
+            name=f"MFR {uuid4().hex[:8]}",
+            email=f"mfr-{uuid4().hex[:8]}@example.com",
+            supported_products=["acrylic_keychain"],
+            unit_prices={},
+            lead_time_days=3,
+            daily_order_limit=100,
+            sharing_method="portal",
+            is_active=True,
+        )
+        db_session.add(manufacturer)
+        await db_session.flush()
+        db_session.add(
+            Product(
+                product_type="acrylic_keychain",
+                size="50x50mm",
+                manufacturer_id=manufacturer.id,
+                cost=500,
+                lead_time_days=3,
+                is_active=True,
+            )
+        )
+
+    api_key = f"v2-key-{uuid4().hex}"
+    source = OrderSource(
+        code=f"V2SRC{uuid4().hex[:8].upper()}",
+        api_key=api_key,
+        name="V2 Source",
+        phone="090-1111-2222",
+        postal_code="100-0001",
+        address_prefecture="東京都",
+        address_city="千代田区",
+        is_active=True,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    return {"api_key": api_key}
+
+
+class TestV2Intake:
+    @pytest.mark.asyncio
+    async def test_v2_order_persists_fields_and_creates_manufacturing_data(
+        self, client, db_session: AsyncSession, v2_setup: dict
+    ):
+        order_number = _digits7()
+        payload = {
+            "order_number": order_number,
+            "customer": {
+                "name": "山田太郎",
+                "postal_code": "100-0001",
+                "address_prefecture": "東京都",
+                "address_city": "千代田区1-1",
+                "phone": "090-0000-0000",
+            },
+            "items": [
+                {
+                    "uid": _digits7(),
+                    "product_type": "acrylic_keychain",
+                    "product_name": "キーホルダー",
+                    "price": 1200,
+                    "quantity": 2,
+                    "size": "50x50mm",
+                    "variant": "clear",
+                    "product_code": f"PC-{uuid4().hex[:8]}",
+                    "source_images": [
+                        {"layer_type": "color", "url": "http://example.com/c.png"},
+                        {"layer_type": "cutline", "url": "http://example.com/l.png"},
+                    ],
+                }
+            ],
+        }
+        resp = await client.post(
+            "/api/v2/orders", json=payload, headers={"X-API-Key": v2_setup["api_key"]}
+        )
+        assert resp.status_code == 201, resp.text
+        order_id = resp.json()["id"]
+
+        # OrderItem に v2 フィールドが永続化されている
+        row = (
+            await db_session.execute(
+                text(
+                    "SELECT product_code, variant, source_images, manufacturing_data_id "
+                    "FROM order_items WHERE order_id = :oid"
+                ),
+                {"oid": order_id},
+            )
+        ).fetchone()
+        assert row is not None
+        assert row.product_code.startswith("PC-")
+        assert row.variant == "clear"
+        assert isinstance(row.source_images, list) and len(row.source_images) == 2
+
+        # 受付後の BackgroundTasks で manufacturing_data(pending) が作成・紐付けされている
+        assert row.manufacturing_data_id is not None
+        md = (
+            await db_session.execute(
+                text("SELECT status FROM manufacturing_data WHERE id = :id"),
+                {"id": row.manufacturing_data_id},
+            )
+        ).fetchone()
+        assert md is not None
+        # ILLUSTRATOR_VM_URL 未設定なので生成は走らず pending のまま
+        assert md.status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_v2_order_missing_variant_rejected(self, client, v2_setup: dict):
+        payload = {
+            "order_number": _digits7(),
+            "customer": {
+                "name": "山田太郎",
+                "postal_code": "100-0001",
+                "address_prefecture": "東京都",
+                "address_city": "千代田区1-1",
+                "phone": "090-0000-0000",
+            },
+            "items": [
+                {
+                    "uid": _digits7(),
+                    "product_type": "acrylic_keychain",
+                    "product_name": "キーホルダー",
+                    "price": 1200,
+                    "quantity": 1,
+                    "size": "50x50mm",
+                    # variant 未指定 → keychain は必須 → 400
+                    "product_code": f"PC-{uuid4().hex[:8]}",
+                    "source_images": [
+                        {"layer_type": "color", "url": "http://example.com/c.png"},
+                        {"layer_type": "cutline", "url": "http://example.com/l.png"},
+                    ],
+                }
+            ],
+        }
+        resp = await client.post(
+            "/api/v2/orders", json=payload, headers={"X-API-Key": v2_setup["api_key"]}
+        )
+        assert resp.status_code == 400, resp.text

--- a/api/tests/unit/test_gcs_file_storage.py
+++ b/api/tests/unit/test_gcs_file_storage.py
@@ -1,0 +1,78 @@
+"""Unit tests for GCSFileStorage and build_file_storage (google-cloud-storage mocked)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utils.file_storage import (
+    BytesUpload,
+    GCSFileStorage,
+    LocalFileStorage,
+    build_file_storage,
+)
+
+
+def _mock_client():
+    """Return (client_mock, blob_mock) wired as Client().bucket().blob()."""
+    blob = MagicMock()
+    bucket = MagicMock()
+    bucket.blob.return_value = blob
+    client = MagicMock()
+    client.bucket.return_value = bucket
+    return client, blob
+
+
+class TestGCSFileStorage:
+    @pytest.mark.asyncio
+    async def test_save_uploads_and_returns_key(self):
+        client, blob = _mock_client()
+        with patch("google.cloud.storage.Client", return_value=client):
+            storage = GCSFileStorage("my-bucket")
+            key = await storage.save(BytesUpload(b"AIDATA", "out.ai"), prefix="manufacturing")
+        assert key.startswith("manufacturing/")
+        assert key.endswith(".ai")
+        blob.upload_from_string.assert_called_once_with(b"AIDATA")
+
+    @pytest.mark.asyncio
+    async def test_get_returns_bytes(self):
+        client, blob = _mock_client()
+        blob.download_as_bytes.return_value = b"CONTENT"
+        with patch("google.cloud.storage.Client", return_value=client):
+            storage = GCSFileStorage("my-bucket")
+            data = await storage.get("manufacturing/x.ai")
+        assert data == b"CONTENT"
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self):
+        from google.cloud.exceptions import NotFound
+
+        client, blob = _mock_client()
+        blob.download_as_bytes.side_effect = NotFound("missing")
+        with patch("google.cloud.storage.Client", return_value=client):
+            storage = GCSFileStorage("my-bucket")
+            data = await storage.get("manufacturing/x.ai")
+        assert data is None
+
+    @pytest.mark.asyncio
+    async def test_exists_true(self):
+        client, blob = _mock_client()
+        blob.exists.return_value = True
+        with patch("google.cloud.storage.Client", return_value=client):
+            storage = GCSFileStorage("my-bucket")
+            assert await storage.exists("manufacturing/x.ai") is True
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_returns_false(self):
+        from google.cloud.exceptions import NotFound
+
+        client, blob = _mock_client()
+        blob.delete.side_effect = NotFound("missing")
+        with patch("google.cloud.storage.Client", return_value=client):
+            storage = GCSFileStorage("my-bucket")
+            assert await storage.delete("manufacturing/x.ai") is False
+
+
+class TestBuildFileStorage:
+    def test_local_by_default(self):
+        # 既定 settings は STORAGE_BACKEND=local
+        assert isinstance(build_file_storage(), LocalFileStorage)

--- a/api/tests/unit/test_illustrator_vm_client.py
+++ b/api/tests/unit/test_illustrator_vm_client.py
@@ -1,0 +1,170 @@
+"""Unit tests for IllustratorVmClient (httpx mocked)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.illustrator_vm_client import IllustratorVmClient, IllustratorVmError
+
+_PATCH = "app.services.illustrator_vm_client.httpx.AsyncClient"
+
+
+def _resp(status_code, *, json_body=None, content=b""):
+    r = MagicMock()
+    r.status_code = status_code
+    r.content = content
+    r.text = ""
+    if json_body is not None:
+        r.json.return_value = json_body
+    else:
+        r.json.side_effect = ValueError("no json")
+    return r
+
+
+def _client_mock(*, response=None, responses=None):
+    inst = AsyncMock()
+    if responses is not None:
+        inst.request.side_effect = responses
+    else:
+        inst.request.return_value = response
+    inst.__aenter__ = AsyncMock(return_value=inst)
+    inst.__aexit__ = AsyncMock(return_value=False)
+    return inst
+
+
+class TestSubmit:
+    @pytest.mark.asyncio
+    async def test_multi_image_payload(self):
+        inst = _client_mock(response=_resp(202, json_body={"job_id": "job-1"}))
+        client = IllustratorVmClient("http://vm:8000", poll_interval=0)
+        with patch(_PATCH, return_value=inst):
+            job_id = await client.submit(
+                product_type="acrylic_keychain",
+                vm_size="50x50",
+                variant="clear",
+                input_mode="multi",
+                order_id="ORDER1",
+                layers={"color": b"c", "cutline": b"l"},
+            )
+        assert job_id == "job-1"
+        body = inst.request.call_args.kwargs["json"]
+        assert body["size"] == "50x50"
+        assert body["variant"] == "clear"
+        assert {i["type"] for i in body["images"]} == {"color", "cutline"}
+
+    @pytest.mark.asyncio
+    async def test_single_image_payload(self):
+        inst = _client_mock(response=_resp(202, json_body={"job_id": "job-2"}))
+        client = IllustratorVmClient("http://vm:8000", poll_interval=0)
+        with patch(_PATCH, return_value=inst):
+            job_id = await client.submit(
+                product_type="tshirt",
+                vm_size="M",
+                variant=None,
+                input_mode="single",
+                order_id="O1",
+                layers={"design": b"d"},
+            )
+        assert job_id == "job-2"
+        body = inst.request.call_args.kwargs["json"]
+        assert "image_data" in body
+        assert "images" not in body
+        assert "variant" not in body
+
+    @pytest.mark.asyncio
+    async def test_4xx_raises_with_detail(self):
+        inst = _client_mock(response=_resp(400, json_body={"detail": "bad size"}))
+        client = IllustratorVmClient("http://vm:8000", poll_interval=0, max_retries=0)
+        with patch(_PATCH, return_value=inst):
+            with pytest.raises(IllustratorVmError) as exc:
+                await client.submit(
+                    product_type="tshirt",
+                    vm_size="M",
+                    variant=None,
+                    input_mode="single",
+                    order_id="O1",
+                    layers={"design": b"d"},
+                )
+        assert "bad size" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_503_retries_then_succeeds(self):
+        inst = _client_mock(
+            responses=[
+                _resp(503, json_body={"detail": "busy"}),
+                _resp(202, json_body={"job_id": "job-3"}),
+            ]
+        )
+        client = IllustratorVmClient("http://vm:8000", poll_interval=0, max_retries=2)
+        with patch(_PATCH, return_value=inst):
+            job_id = await client.submit(
+                product_type="tshirt",
+                vm_size="M",
+                variant=None,
+                input_mode="single",
+                order_id="O1",
+                layers={"design": b"d"},
+            )
+        assert job_id == "job-3"
+        assert inst.request.call_count == 2
+
+
+class TestStatusDownloadWait:
+    @pytest.mark.asyncio
+    async def test_get_status_parses(self):
+        inst = _client_mock(
+            response=_resp(
+                200,
+                json_body={
+                    "job_id": "j",
+                    "status": "completed",
+                    "progress": 100,
+                    "message": "ok",
+                    "output_filename": "OUT.ai",
+                },
+            )
+        )
+        client = IllustratorVmClient("http://vm:8000", poll_interval=0)
+        with patch(_PATCH, return_value=inst):
+            st = await client.get_status("j")
+        assert st.is_completed
+        assert st.output_filename == "OUT.ai"
+
+    @pytest.mark.asyncio
+    async def test_download_returns_bytes(self):
+        inst = _client_mock(response=_resp(200, content=b"AIDATA"))
+        client = IllustratorVmClient("http://vm:8000", poll_interval=0)
+        with patch(_PATCH, return_value=inst):
+            assert await client.download("j") == b"AIDATA"
+
+    @pytest.mark.asyncio
+    async def test_wait_polls_until_completed(self):
+        inst = _client_mock(
+            responses=[
+                _resp(200, json_body={"status": "processing", "progress": 50}),
+                _resp(
+                    200,
+                    json_body={"status": "completed", "progress": 100, "output_filename": "O.ai"},
+                ),
+            ]
+        )
+        client = IllustratorVmClient("http://vm:8000", poll_interval=0, poll_timeout=1)
+        with patch(_PATCH, return_value=inst):
+            st = await client.wait_for_completion("j")
+        assert st.is_completed
+        assert inst.request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_failed_raises(self):
+        inst = _client_mock(response=_resp(200, json_body={"status": "failed", "message": "boom"}))
+        client = IllustratorVmClient("http://vm:8000", poll_interval=0, poll_timeout=1)
+        with patch(_PATCH, return_value=inst):
+            with pytest.raises(IllustratorVmError) as exc:
+                await client.wait_for_completion("j")
+        assert "boom" in str(exc.value)
+
+
+class TestFromSettings:
+    def test_returns_none_when_unset(self):
+        # .env の ILLUSTRATOR_VM_URL は未設定 → None（生成機能オフ）
+        assert IllustratorVmClient.from_settings() is None

--- a/api/tests/unit/test_manufacturer_order_gate.py
+++ b/api/tests/unit/test_manufacturer_order_gate.py
@@ -1,0 +1,127 @@
+"""Unit tests for the manufacturer order gate (manufacturing-data readiness)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models.manufacturing_data import MfgDataStatus
+from app.schemas.manufacturer import ManufacturerOrderStatusUpdate
+from app.services.manufacturer_order_service import ManufacturerOrderService
+from app.utils.exceptions import ManufacturingDataNotReadyError
+
+
+def _md(status=MfgDataStatus.READY.value, file_path="path", md_id="md-1"):
+    return SimpleNamespace(id=md_id, status=status, file_path=file_path)
+
+
+def _oi(oi_id="oi-1", product_code="PC", manufacturing_data_id="md-1"):
+    return SimpleNamespace(
+        id=oi_id, product_code=product_code, manufacturing_data_id=manufacturing_data_id
+    )
+
+
+def _row(order_item, item_status="ordered"):
+    # (order_item, order_number, ordered_at, customer_name, cost, item_status, order_status, lead)
+    return (order_item, "0000001", None, "cust", 100, item_status, "ordered", 3)
+
+
+def _service(mfg_repo=None, file_storage=None, order_repo=None, manufacturer_repo=None):
+    return ManufacturerOrderService(
+        order_repo or AsyncMock(),
+        manufacturer_repo or AsyncMock(),
+        AsyncMock(),
+        mfg_repo,
+        file_storage,
+    )
+
+
+class TestPartitionByReadiness:
+    @pytest.mark.asyncio
+    async def test_gate_inactive_includes_all(self):
+        svc = _service()  # mfg_repo / file_storage 未設定 → ゲート無効
+        includable, held, content = await svc._partition_by_readiness([_row(_oi())])
+        assert len(includable) == 1
+        assert held == 0
+        assert content == {}
+
+    @pytest.mark.asyncio
+    async def test_legacy_item_always_included(self):
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_ids.return_value = []
+        svc = _service(mfg_repo, AsyncMock())
+        legacy = _oi(oi_id="leg", product_code=None, manufacturing_data_id=None)
+        includable, held, _ = await svc._partition_by_readiness([_row(legacy)])
+        assert len(includable) == 1
+        assert held == 0
+
+    @pytest.mark.asyncio
+    async def test_ready_v2_included_with_stored_content(self):
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_ids.return_value = [_md()]
+        fs = AsyncMock()
+        fs.get.return_value = b"AIDATA"
+        svc = _service(mfg_repo, fs)
+        includable, held, content = await svc._partition_by_readiness([_row(_oi())])
+        assert len(includable) == 1
+        assert held == 0
+        assert content["oi-1"] == b"AIDATA"
+
+    @pytest.mark.asyncio
+    async def test_not_ready_v2_is_held(self):
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_ids.return_value = [_md(status=MfgDataStatus.PENDING.value)]
+        svc = _service(mfg_repo, AsyncMock())
+        includable, held, _ = await svc._partition_by_readiness([_row(_oi())])
+        assert includable == []
+        assert held == 1
+
+    @pytest.mark.asyncio
+    async def test_ready_but_file_missing_is_held(self):
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_ids.return_value = [_md()]
+        fs = AsyncMock()
+        fs.get.return_value = None  # GCS 180日ライフサイクル等でファイル消失
+        svc = _service(mfg_repo, fs)
+        includable, held, _ = await svc._partition_by_readiness([_row(_oi())])
+        assert includable == []
+        assert held == 1
+
+
+class TestAssertManufacturingReady:
+    @pytest.mark.asyncio
+    async def test_raises_when_not_ready(self):
+        order_repo = AsyncMock()
+        order_repo.find_manufacturer_items.return_value = [_oi()]
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_ids.return_value = [_md(status=MfgDataStatus.FAILED.value)]
+        svc = _service(mfg_repo, AsyncMock(), order_repo)
+        with pytest.raises(ManufacturingDataNotReadyError):
+            await svc._assert_manufacturing_ready("mfr-1", None)
+
+    @pytest.mark.asyncio
+    async def test_passes_when_ready(self):
+        order_repo = AsyncMock()
+        order_repo.find_manufacturer_items.return_value = [_oi()]
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_ids.return_value = [_md()]
+        fs = AsyncMock()
+        fs.exists.return_value = True
+        svc = _service(mfg_repo, fs, order_repo)
+        await svc._assert_manufacturing_ready("mfr-1", None)  # 例外が出なければOK
+
+    @pytest.mark.asyncio
+    async def test_update_order_status_rejects_not_ready(self):
+        order_repo = AsyncMock()
+        order_repo.find_manufacturer_items.return_value = [_oi()]
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_ids.return_value = [_md(status=MfgDataStatus.PENDING.value)]
+        manufacturer_repo = AsyncMock()
+        manufacturer_repo.find_by_id.return_value = SimpleNamespace(id="mfr-1", name="M")
+        svc = ManufacturerOrderService(
+            order_repo, manufacturer_repo, AsyncMock(), mfg_repo, AsyncMock()
+        )
+        data = ManufacturerOrderStatusUpdate(status="manufacturing", order_item_ids=None, note=None)
+        with pytest.raises(ManufacturingDataNotReadyError):
+            await svc.update_order_status("mfr-1", data)
+        order_repo.update_item_status_by_manufacturer.assert_not_awaited()

--- a/api/tests/unit/test_manufacturing_data_service.py
+++ b/api/tests/unit/test_manufacturing_data_service.py
@@ -1,0 +1,211 @@
+"""Unit tests for ManufacturingDataService (repos / VM / storage / session mocked)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+from app.services.illustrator_vm_client import IllustratorVmError, VmJobStatus
+from app.services.manufacturing_data_service import (
+    ManufacturingDataService,
+    is_generatable_item,
+)
+
+_HTTPX = "app.services.manufacturing_data_service.httpx.AsyncClient"
+
+_LAYERS = [
+    {"layer_type": "color", "url": "http://x/c.png"},
+    {"layer_type": "cutline", "url": "http://x/l.png"},
+]
+
+
+def _md(**overrides):
+    md = ManufacturingData(
+        order_source_id="src",
+        product_code="PC",
+        product_type="acrylic_keychain",
+        size="50x50mm",
+        variant="clear",
+        status=MfgDataStatus.PENDING.value,
+        source_images=_LAYERS,
+    )
+    md.id = "md-1"
+    md.attempts = 0
+    md.file_path = None
+    for key, value in overrides.items():
+        setattr(md, key, value)
+    return md
+
+
+def _item(**overrides):
+    data = {
+        "product_code": "PC",
+        "source_images": _LAYERS,
+        "product_type": "acrylic_keychain",
+        "size": "50x50mm",
+        "variant": "clear",
+        "order_id": "ORDER1",
+        "manufacturing_data_id": None,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def _httpx_mock():
+    resp = MagicMock()
+    resp.content = b"png"
+    resp.raise_for_status = MagicMock()
+    inst = AsyncMock()
+    inst.get.return_value = resp
+    inst.__aenter__ = AsyncMock(return_value=inst)
+    inst.__aexit__ = AsyncMock(return_value=False)
+    return inst
+
+
+def _service(*, mfg_repo, order_repo=None, file_storage=None, vm_client=None):
+    session = AsyncMock()
+    service = ManufacturingDataService(
+        session,
+        mfg_repo,
+        order_repo or AsyncMock(),
+        file_storage or AsyncMock(),
+        vm_client,
+    )
+    return service, session
+
+
+class TestIsGeneratableItem:
+    def test_true_when_product_code_and_layers(self):
+        assert is_generatable_item(_item()) is True
+
+    def test_false_without_product_code_or_layers(self):
+        assert is_generatable_item(_item(product_code=None)) is False
+        assert is_generatable_item(_item(source_images=None)) is False
+
+
+class TestEnsureForOrder:
+    @pytest.mark.asyncio
+    async def test_generates_on_cache_miss(self):
+        md = _md()
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_cache_key.return_value = None
+        mfg_repo.create.return_value = md
+        mfg_repo.claim_for_generation.return_value = True
+        order = SimpleNamespace(order_source_id="src", items=[_item()])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+        file_storage = AsyncMock()
+        file_storage.save.return_value = "manufacturing/out.ai"
+        vm = AsyncMock()
+        vm.submit.return_value = "job1"
+        vm.wait_for_completion.return_value = VmJobStatus("job1", "completed", 100, None, "OUT.ai")
+        vm.download.return_value = b"AIDATA"
+
+        service, _ = _service(
+            mfg_repo=mfg_repo, order_repo=order_repo, file_storage=file_storage, vm_client=vm
+        )
+        with patch(_HTTPX, return_value=_httpx_mock()):
+            await service.ensure_for_order("order-1")
+
+        assert md.status == MfgDataStatus.READY.value
+        assert md.file_path == "manufacturing/out.ai"
+        assert md.output_filename == "OUT.ai"
+        assert md.file_size == len(b"AIDATA")
+        vm.submit.assert_awaited_once()
+        file_storage.save.assert_awaited_once()
+        assert order.items[0].manufacturing_data_id == "md-1"
+
+    @pytest.mark.asyncio
+    async def test_reuses_ready_cache_without_calling_vm(self):
+        md = _md(status=MfgDataStatus.READY.value, file_path="manufacturing/exist.ai")
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_cache_key.return_value = md
+        order = SimpleNamespace(order_source_id="src", items=[_item()])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+        file_storage = AsyncMock()
+        file_storage.exists.return_value = True
+        vm = AsyncMock()
+
+        service, _ = _service(
+            mfg_repo=mfg_repo, order_repo=order_repo, file_storage=file_storage, vm_client=vm
+        )
+        await service.ensure_for_order("order-1")
+
+        vm.submit.assert_not_awaited()
+        mfg_repo.create.assert_not_awaited()
+        file_storage.exists.assert_awaited_once_with("manufacturing/exist.ai")
+
+    @pytest.mark.asyncio
+    async def test_regenerates_ready_when_file_missing(self):
+        md = _md(status=MfgDataStatus.READY.value, file_path="manufacturing/gone.ai")
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_cache_key.return_value = md
+        mfg_repo.claim_for_generation.return_value = True
+        order = SimpleNamespace(order_source_id="src", items=[_item()])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+        file_storage = AsyncMock()
+        file_storage.exists.return_value = False  # ファイル消失
+        file_storage.save.return_value = "manufacturing/new.ai"
+        vm = AsyncMock()
+        vm.submit.return_value = "job2"
+        vm.wait_for_completion.return_value = VmJobStatus("job2", "completed", 100, None, "NEW.ai")
+        vm.download.return_value = b"NEW"
+
+        service, _ = _service(
+            mfg_repo=mfg_repo, order_repo=order_repo, file_storage=file_storage, vm_client=vm
+        )
+        with patch(_HTTPX, return_value=_httpx_mock()):
+            await service.ensure_for_order("order-1")
+
+        mfg_repo.claim_for_generation.assert_awaited_once_with("md-1", allow_ready=True)
+        vm.submit.assert_awaited_once()
+        assert md.file_path == "manufacturing/new.ai"
+
+    @pytest.mark.asyncio
+    async def test_generation_failure_marks_failed(self):
+        md = _md()
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_cache_key.return_value = None
+        mfg_repo.create.return_value = md
+        mfg_repo.claim_for_generation.return_value = True
+        mfg_repo.get_by_id.return_value = md
+        order = SimpleNamespace(order_source_id="src", items=[_item()])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+        vm = AsyncMock()
+        vm.submit.side_effect = IllustratorVmError("boom")
+
+        service, _ = _service(mfg_repo=mfg_repo, order_repo=order_repo, vm_client=vm)
+        with patch(_HTTPX, return_value=_httpx_mock()):
+            await service.ensure_for_order("order-1")
+
+        assert md.status == MfgDataStatus.FAILED.value
+        assert "boom" in (md.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_vm_unconfigured_leaves_pending(self):
+        md = _md()
+        mfg_repo = AsyncMock()
+        mfg_repo.find_by_cache_key.return_value = None
+        mfg_repo.create.return_value = md
+        order = SimpleNamespace(order_source_id="src", items=[_item()])
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = order
+
+        service, _ = _service(mfg_repo=mfg_repo, order_repo=order_repo, vm_client=None)
+        await service.ensure_for_order("order-1")
+
+        assert md.status == MfgDataStatus.PENDING.value
+        mfg_repo.claim_for_generation.assert_not_awaited()
+
+
+class TestGenerateById:
+    @pytest.mark.asyncio
+    async def test_missing_row_is_noop(self):
+        mfg_repo = AsyncMock()
+        mfg_repo.get_by_id.return_value = None
+        service, _ = _service(mfg_repo=mfg_repo, vm_client=AsyncMock())
+        await service.generate_by_id("nope")  # should not raise

--- a/api/tests/unit/test_mfg_product_mapping.py
+++ b/api/tests/unit/test_mfg_product_mapping.py
@@ -1,0 +1,203 @@
+"""Unit tests for mfg_product_mapping (pure attribute mapping for illustrator-vm)."""
+
+import pytest
+
+from app.utils.exceptions import ValidationError
+from app.utils.mfg_product_mapping import (
+    SUPPORTED_PRODUCT_TYPES,
+    is_supported,
+    normalize_variant,
+    resolve_vm_mapping,
+    select_layers,
+    validate_v2_item,
+)
+
+
+class TestSupportedTypes:
+    def test_supported_set_is_five_types(self):
+        assert SUPPORTED_PRODUCT_TYPES == {
+            "tshirt",
+            "tote_bag",
+            "acrylic_keychain",
+            "acrylic_stand",
+            "sticker",
+        }
+
+    def test_mug_cup_out_of_scope(self):
+        assert not is_supported("mug_cup")
+        assert is_supported("acrylic_keychain")
+
+
+class TestResolveVmMapping:
+    @pytest.mark.parametrize(
+        ("product_type", "size", "expected_vm_size"),
+        [
+            ("acrylic_keychain", "50x50mm", "50x50"),
+            ("acrylic_keychain", "70x70mm", "70x70"),
+            ("acrylic_keychain", "100x100mm", "100x100"),
+            ("sticker", "50x50mm", "50x50"),
+            ("sticker", "100x100mm", "100x100"),
+            # acrylic_stand uses a DIFFERENT size id mapping
+            ("acrylic_stand", "50x50mm", "50mm"),
+            ("acrylic_stand", "70x70mm", "70mm"),
+            ("acrylic_stand", "100x100mm", "100mm"),
+            ("tshirt", "M", "M"),
+            ("tshirt", "XL", "XL"),
+            ("tote_bag", "M", "M"),
+        ],
+    )
+    def test_size_mapping(self, product_type, size, expected_vm_size):
+        variant = "clear" if product_type in ("acrylic_keychain", "sticker") else None
+        mapping = resolve_vm_mapping(product_type, size, variant)
+        assert mapping.vm_size == expected_vm_size
+
+    def test_keychain_variant_and_layers(self):
+        mapping = resolve_vm_mapping("acrylic_keychain", "50x50mm", "color")
+        assert mapping.variant == "color"
+        assert mapping.input_mode == "multi"
+        assert mapping.required_layers == ("color", "cutline")
+        assert mapping.optional_layers == ("white",)
+        assert mapping.output_format == "ai"
+
+    def test_sticker_has_no_white_layer(self):
+        mapping = resolve_vm_mapping("sticker", "70x70mm", "clear")
+        assert mapping.required_layers == ("color", "cutline")
+        assert mapping.optional_layers == ()
+        assert mapping.variant == "clear"
+
+    def test_tshirt_is_single_pdf(self):
+        mapping = resolve_vm_mapping("tshirt", "L", None)
+        assert mapping.input_mode == "single"
+        assert mapping.required_layers == ("design",)
+        assert mapping.output_format == "pdf"
+        assert mapping.variant is None
+
+    def test_stand_variant_is_ignored(self):
+        # acrylic_stand はバリアントなし → 送られても None に正規化
+        mapping = resolve_vm_mapping("acrylic_stand", "70x70mm", "clear")
+        assert mapping.variant is None
+
+    def test_unsupported_product_type_raises(self):
+        with pytest.raises(ValidationError):
+            resolve_vm_mapping("mug_cup", "normal", None)
+
+    @pytest.mark.parametrize(
+        ("product_type", "size"),
+        [
+            ("tshirt", "XXL"),
+            ("acrylic_keychain", "60x60mm"),
+            ("acrylic_stand", "M"),
+            ("tote_bag", "L"),
+        ],
+    )
+    def test_invalid_size_raises(self, product_type, size):
+        variant = "clear" if product_type == "acrylic_keychain" else None
+        with pytest.raises(ValidationError):
+            resolve_vm_mapping(product_type, size, variant)
+
+    def test_keychain_missing_variant_raises(self):
+        with pytest.raises(ValidationError):
+            resolve_vm_mapping("acrylic_keychain", "50x50mm", None)
+
+    def test_keychain_invalid_variant_raises(self):
+        with pytest.raises(ValidationError):
+            resolve_vm_mapping("acrylic_keychain", "50x50mm", "blue")
+
+    def test_sticker_missing_variant_raises(self):
+        with pytest.raises(ValidationError):
+            resolve_vm_mapping("sticker", "50x50mm", None)
+
+
+class TestNormalizeVariant:
+    def test_required_variant_ok(self):
+        assert normalize_variant("acrylic_keychain", "clear") == "clear"
+        assert normalize_variant("sticker", "clear") == "clear"
+
+    def test_non_variant_type_forces_none(self):
+        assert normalize_variant("acrylic_stand", "clear") is None
+        assert normalize_variant("tshirt", None) is None
+        assert normalize_variant("tote_bag", "anything") is None
+
+
+class TestSelectLayers:
+    def test_keychain_color_cutline(self):
+        layers = select_layers(
+            "acrylic_keychain",
+            [
+                {"layer_type": "color", "url": "http://x/c.png"},
+                {"layer_type": "cutline", "url": "http://x/l.png"},
+            ],
+        )
+        assert layers == {"color": "http://x/c.png", "cutline": "http://x/l.png"}
+
+    def test_keychain_with_optional_white(self):
+        layers = select_layers(
+            "acrylic_keychain",
+            [
+                {"layer_type": "color", "url": "http://x/c.png"},
+                {"layer_type": "cutline", "url": "http://x/l.png"},
+                {"layer_type": "white", "url": "http://x/w.png"},
+            ],
+        )
+        assert layers["white"] == "http://x/w.png"
+
+    def test_keychain_missing_cutline_raises(self):
+        with pytest.raises(ValidationError):
+            select_layers(
+                "acrylic_keychain",
+                [{"layer_type": "color", "url": "http://x/c.png"}],
+            )
+
+    def test_sticker_white_is_unknown_layer(self):
+        # sticker は white レイヤーを持たない → 未対応レイヤーとして拒否
+        with pytest.raises(ValidationError):
+            select_layers(
+                "sticker",
+                [
+                    {"layer_type": "color", "url": "http://x/c.png"},
+                    {"layer_type": "cutline", "url": "http://x/l.png"},
+                    {"layer_type": "white", "url": "http://x/w.png"},
+                ],
+            )
+
+    def test_tshirt_design(self):
+        layers = select_layers("tshirt", [{"layer_type": "design", "url": "http://x/d.png"}])
+        assert layers == {"design": "http://x/d.png"}
+
+    def test_tshirt_accepts_color_as_design_alias(self):
+        layers = select_layers("tshirt", [{"layer_type": "color", "url": "http://x/c.png"}])
+        assert layers == {"design": "http://x/c.png"}
+
+    def test_single_missing_image_raises(self):
+        with pytest.raises(ValidationError):
+            select_layers("tote_bag", [])
+
+    def test_multi_unknown_layer_raises(self):
+        with pytest.raises(ValidationError):
+            select_layers(
+                "acrylic_stand",
+                [
+                    {"layer_type": "color", "url": "http://x/c.png"},
+                    {"layer_type": "cutline", "url": "http://x/l.png"},
+                    {"layer_type": "bogus", "url": "http://x/b.png"},
+                ],
+            )
+
+
+class TestValidateV2Item:
+    def test_valid_item_returns_mapping(self):
+        mapping = validate_v2_item(
+            "acrylic_keychain",
+            "50x50mm",
+            "clear",
+            [
+                {"layer_type": "color", "url": "http://x/c.png"},
+                {"layer_type": "cutline", "url": "http://x/l.png"},
+            ],
+        )
+        assert mapping.vm_size == "50x50"
+        assert mapping.variant == "clear"
+
+    def test_invalid_layers_raise(self):
+        with pytest.raises(ValidationError):
+            validate_v2_item("acrylic_keychain", "50x50mm", "clear", [])

--- a/api/tests/unit/test_order_service_create_v2.py
+++ b/api/tests/unit/test_order_service_create_v2.py
@@ -1,0 +1,118 @@
+"""Unit tests for OrderService.create_v2 (v2 intake field persistence + validation)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.schemas.order_v2 import OrderCreateV2
+from app.services.order_service import OrderService
+from app.utils.exceptions import DuplicateError, ValidationError
+
+
+def _service():
+    order_repo = AsyncMock()
+    product_repo = AsyncMock()
+    shipment_repo = AsyncMock()
+    service = OrderService(order_repo, product_repo, shipment_repo)
+    # _to_response は別テスト対象なので固定値でバイパス
+    service._to_response = AsyncMock(return_value=MagicMock())
+    return service, order_repo, product_repo
+
+
+def _customer():
+    return {
+        "name": "山田太郎",
+        "postal_code": "100-0001",
+        "address_prefecture": "東京都",
+        "address_city": "千代田区1-1",
+        "phone": "090-0000-0000",
+    }
+
+
+def _keychain_payload(**item_overrides):
+    item = {
+        "uid": "0000001",
+        "product_type": "acrylic_keychain",
+        "product_name": "キーホルダー",
+        "price": 1000,
+        "quantity": 1,
+        "size": "50x50mm",
+        "variant": "clear",
+        "product_code": "PC-1",
+        "source_images": [
+            {"layer_type": "color", "url": "http://x/c.png"},
+            {"layer_type": "cutline", "url": "http://x/l.png"},
+        ],
+    }
+    item.update(item_overrides)
+    return OrderCreateV2(order_number="0000001", customer=_customer(), items=[item])
+
+
+class TestCreateV2:
+    @pytest.mark.asyncio
+    async def test_persists_v2_fields_on_order_item(self):
+        service, order_repo, product_repo = _service()
+        order_repo.find_by_order_number.return_value = None
+        product_repo.find_by_product_type.return_value = MagicMock(id="prod-1", lead_time_days=3)
+        order_repo.create.side_effect = lambda order: order  # echo the built order
+
+        await service.create_v2(_keychain_payload(), order_source_id="src-1")
+
+        order_repo.create.assert_awaited_once()
+        built_order = order_repo.create.call_args.args[0]
+        item = built_order.items[0]
+        assert item.product_code == "PC-1"
+        assert item.variant == "clear"
+        assert item.source_images == [
+            {"layer_type": "color", "url": "http://x/c.png"},
+            {"layer_type": "cutline", "url": "http://x/l.png"},
+        ]
+        assert built_order.order_source_id == "src-1"
+
+    @pytest.mark.asyncio
+    async def test_stand_variant_normalized_to_none(self):
+        service, order_repo, product_repo = _service()
+        order_repo.find_by_order_number.return_value = None
+        product_repo.find_by_product_type.return_value = MagicMock(id="prod-1", lead_time_days=3)
+        order_repo.create.side_effect = lambda order: order
+        # acrylic_stand はバリアントなし: variant を送っても None に正規化される
+        payload = OrderCreateV2(
+            order_number="0000002",
+            customer=_customer(),
+            items=[
+                {
+                    "uid": "0000002",
+                    "product_type": "acrylic_stand",
+                    "product_name": "スタンド",
+                    "price": 1500,
+                    "quantity": 1,
+                    "size": "70x70mm",
+                    "variant": "clear",
+                    "product_code": "PC-STAND",
+                    "source_images": [
+                        {"layer_type": "color", "url": "http://x/c.png"},
+                        {"layer_type": "cutline", "url": "http://x/l.png"},
+                    ],
+                }
+            ],
+        )
+        await service.create_v2(payload, order_source_id="src-1")
+        item = order_repo.create.call_args.args[0].items[0]
+        assert item.variant is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_item_missing_variant_raises(self):
+        service, order_repo, product_repo = _service()
+        order_repo.find_by_order_number.return_value = None
+        # keychain で variant 未指定 → mfg_product_mapping 検証で ValidationError
+        with pytest.raises(ValidationError):
+            await service.create_v2(_keychain_payload(variant=None), order_source_id="src-1")
+        order_repo.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_order_number_raises(self):
+        service, order_repo, product_repo = _service()
+        order_repo.find_by_order_number.return_value = MagicMock()  # 既存注文あり
+        with pytest.raises(DuplicateError):
+            await service.create_v2(_keychain_payload(), order_source_id="src-1")
+        order_repo.create.assert_not_awaited()

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -251,6 +251,79 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7f/42/fb9436c103a881a377e34b9f58d77b5f503461c702ff654ebe86151bcfe9/chardet-6.0.0.post1.tar.gz", hash = "sha256:6b78048c3c97c7b2ed1fbad7a18f76f5a6547f7d34dbab536cc13887c9a92fa4", size = 12521798, upload-time = "2026-02-22T15:09:17.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/42/5de54f632c2de53cd3415b3703383d5fff43a94cbc0567ef362515261a21/chardet-6.0.0.post1-py3-none-any.whl", hash = "sha256:c894a36800549adf7bb5f2af47033281b75fdfcd2aa0f0243be0ad22a52e2dcb", size = 627245, upload-time = "2026-02-22T15:09:15.876Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -521,6 +594,112 @@ woff = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
     { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
     { name = "zopfli" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl", hash = "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c", size = 340605, upload-time = "2026-06-12T18:03:12.677Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -970,6 +1149,7 @@ dependencies = [
     { name = "chardet" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "jpholiday" },
@@ -1015,6 +1195,7 @@ requires-dist = [
     { name = "chardet", specifier = ">=5.0.0" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "google-cloud-storage", specifier = ">=3.12.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jpholiday", specifier = ">=0.1.9" },
@@ -1049,12 +1230,51 @@ dev = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1329,6 +1549,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rsa"
 version = "4.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1494,6 +1729,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要
Refs #76 （**バックエンドslice**。フロントエンドは別PRで対応するため `Closes` にしていません）

外部注文(v2)で完成データURLではなく**元データ(PNGレイヤー)** を受け取り、`illustrator-vm`(Product Manufacturing API) で製造データ(.ai/.pdf)を生成し、**受注元×商品×サイズ×バリアント単位でキャッシュ再利用**する。製造データが `ready` になるまでメーカー発注を保留/拒否する。既存 `POST /api/v1/orders` は不変。

## 変更内容
- **データモデル / Alembic**: `manufacturing_data` テーブル＋`MfgDataStatus`、`order_items` に v2 列（`product_code`/`variant`/`source_images`/`manufacturing_data_id`）追加。`down_revision=add_ext_order_notif_settings`。キャッシュキーは `(order_source_id, product_code, size, variant)` の一意インデックス（`variant` NULL を含めて一意にするため **NULLS NOT DISTINCT**）。
- **v2 intake**: `POST /api/v2/orders`（`verify_api_key` 流用）。`OrderService.create_v2` が新フィールドを永続化し、受付後 `BackgroundTasks` で製造データ生成を自動起動（注文を確定コミットしてから起動）。
- **illustrator-vm クライアント**: `services/illustrator_vm_client.py`（submit/status/download＋タイムアウト＋503バックオフ再送、エラーは `detail` 参照、`output_filename` を正）。設定 `ILLUSTRATOR_VM_*` ＋ `.env.example` ＋ DI（未設定なら生成スキップ＝pending）。
- **属性マッピング**: `utils/mfg_product_mapping.py`（5タイプの決定的 size/variant/必須レイヤー変換。keychain/sticker `50x50mm→50x50`、**stand `50x50mm→50mm`**。mug_cup はスコープ外）。
- **ストレージ**: `FileStorage` の **GCS バックエンド**＋`build_file_storage()` ファクトリ（`STORAGE_BACKEND=local|gcs`）。生成bytes保存用 `BytesUpload` アダプタ。`google-cloud-storage` 追加。
- **生成サービス**: `ManufacturingDataService`（キャッシュ解決・生成ドライバ・失敗記録・手動リトライ）。独自セッションのバックグラウンドワーカー、**原子的 claim(UPDATE...RETURNING)** で多重生成を防止。`ready`＋ファイル存在で再利用、ファイル消失(GCS 180日等)は再生成。
- **状態/リトライ API**: `GET /api/v1/manufacturing-data`（一覧）＋ `POST /api/v1/manufacturing-data/{id}/retry`（管理者）。
- **発注ゲート**: `generate_order_documents` で未ready明細を除外し ORDERED のまま保留、**ready分のみ保存済み生成ファイルをZIP封入**（`design_image_url` DL＋リネームを置換、acrylic_stand の `_stand.ai` は従来通り）。`update_order_status(→MANUFACTURING)` は未ready明細を **409(`ManufacturingDataNotReadyError`)** で拒否。
- **セルフレビュー**: `create`/`create_v2` の重複を `_build_order`/`_finalize_order` に抽出。

## 影響範囲
- **直接変更**: `models/order.py`(OrderItem列＋relationship＋ManufacturingData runtime import), `order_service.py`(create_v2＋共通ヘルパ抽出), `manufacturer_order_service.py`(発注ゲート＋optional mfg_repo/file_storage), `order_repository.py`(`find_manufacturer_items`), `dependencies.py`(DI providers), `main.py`(v2/manufacturing-data router登録), `config.py`/`.env.example`(設定), `exceptions.py`(新例外), `file_storage.py`(GCS backend), `alembic/`(新migration＋env.py import), `pyproject.toml`/`uv.lock`(依存)。
- **間接的に影響しうる箇所**: `get_manufacturer_order_service` が `mfg_repo`/`file_storage` を要求（DI配線済み・コンストラクタは後方互換で `None` 既定）。発注ゲートは **v2明細(product_code/manufacturing_data_id保有)のみ作用**し、旧v1明細は不変。`OrderItem` にリレーション追加（既存クエリは lazy のため無影響。mapper登録のため `order.py` で runtime import＝既存の `product.py` と同パターン）。
- **後方互換 / マイグレーション**: 新テーブル＋列（全 nullable）。**旧 `POST /api/v1/orders`・既存挙動は不変**。`alembic upgrade head` 要。`google-cloud-storage` 依存追加（`STORAGE_BACKEND=local` 既定なので未接続でも動作）。
- **対象外（今回触っていない）**: フロントエンド、mug_cup、CI 追加、既存 lint/type 負債。

## 動作確認チェックリスト（レビュアー向け）
- [ ] **前提**: `alembic upgrade head`（or `make migrate`）で `manufacturing_data` 作成。`ILLUSTRATOR_VM_URL` 未設定なら生成はスキップ（`pending`）。GCS利用時のみ `STORAGE_BACKEND=gcs`＋`GCS_BUCKET`。
- [ ] **v2受付**: `POST /api/v2/orders`（`X-API-Key`）に `product_code`/`variant`/`source_images` 付き明細 → **201**、`order_items` に永続化、`manufacturing_data(pending)` が作成・紐付け（`GET /api/v1/manufacturing-data`）。
- [ ] **キャッシュ再利用**: 同一 `(order_source, product_code, size, variant)` で再注文 → VM を再呼び出しせず既存行を再利用。
- [ ] **発注ゲート(保留)**: 未ready明細を含むメーカー発注ZIP DL → 未ready分は **ORDERED のまま保留**、ready分のみZIPに封入。
- [ ] **発注ゲート(拒否)**: 管理者が未ready明細を `PATCH /manufacturers/{id}/order-status`(manufacturing) → **409**。
- [ ] **リトライ**: `POST /api/v1/manufacturing-data/{id}/retry` で `failed`/スタック行が `pending` に戻り再実行される。
- [ ] **後方互換**: 旧 `POST /api/v1/orders` が不変。
- [ ] **既存テスト＋新規テスト**: `make test`（Docker）or ローカル `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib uv run pytest tests/unit`。新規81テスト全pass・既存回帰なし。

## セルフレビュー
- 実行した simplify: **手動で `/simplify max` 相当のレビュー**（worktree運用のため `/simplify` コマンド未使用）。
- 主な対応: `create`/`create_v2` の重複ボイラープレートを `_build_order`/`_finalize_order` に抽出。全新規ファイルは `ruff`/`ruff format`/`mypy(strict)` クリーン。既存改変ファイルは **新規の lint/type エラーを追加していないこと**を main と件数比較して確認（回帰ゼロ）。

## 検証メモ / 制約
- 単体72＋結合9の新規テスト追加。**Alembic migration は実 PostgreSQL 16 で upgrade/downgrade を確認**（NULLS NOT DISTINCT 反映済み）。
- `illustrator-vm` と GCS はこの環境で実行不可のため **httpx / SDK モックで検証**（本番疎通は要確認）。
- 既存 unit スイートには本PR無関係の **pre-existing 失敗39件**（Pydantic 2.12 環境の MagicMock→date 変換等）があり、件数は main と一致（回帰なし）。結合テストは seed 前提のため空DBでは多数 error になるが main と同挙動。

## フォローアップ候補
- **フロントエンド**（製造データ状態表示・SWRポーリング・発注DL無効化/保留表示・リトライボタン）＝別PR。
- `mug_cup` 対応（ProductType/enum/価格/マッピング追加が必要＝別Issue）。
- 発注ゲートの低レベル `OrderRepository.update_item_status_by_manufacturer` 防御（今回はサービス層＝bulk保留＋admin拒否で担保）。
- 発注ZIP応答での「保留件数」提示（現状はログ出力。フロント可視化で代替予定）。
- 既存 lint/type 負債の整理（`B904`/`B007`/`B008`、`config.py` の `ConfigDict→SettingsConfigDict`、`aiofiles` スタブ、`file_storage`/`order_service` の型負債）。
- backend の CI（pytest/ruff/mypy＋postgres service）整備（現状 `@claude` ワークフローのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
