### PR TITLE
feat: 発注CSV・配送CSVの商品種類を発注リスト形式に統一 (#79)

### DIFF
--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -20,7 +20,11 @@ from app.schemas.manufacturer import (
     AllManufacturerOrderItemListResponse,
 )
 from app.utils.exceptions import NotFoundError, NoOrderedItemsError
-from app.utils.order_list_generator import OrderListGenerator, get_product_type_name
+from app.utils.order_list_generator import (
+    OrderListGenerator,
+    format_product_detail,
+    get_product_type_name,
+)
 from app.utils.stand_file_config import load_stand_file
 from app.utils.zip_builder import ZipBuilder
 
@@ -432,14 +436,12 @@ class ManufacturerOrderService:
                 ordered_date = item.get("ordered_date")
 
                 # Build product detail: {商品種類} - {サイズ} - {位置} - {色}
-                detail_parts = [product_type_name]
-                if item.get("size"):
-                    detail_parts.append(item["size"])
-                if item.get("position"):
-                    detail_parts.append(item["position"])
-                if item.get("color"):
-                    detail_parts.append(item["color"])
-                product_detail = " - ".join(detail_parts)
+                product_detail = format_product_detail(
+                    item_product_type,
+                    item.get("size"),
+                    item.get("position"),
+                    item.get("color"),
+                )
 
                 # MMDDを注文日から計算
                 mmdd = ordered_date.strftime("%m%d") if ordered_date else ""

--- a/api/app/services/order_service.py
+++ b/api/app/services/order_service.py
@@ -61,6 +61,7 @@ from app.utils.exceptions import (
     ProductNotFoundError,
     ValidationError,
 )
+from app.utils.order_list_generator import format_product_detail
 from app.utils.zip_builder import ZipBuilder
 
 logger = logging.getLogger(__name__)
@@ -656,7 +657,9 @@ class OrderService:
                     order.order_number,  # 1. 注文番号
                     order.customer_name,  # 2. お客様氏名
                     item.product_name,  # 3. 商品名
-                    self._format_product_type(item.product_type),  # 4. 商品種類
+                    format_product_detail(
+                        item.product_type, item.size, item.position, item.color
+                    ),  # 4. 商品種類（{商品種類} - {サイズ} - {位置} - {色}）
                     str(item.quantity),  # 5. 数量
                     item.uid or "",  # 6. 商品番号（アイテムUID）
                     order.customer_phone,  # 7. お届け先電話番号
@@ -820,18 +823,6 @@ class OrderService:
         filename = f"注文サムネイル_{timestamp}.zip"
 
         return zip_bytes, filename
-
-    def _format_product_type(self, product_type: str) -> str:
-        """Convert product_type to Japanese display name."""
-        type_map = {
-            "acrylic_keychain": "アクリルキーホルダー",
-            "acrylic_stand": "アクリルスタンド",
-            "sticker": "ステッカー",
-            "tote_bag": "トートバッグ",
-            "mug": "マグカップ",
-            "tshirt": "Tシャツ",
-        }
-        return type_map.get(product_type, product_type)
 
     @staticmethod
     def _get_extension_from_url(url: str) -> str | None:

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -40,6 +40,7 @@ from app.schemas.shipment import (
 )
 from app.utils.exceptions import InvalidStatusTransitionError, NotFoundError, ValidationError
 from app.utils.file_storage import FileStorage
+from app.utils.order_list_generator import format_product_detail
 from app.utils.zip_builder import ZipBuilder
 
 import chardet
@@ -906,18 +907,6 @@ class ShipmentService:
             updated_at=shipment.updated_at,
         )
 
-    def _format_product_type(self, product_type: str) -> str:
-        """Convert product_type to Japanese display name."""
-        type_map = {
-            "acrylic_keychain": "アクリルキーホルダー",
-            "acrylic_stand": "アクリルスタンド",
-            "sticker": "ステッカー",
-            "tote_bag": "トートバッグ",
-            "mug": "マグカップ",
-            "tshirt": "Tシャツ",
-        }
-        return type_map.get(product_type, product_type)
-
     async def export_csv(
         self,
         shipment_ids: list[str] | None = None,
@@ -1022,7 +1011,9 @@ class ShipmentService:
                 order.order_number,  # 1. 注文番号
                 order.customer_name,  # 2. お客様氏名
                 item.product_name,  # 3. 商品名
-                self._format_product_type(item.product_type),  # 4. 商品種類
+                format_product_detail(
+                    item.product_type, item.size, item.position, item.color
+                ),  # 4. 商品種類（{商品種類} - {サイズ} - {位置} - {色}）
                 str(item.quantity),  # 5. 数量
                 item.uid or "",  # 6. 商品番号（アイテムUID）
                 order.customer_phone,  # 7. お届け先電話番号

--- a/api/app/utils/order_list_generator.py
+++ b/api/app/utils/order_list_generator.py
@@ -24,6 +24,26 @@ def get_product_type_name(product_type: str) -> str:
     return PRODUCT_TYPE_NAMES.get(product_type, product_type)
 
 
+def format_product_detail(
+    product_type: str,
+    size: str | None = None,
+    position: str | None = None,
+    color: str | None = None,
+) -> str:
+    """Build the unified product detail label used across order/shipment reports.
+
+    Format: ``{商品種類} - {サイズ} - {位置} - {色}`` (ex. ``Tシャツ - L - 正面 - 白``).
+    Empty/None elements are skipped so no redundant separators appear
+    (ex. ``ステッカー - 100x100mm - ホワイト`` when position is absent).
+    The separator is a half-width " - ".
+    """
+    parts = [get_product_type_name(product_type)]
+    for value in (size, position, color):
+        if value:
+            parts.append(value)
+    return " - ".join(parts)
+
+
 class OrderListGenerator:
     """CSV generator for manufacturer order lists (発注リスト)."""
 
@@ -89,23 +109,17 @@ class OrderListGenerator:
             color = item.get("color", "")
             cost = item.get("cost", 0)
 
-            # Get product type name (use argument if provided, else from item)
+            # Get product type (use argument if provided, else from item)
             item_product_type = product_type or item.get("product_type", "")
-            product_type_name = get_product_type_name(item_product_type)
 
             # Format date as "MM月DD日"
             formatted_date = ordered_date.strftime("%m月%d日") if ordered_date else ""
             mmdd = ordered_date.strftime("%m%d") if ordered_date else ""
 
             # Build product detail: {商品種類} - {サイズ} - {位置} - {色}
-            detail_parts = [product_type_name]
-            if size:
-                detail_parts.append(size)
-            if position:
-                detail_parts.append(position)
-            if color:
-                detail_parts.append(color)
-            product_detail = " - ".join(detail_parts)
+            product_detail = format_product_detail(
+                item_product_type, size, position, color
+            )
 
             # Build seal text: {商品種類}【個数】{個数}個_{注文番号}_{製品番号}_{MMDD}
             seal_text = f"{product_detail}【個数】{quantity}個_{order_number}_{uid}_{mmdd}"
@@ -190,9 +204,8 @@ class OrderListGenerator:
             position = item.get("position", "")
             color = item.get("color", "")
 
-            # Get product type name
+            # Get product type
             item_product_type = product_type or item.get("product_type", "")
-            product_type_name = get_product_type_name(item_product_type)
 
             # Format date as "M月D日" (no zero-padding)
             if ordered_date:
@@ -203,14 +216,9 @@ class OrderListGenerator:
                 mmdd = ""
 
             # Build product detail: {商品種類} - {サイズ} - {位置} - {色}
-            detail_parts = [product_type_name]
-            if size:
-                detail_parts.append(size)
-            if position:
-                detail_parts.append(position)
-            if color:
-                detail_parts.append(color)
-            product_detail = " - ".join(detail_parts)
+            product_detail = format_product_detail(
+                item_product_type, size, position, color
+            )
 
             # Build seal text: {商品種類}【個数】{個数}個_{注文番号}_{製品番号}_{MMDD}
             seal_text = f"{product_detail}【個数】{quantity}個_{order_number}_{uid}_{mmdd}"

--- a/api/tests/unit/test_order_export_csv.py
+++ b/api/tests/unit/test_order_export_csv.py
@@ -1,0 +1,102 @@
+"""Unit tests for OrderService.export_csv() product type column (Issue #79).
+
+OrderService.export_csv generates the delivery-company CSV for pending orders
+(orders that do not have a Shipment yet). Its "商品種類" column (4th) must be
+formatted identically to the shipment CSV and the order list (発注リスト):
+{商品種類} - {サイズ} - {位置} - {色}.
+"""
+
+import csv
+import io
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.order import Order, OrderItem
+from app.models.order_source import OrderSource
+from app.services.order_service import OrderService
+
+# 商品種類 column index in the delivery CSV (0-based)
+PRODUCT_TYPE_COL = 3
+
+
+@pytest.fixture
+def order_service():
+    """OrderService with mocked dependencies (order_source_repo configured)."""
+    return OrderService(
+        order_repo=AsyncMock(),
+        product_repo=AsyncMock(),
+        shipment_repo=AsyncMock(),
+        order_source_repo=AsyncMock(),
+    )
+
+
+def _order_source() -> MagicMock:
+    source = MagicMock(spec=OrderSource)
+    source.name = "テスト配送元"
+    source.phone = "03-1234-5678"
+    source.postal_code = "100-0001"
+    source.address_prefecture = "東京都"
+    source.address_city = "千代田区1-1-1"
+    source.address_building = "テストビル101"
+    return source
+
+
+def _order_item(
+    product_type: str,
+    size: str | None = None,
+    position: str | None = None,
+    color: str | None = None,
+) -> MagicMock:
+    item = MagicMock(spec=OrderItem)
+    item.product_name = "テスト商品"
+    item.product_type = product_type
+    item.quantity = 1
+    item.uid = "ITEM-001"
+    item.size = size
+    item.position = position
+    item.color = color
+    return item
+
+
+def _order(item: MagicMock) -> MagicMock:
+    order = MagicMock(spec=Order)
+    order.id = "order-001"
+    order.order_number = "ORD-0001"
+    order.customer_name = "テスト顧客"
+    order.customer_phone = "090-0000-0000"
+    order.customer_postal_code = "100-0001"
+    order.customer_address_prefecture = "東京都"
+    order.customer_address_city = "千代田区1-1-1"
+    order.customer_address_building = ""
+    order.items = [item]
+    order.order_source = _order_source()
+    return order
+
+
+class TestOrderExportCsvProductDetail:
+    """Issue #79: order delivery CSV 商品種類 column uses the unified format."""
+
+    async def _export_detail(self, order_service, item) -> str:
+        order_service._order_repo.find_by_id.return_value = _order(item)
+        csv_bytes, _ = await order_service.export_csv(["order-001"])
+        rows = list(csv.reader(io.StringIO(csv_bytes.decode("utf-8-sig"))))
+        return rows[1][PRODUCT_TYPE_COL]
+
+    @pytest.mark.asyncio
+    async def test_includes_size_position_color(self, order_service):
+        """Tシャツはサイズ・位置・色を半角 ' - ' で連結して出力する."""
+        detail = await self._export_detail(
+            order_service, _order_item("tshirt", "L", "正面", "白")
+        )
+        assert detail == "Tシャツ - L - 正面 - 白"
+
+    @pytest.mark.asyncio
+    async def test_acrylic_stand_maps_to_acrylic_figure_and_skips_empty(
+        self, order_service
+    ):
+        """acrylic_stand は「アクリルフィギュア」となり、位置なしはスキップされる."""
+        detail = await self._export_detail(
+            order_service, _order_item("acrylic_stand", "100mm", None, "クリア")
+        )
+        assert detail == "アクリルフィギュア - 100mm - クリア"

--- a/api/tests/unit/test_order_list_generator.py
+++ b/api/tests/unit/test_order_list_generator.py
@@ -6,7 +6,11 @@ from datetime import datetime
 import pytest
 from openpyxl import load_workbook
 
-from app.utils.order_list_generator import OrderListGenerator, get_product_type_name
+from app.utils.order_list_generator import (
+    OrderListGenerator,
+    format_product_detail,
+    get_product_type_name,
+)
 
 
 class TestOrderListGenerator:
@@ -368,6 +372,43 @@ class TestGetProductTypeName:
     def test_get_product_type_name_unknown(self):
         """Test unknown product type returns original value."""
         assert get_product_type_name("unknown_type") == "unknown_type"
+
+
+class TestFormatProductDetail:
+    """Tests for the shared format_product_detail helper (Issue #79)."""
+
+    def test_all_attributes(self):
+        """種類・サイズ・位置・色を半角 ' - ' で連結する."""
+        assert (
+            format_product_detail("tshirt", "L", "正面", "白")
+            == "Tシャツ - L - 正面 - 白"
+        )
+
+    def test_skips_missing_position(self):
+        """位置が None の場合は余分な区切りを出さずスキップする."""
+        assert (
+            format_product_detail("sticker", "100x100mm", None, "ホワイト")
+            == "ステッカー - 100x100mm - ホワイト"
+        )
+
+    def test_skips_empty_string_attributes(self):
+        """空文字の属性はスキップする."""
+        assert format_product_detail("tote_bag", "", "", "") == "トートバッグ"
+
+    def test_type_name_only_when_no_attributes(self):
+        """属性が無い場合は商品種類名のみを返す."""
+        assert format_product_detail("acrylic_keychain") == "アクリルキーホルダー"
+
+    def test_acrylic_stand_maps_to_acrylic_figure(self):
+        """acrylic_stand は「アクリルフィギュア」にマッピングされる."""
+        assert (
+            format_product_detail("acrylic_stand", "100mm", None, "クリア")
+            == "アクリルフィギュア - 100mm - クリア"
+        )
+
+    def test_unknown_product_type_falls_back_to_code(self):
+        """未知の商品種類コードはそのまま先頭に使用する."""
+        assert format_product_detail("mystery", "S") == "mystery - S"
 
 
 class TestOrderListGeneratorXlsx:

--- a/api/tests/unit/test_shipment_export_csv.py
+++ b/api/tests/unit/test_shipment_export_csv.py
@@ -1,4 +1,4 @@
-"""Unit tests for ShipmentService.export_csv() - 18th column addition.
+"""Unit tests for ShipmentService.export_csv().
 
 FEAT-0017: Add "商品名（処理用）" column to shipment CSV export.
 Tests verify that the 18th column is correctly added to both the header
@@ -9,6 +9,10 @@ AC-002: Data row 18th column is "{order_number}_{uid}" format
 AC-003: Multiple OrderItems produce correct values per row
 AC-004: uid=None produces "{order_number}_"
 AC-005: Existing 17 columns remain unchanged
+
+Issue #79: The "商品種類" column (4th) now uses the same
+"{商品種類} - {サイズ} - {位置} - {色}" format as the order list (発注リスト).
+See TestShipmentExportCsvProductDetail.
 """
 
 import csv
@@ -21,6 +25,7 @@ from app.models.order import Order, OrderItem
 from app.models.order_source import OrderSource
 from app.models.shipment import Shipment, ShipmentItem, ShipmentStatus
 from app.services.shipment_service import ShipmentService
+from app.utils.order_list_generator import OrderListGenerator
 
 # ---- Existing 17 header columns (must not change) ----
 EXPECTED_17_HEADERS = [
@@ -101,6 +106,9 @@ def create_mock_order_item(
     product_type: str = "acrylic_keychain",
     quantity: int = 1,
     uid: str | None = "ITEM-001",
+    size: str | None = None,
+    position: str | None = None,
+    color: str | None = None,
 ) -> MagicMock:
     """Create a mock OrderItem."""
     item = MagicMock(spec=OrderItem)
@@ -108,6 +116,9 @@ def create_mock_order_item(
     item.product_type = product_type
     item.quantity = quantity
     item.uid = uid
+    item.size = size
+    item.position = position
+    item.color = color
     return item
 
 
@@ -409,3 +420,75 @@ class TestShipmentExportCsvColumn18:
         assert row[14] == "千代田区1-1-1"  # 配送元住所2
         assert row[15] == "テストビル101"  # 配送元住所3
         assert row[16] == "テスト配送元"  # 配送元氏名
+
+
+# 商品種類 column index in the shipment export CSV (0-based)
+PRODUCT_TYPE_COL = 3
+# 商品種類 column index in the order list (発注リスト) CSV (0-based)
+ORDER_LIST_PRODUCT_TYPE_COL = 4
+
+
+class TestShipmentExportCsvProductDetail:
+    """Issue #79: 「商品種類」列を発注リストと同じ形式に統一.
+
+    Format: {商品種類} - {サイズ} - {位置} - {色}（半角 " - " 区切り、空要素はスキップ）。
+    """
+
+    async def _export_single_item(
+        self, shipment_service, mock_shipment_repo, order_item
+    ) -> str:
+        """Export one order item and return its 商品種類 cell value."""
+        order = create_mock_order(
+            order_items=[order_item],
+            order_source=create_mock_order_source(),
+        )
+        shipment = create_mock_shipment(shipment_items=[("si-001", order)])
+        mock_shipment_repo.find_by_id.return_value = shipment
+
+        csv_bytes, _ = await shipment_service.export_csv(["shipment-001"])
+        _, data_rows = parse_csv_bytes(csv_bytes)
+        return data_rows[0][PRODUCT_TYPE_COL]
+
+    @pytest.mark.asyncio
+    async def test_includes_size_position_color(
+        self, shipment_service, mock_shipment_repo
+    ):
+        """Tシャツはサイズ・位置・色を半角 ' - ' で連結して出力する."""
+        item = create_mock_order_item(
+            product_type="tshirt", size="L", position="正面", color="白"
+        )
+        detail = await self._export_single_item(
+            shipment_service, mock_shipment_repo, item
+        )
+        assert detail == "Tシャツ - L - 正面 - 白"
+
+    @pytest.mark.asyncio
+    async def test_acrylic_stand_maps_to_acrylic_figure_and_matches_order_list(
+        self, shipment_service, mock_shipment_repo
+    ):
+        """acrylic_stand は「アクリルフィギュア - …」となり発注リスト出力と完全一致する.
+
+        position=None のため空要素スキップ（余分な区切りが出ない）も同時に検証する。
+        商品種類名の網羅的な整形パターンは TestFormatProductDetail を参照。
+        """
+        item = create_mock_order_item(
+            product_type="acrylic_stand", size="100mm", position=None, color="クリア"
+        )
+        shipment_detail = await self._export_single_item(
+            shipment_service, mock_shipment_repo, item
+        )
+
+        # 発注リスト（order_list_generator）が同一入力から生成する文字列
+        order_list_bytes = OrderListGenerator().generate_order_list_csv(
+            [{
+                "product_type": "acrylic_stand",
+                "size": "100mm",
+                "position": None,
+                "color": "クリア",
+            }]
+        )
+        _, order_list_rows = parse_csv_bytes(order_list_bytes)
+        order_list_detail = order_list_rows[0][ORDER_LIST_PRODUCT_TYPE_COL]
+
+        assert shipment_detail == "アクリルフィギュア - 100mm - クリア"
+        assert shipment_detail == order_list_detail

--- a/web/src/app/(dashboard)/purchase-orders/all/page.tsx
+++ b/web/src/app/(dashboard)/purchase-orders/all/page.tsx
@@ -50,13 +50,25 @@ function useDebounce<T>(value: T, delay: number): T {
   return debouncedValue;
 }
 
+// CSV出力の「商品タイプ」列用。発注リスト（order_list_generator）の商品種類名に一致させる
+// （画面表示ラベルとは別。特に acrylic_stand は「アクリルフィギュア」）。
 const productTypeLabels: Record<string, string> = {
   acrylic_keychain: "アクリルキーホルダー",
-  acrylic_stand: "アクリルスタンド",
+  acrylic_stand: "アクリルフィギュア",
   sticker: "ステッカー",
   tote_bag: "トートバッグ",
+  mug: "マグカップ",
   tshirt: "Tシャツ",
 };
+
+// 発注リストと同じ「{商品種類} - {サイズ} - {位置} - {色}」形式に整形（CSV出力用）。
+// 半角 " - " 区切り。値が無い要素（サイズ/位置/色）はスキップする。
+function formatProductDetail(item: AllManufacturerOrderItem): string {
+  const typeName = productTypeLabels[item.product_type] || item.product_type;
+  return [typeName, item.size, item.position, item.color]
+    .filter((v): v is string => Boolean(v))
+    .join(" - ");
+}
 
 const statusLabels: Record<string, string> = {
   ordered: "発注済み",
@@ -194,7 +206,7 @@ export default function AllPurchaseOrdersPage() {
       item.order_number,
       item.uid || "",
       item.product_name,
-      productTypeLabels[item.product_type] || item.product_type,
+      formatProductDetail(item),
       statusLabels[item.status] || item.status,
       item.quantity.toString(),
       item.price.toString(),

--- a/web/tests/unit/issue-79-purchase-order-csv-product-detail.test.tsx
+++ b/web/tests/unit/issue-79-purchase-order-csv-product-detail.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Issue #79: 発注明細CSV（すべての発注ページ）の「商品タイプ」列を、発注リストと同じ
+ * 「{商品種類} - {サイズ} - {位置} - {色}」形式（半角 " - " 区切り、空要素はスキップ）に統一する。
+ *
+ * 対象: web/src/app/(dashboard)/purchase-orders/all/page.tsx の handleExportCSV
+ *
+ * 検証方法: ページを描画して「CSVダウンロード」を押下し、生成された Blob を
+ * URL.createObjectURL のモック経由で取得して中身を検証する。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock API client (page imports it at module level)
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+}))
+
+// Mock SWR (indirectly used by the hooks)
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({
+    data: undefined,
+    error: undefined,
+    isLoading: false,
+    isValidating: false,
+    mutate: vi.fn(),
+  })),
+}))
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+// Mock data hooks
+vi.mock('@/features/purchase-orders/hooks/use-manufacturer-orders', () => ({
+  useAllManufacturerOrderItems: vi.fn(),
+}))
+
+vi.mock('@/features/manufacturers/hooks/use-manufacturers', () => ({
+  useManufacturers: vi.fn(),
+}))
+
+import { useAllManufacturerOrderItems } from '@/features/purchase-orders/hooks/use-manufacturer-orders'
+import { useManufacturers } from '@/features/manufacturers/hooks/use-manufacturers'
+
+// ======================================
+// Mock data
+// ======================================
+
+interface MockOrderItem {
+  id: string
+  order_id: string
+  order_number: string
+  uid: string | null
+  product_id: string
+  product_name: string
+  product_type: string
+  price: number
+  quantity: number
+  size: string | null
+  position: string | null
+  color: string | null
+  design_image_url: string | null
+  thumbnail_image_url: string | null
+  ordered_at: string
+  customer_name: string
+  status: string
+  manufacturer_id: string
+  manufacturer_name: string
+  lead_time_days: number
+  expected_delivery_date: string
+}
+
+function makeItem(overrides: Partial<MockOrderItem>): MockOrderItem {
+  return {
+    id: 'item-x',
+    order_id: 'order-x',
+    order_number: 'ORD-X',
+    uid: 'UID-X',
+    product_id: 'prod-x',
+    product_name: '商品',
+    product_type: 'tshirt',
+    price: 1000,
+    quantity: 1,
+    size: null,
+    position: null,
+    color: null,
+    design_image_url: null,
+    thumbnail_image_url: null,
+    ordered_at: '2026-01-15T10:00:00Z',
+    customer_name: '顧客',
+    status: 'ordered',
+    manufacturer_id: 'mfr-1',
+    manufacturer_name: 'メーカーA',
+    lead_time_days: 7,
+    expected_delivery_date: '2026-01-22',
+    ...overrides,
+  }
+}
+
+const MOCK_ITEMS: MockOrderItem[] = [
+  // 種類・サイズ・位置・色すべてあり
+  makeItem({ id: 'i1', product_type: 'tshirt', size: 'M', position: '正面', color: '白' }),
+  // 位置なし（空要素スキップ）
+  makeItem({ id: 'i2', product_type: 'sticker', size: '100x100mm', position: null, color: 'ホワイト' }),
+  // acrylic_stand → アクリルフィギュア
+  makeItem({ id: 'i3', product_type: 'acrylic_stand', size: '100mm', position: null, color: 'クリア' }),
+  // 属性なし（種類名のみ）
+  makeItem({ id: 'i4', product_type: 'acrylic_keychain', size: null, position: null, color: null }),
+]
+
+// The generated CSV string, captured from the Blob constructor (jsdom's Blob
+// does not implement .text(), so we read the constructor parts directly).
+let capturedCsv = ''
+const OriginalBlob = globalThis.Blob
+
+/** ページを描画し「CSVダウンロード」を押して、生成されたCSV文字列を返す。 */
+async function exportCsvText(): Promise<string> {
+  const user = userEvent.setup()
+  const { default: AllPurchaseOrdersPage } = await import(
+    '@/app/(dashboard)/purchase-orders/all/page'
+  )
+
+  render(<AllPurchaseOrdersPage />)
+
+  const button = screen.getByRole('button', { name: /CSVダウンロード/ })
+  await user.click(button)
+
+  expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+  return capturedCsv
+}
+
+describe('Issue #79: 発注明細CSVの「商品タイプ」列を発注リスト形式に統一', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedCsv = ''
+
+    vi.mocked(useAllManufacturerOrderItems).mockReturnValue({
+      data: {
+        items: MOCK_ITEMS,
+        total: MOCK_ITEMS.length,
+        total_quantity: 4,
+        total_amount: 4000,
+      },
+      isLoading: false,
+      isFiltering: false,
+      error: undefined,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useAllManufacturerOrderItems>)
+
+    vi.mocked(useManufacturers).mockReturnValue({
+      manufacturers: [],
+      isLoading: false,
+      error: undefined,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useManufacturers>)
+
+    // Capture CSV content from the Blob parts; jsdom's Blob lacks .text().
+    vi.stubGlobal(
+      'Blob',
+      class MockBlob extends OriginalBlob {
+        constructor(parts: BlobPart[] = [], options?: BlobPropertyBag) {
+          super(parts, options)
+          capturedCsv = parts
+            .map((p) => (typeof p === 'string' ? p : ''))
+            .join('')
+        }
+      }
+    )
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    URL.revokeObjectURL = vi.fn()
+
+    // Prevent jsdom from attempting to navigate to the blob URL on download.
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('種類・サイズ・位置・色を半角 " - " で連結する（Tシャツ）', async () => {
+    const csv = await exportCsvText()
+    expect(csv).toContain('Tシャツ - M - 正面 - 白')
+  })
+
+  it('値が無い要素（位置なし）をスキップし余分な区切りを出さない（ステッカー）', async () => {
+    const csv = await exportCsvText()
+    expect(csv).toContain('ステッカー - 100x100mm - ホワイト')
+  })
+
+  it('acrylic_stand は「アクリルフィギュア」にマッピングされる', async () => {
+    const csv = await exportCsvText()
+    expect(csv).toContain('アクリルフィギュア - 100mm - クリア')
+    expect(csv).not.toContain('アクリルスタンド')
+  })
+
+  it('サイズ・位置・色が無い場合は商品種類名のみを出力する（アクリルキーホルダー）', async () => {
+    const csv = await exportCsvText()
+    // CSVセルは引用符で囲まれるため、完全一致セルとして検証（末尾に余分な区切りが付かない）
+    expect(csv).toContain('"アクリルキーホルダー"')
+  })
+})


### PR DESCRIPTION
## 概要

**Intent Spec:** #79

### なぜこの変更が必要か

発注明細CSV（発注画面）と配送CSV（配送画面）の「商品種類」列は、これまで基本の商品タイプ名のみ（例: `ステッカー`）を出力していた。これを発注リスト（`order_list_generator`）と同じ `{商品種類} - {サイズ} - {位置} - {色}` 形式（例: `Tシャツ - L - 正面 - 白`）に統一し、帳票間で表記を揃える。

追加のデータ取得は不要で、表示の組み立てのみの変更。連結ロジックが複数箇所に重複していたため、共通ヘルパー `format_product_detail` に集約して重複を増やさないようにした。

**主な変更点**

- `order_list_generator.py` に共通ヘルパー `format_product_detail(product_type, size, position, color)` を追加（半角 ` - ` 区切り、値が無い要素はスキップ、`get_product_type_name` を再利用）。
- 既存の重複していた連結ロジック（発注リストCSV/XLSX生成、発注資料ZIP `manufacturer_order_service`）を同ヘルパーに集約（挙動は不変）。
- **配送CSV**（`shipment_service._append_order_rows`）の商品種類列を統一形式へ変更。
- **発注明細CSV**（フロント `purchase-orders/all/page.tsx` の `handleExportCSV`）の商品タイプ列を統一形式へ変更。`acrylic_stand` → `アクリルフィギュア`、`mug` を追加。
- レビュー（`/simplify max`）で発見した見落とし: **受注CSV**（`order_service.export_csv`、未出荷注文向けの同一の配送業者向けCSV）も同形式に統一。放置すると同じ配送CSVが出荷済み/未出荷で表記が食い違うため。
- 重複していた `_format_product_type`（配送・受注サービス、`acrylic_stand` を旧称「アクリルスタンド」にマップしていた）を削除。

**やっていないこと**（スコープ外）
- 画面上の一覧表示ラベルは変更なし（CSV出力列のみが対象）。
- 発注リスト（③）側の形式・区切りは不変（全角化しない）。
- CSVの列構成・列順・他列は不変。

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | 変更ファイルは新規エラーなし（`tsc --noEmit` の総エラー数は変更前後とも 26 で、いずれも本PRと無関係な既存テストファイル由来）。 |
| リンター | ✅ | ruff / ESLint とも変更ファイルに新規エラーなし（対象バックエンドファイルの既存ベースライン件数は変更前後で不変）。 |
| ユニットテスト | ✅ | 本変更に関わるテストは全通過。バックエンド新規/更新: `TestFormatProductDetail`(6) / 配送CSV(7) / 受注CSV新規(2) / 発注リスト既存。フロント新規4 + 既存回帰22 = 26 passed。 |
| 統合テスト | ⚠️ 未実行 | 本環境（サンドボックス）に PostgreSQL が無いため統合テストは未実行。関連する統合テスト（`tests/integration/test_shipment_export_csv.py`）は列数・18列目のみを検証しており本変更で破壊されない。 |
| 仕様適合 | ✅ | AC 7/7 カバー（下表）。 |
| AI意味レビュー | ✅ | `/simplify max`（reuse / simplification / efficiency / altitude の4観点）を実施。受注CSVの見落とし修正・冗長テストの削減を反映。 |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| 発注明細CSVが `Tシャツ - L - 正面 - 白` を出力 | `web/tests/unit/issue-79-purchase-order-csv-product-detail.test.tsx` | ✅ |
| 配送CSVの商品種類列が同形式 | `api/tests/unit/test_shipment_export_csv.py::TestShipmentExportCsvProductDetail` | ✅ |
| 空要素をスキップ（ステッカー例、区切り重複なし） | `test_order_list_generator.py::TestFormatProductDetail::test_skips_missing_position` ／ フロントのステッカーケース | ✅ |
| `acrylic_stand` が両CSVで `アクリルフィギュア`、発注リストと完全一致 | `test_shipment_export_csv.py::...::test_acrylic_stand_maps_to_acrylic_figure_and_matches_order_list` ／ 受注CSV・フロント | ✅ |
| 区切りは半角 ` - ` | 上記 `TestFormatProductDetail` 一式 | ✅ |
| 既存CSVテスト更新＋発注CSV（フロント）テスト追加 | `test_shipment_export_csv.py` 更新 ／ フロント新規 | ✅ |
| 画面表示ラベルに回帰なし | `feat-0018-all-manufacturer-orders.test.tsx`(22 passed)、画面用ラベルマップは未変更 | ✅ |

## スクリーンショット

N/A — 画面UIの見た目変更はなし（変更対象はCSVファイルの出力内容のみ）。

## レビューのポイント

- **共通ヘルパーへの集約**: `format_product_detail` はバックエンドの単一の真実の源。発注リスト生成・発注資料ZIP・配送CSV・受注CSV が同ヘルパーを共有し、連結ロジックの重複を解消した（発注リスト側の出力は不変）。
- **受注CSV（`order_service.export_csv`）も対象に含めた判断**: Issue本文の明示スコープは①発注明細CSVと②配送CSVだが、`order_service.export_csv` は未出荷注文向けの同一フォーマットの配送業者向けCSV。ここを揃えないと同じ配送CSVが出荷済み/未出荷で食い違い、Issueの目的（表記統一）を満たせないため合わせて修正した。
- **フロントの商品種類マップ**: `page.tsx` のCSV用 `productTypeLabels` は意図的に画面表示ラベル（`acrylic_stand`＝アクリルスタンド）と分離し、バックエンド `PRODUCT_TYPE_NAMES` に一致（アクリルフィギュア）。コメントで意図を明記済み。TS/Python の言語境界のため、フロントはバックエンドの対応表を1箇所でミラーする形とした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F35KgJ7J4pHYJgP1pTm8D

---
_Generated by [Claude Code](https://claude.ai/code/session_012F35KgJ7J4pHYJgP1pTm8D)_