### PR TITLE
メーカー別 発注済み内容の日次メール通知（運営ダッシュボードで宛先To/CC・送信時刻・ON/OFFを設定）

### DIFF
--- a/.github/workflows/manufacturer-daily-digest.yml
+++ b/.github/workflows/manufacturer-daily-digest.yml
@@ -1,0 +1,51 @@
+name: メーカー日次発注通知トリガー
+
+# メーカー別 日次発注ダイジェストメールの外部トリガ。
+# pod-admin API 側で「JST が送信時刻以降 かつ 本日未実行」の場合のみ実際に送信されるため、
+# ここでは高頻度で叩くだけでよい（多重発火でも二重送信しない設計）。
+#
+# 必要な設定（リポジトリの Settings → Secrets and variables → Actions）:
+#   - Variables: API_BASE_URL  例) https://<your-app>.railway.app
+#   - Secrets:   INTERNAL_API_SECRET  （API の環境変数 INTERNAL_API_SECRET と同じ値）
+
+on:
+  schedule:
+    # 15 分ごと（UTC 実行だが送信可否は API 側が JST で判定するため問題なし）
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "時刻・日次ガードを無視して即時送信（手動テスト用）"
+        type: boolean
+        default: false
+
+# 同時実行を抑止（多重発火は API 側でも安全だが念のため直列化）
+concurrency:
+  group: manufacturer-daily-digest
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call internal daily digest endpoint
+        env:
+          API_BASE_URL: ${{ vars.API_BASE_URL }}
+          INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
+          FORCE: ${{ github.event.inputs.force || 'false' }}
+        run: |
+          if [ -z "$API_BASE_URL" ] || [ -z "$INTERNAL_API_SECRET" ]; then
+            echo "API_BASE_URL (variable) と INTERNAL_API_SECRET (secret) を設定してください" >&2
+            exit 1
+          fi
+          url="${API_BASE_URL%/}/api/v1/internal/manufacturer-daily-digest?force=${FORCE}"
+          http_code=$(curl -sS -o /tmp/resp.json -w "%{http_code}" \
+            -X POST "$url" \
+            -H "X-Internal-Secret: ${INTERNAL_API_SECRET}")
+          echo "HTTP ${http_code}"
+          cat /tmp/resp.json || true
+          echo ""
+          if [ "$http_code" -ge 300 ]; then
+            echo "内部エンドポイントの呼び出しに失敗しました" >&2
+            exit 1
+          fi

--- a/api/.env.example
+++ b/api/.env.example
@@ -27,3 +27,11 @@ CONTACT_EMAIL=
 
 # 管理画面のベースURL（受注通知メールの注文詳細リンク用。例: https://pod-admin-beige.vercel.app）
 ADMIN_BASE_URL=
+
+# メーカーポータルのログインURL（メーカー日次発注通知メールに記載。未設定なら既定値を使用）
+MANUFACTURER_LOGIN_URL=https://pod-admin-beige.vercel.app/manufacturer-login
+
+# 内部エンドポイント（メーカー日次発注ダイジェスト）の共有シークレット。
+# 外部トリガ（cron / GitHub Actions 等）が X-Internal-Secret ヘッダーで認証する。
+# 未設定なら内部エンドポイントは無効（403）。例: openssl rand -hex 32
+INTERNAL_API_SECRET=

--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -14,6 +14,9 @@ from app.models.base import Base
 # Import all models here to ensure they are registered with Base.metadata
 from app.models.chat_message import ChatAttachment, ChatMessage  # noqa: F401
 from app.models.manufacturer import Manufacturer  # noqa: F401
+from app.models.manufacturer_notification_settings import (  # noqa: F401
+    ManufacturerNotificationSettings,
+)
 from app.models.order import Order, OrderItem  # noqa: F401
 from app.models.product import Product  # noqa: F401
 from app.models.shipment import Shipment, ShipmentItem  # noqa: F401

--- a/api/alembic/versions/add_manufacturer_notification_settings.py
+++ b/api/alembic/versions/add_manufacturer_notification_settings.py
@@ -1,0 +1,103 @@
+"""Add manufacturer notification settings.
+
+Revision ID: add_mfr_notif_settings
+Revises: add_ext_order_notif_settings
+Create Date: 2026-07-09
+
+メーカー別 日次発注ダイジェストメール機能のためのスキーマ追加。
+- manufacturer_notification_settings テーブル
+  （メーカー別 To/CC・ON/OFF・last_notified_at ウォーターマーク）
+- app_settings キーの seed（全社共通の送信時刻・日次ガード・マスタスイッチ）
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "add_mfr_notif_settings"
+down_revision = "add_ext_order_notif_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "manufacturer_notification_settings",
+        sa.Column("id", sa.UUID(as_uuid=False), nullable=False),
+        sa.Column("manufacturer_id", sa.UUID(as_uuid=False), nullable=False),
+        sa.Column(
+            "daily_digest_enabled",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "to_emails",
+            postgresql.ARRAY(sa.String()),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+        sa.Column(
+            "cc_emails",
+            postgresql.ARRAY(sa.String()),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+        sa.Column("last_notified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["manufacturer_id"], ["manufacturers.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_manufacturer_notification_settings_manufacturer_id"),
+        "manufacturer_notification_settings",
+        ["manufacturer_id"],
+        unique=True,
+    )
+
+    # app_settings のシード（GET /settings に説明付きで並ぶ）
+    op.execute(
+        "INSERT INTO app_settings (key, value, description) "
+        "VALUES ('manufacturer_daily_digest_enabled', 'false', "
+        "'メーカー日次発注通知メールの有効/無効（マスタスイッチ）') "
+        "ON CONFLICT (key) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO app_settings (key, value, description) "
+        "VALUES ('manufacturer_daily_digest_send_time', '09:00', "
+        "'メーカー日次発注通知メールの送信時刻（JST・全社共通・HH:MM）') "
+        "ON CONFLICT (key) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO app_settings (key, value, description) "
+        "VALUES ('manufacturer_daily_digest_last_run_date', '', "
+        "'メーカー日次発注通知メールの最終実行日（JST・YYYY-MM-DD・日次ガード用）') "
+        "ON CONFLICT (key) DO NOTHING"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM app_settings WHERE key IN ("
+        "'manufacturer_daily_digest_enabled', "
+        "'manufacturer_daily_digest_send_time', "
+        "'manufacturer_daily_digest_last_run_date')"
+    )
+    op.drop_index(
+        op.f("ix_manufacturer_notification_settings_manufacturer_id"),
+        table_name="manufacturer_notification_settings",
+    )
+    op.drop_table("manufacturer_notification_settings")

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -54,5 +54,12 @@ class Settings(BaseSettings):
     # 管理画面のベースURL（受注通知メールの注文詳細リンク用、未設定ならリンクを描画しない）
     ADMIN_BASE_URL: str = ""
 
+    # メーカーポータルのログインURL（メーカー日次発注通知メールに記載）
+    MANUFACTURER_LOGIN_URL: str = "https://pod-admin-beige.vercel.app/manufacturer-login"
+
+    # 内部エンドポイント（メーカー日次発注ダイジェスト）の共有シークレット。
+    # 未設定なら内部エンドポイントは無効（403）。外部トリガ(cron等)から X-Internal-Secret で認証する。
+    INTERNAL_API_SECRET: str = ""
+
 
 settings = Settings()

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -1,5 +1,6 @@
 """Dependency injection functions."""
 
+import secrets
 from collections.abc import AsyncGenerator
 from typing import Annotated
 
@@ -13,6 +14,9 @@ from app.models.user import User, UserRole
 from app.repositories.app_setting_repository import AppSettingRepository
 from app.repositories.chat_repository import ChatRepository
 from app.repositories.company_holiday_repository import CompanyHolidayRepository
+from app.repositories.manufacturer_notification_settings_repository import (
+    ManufacturerNotificationSettingsRepository,
+)
 from app.repositories.manufacturer_repository import ManufacturerRepository
 from app.repositories.order_repository import OrderRepository
 from app.repositories.order_source_repository import OrderSourceRepository
@@ -26,6 +30,8 @@ from app.services.email_service import EmailService
 from app.services.external_order_notification import ExternalOrderNotificationService
 from app.services.external_service import ExternalService
 from app.services.invoice_service import InvoiceService
+from app.services.manufacturer_daily_digest import ManufacturerDailyDigestService
+from app.services.manufacturer_notification import ManufacturerNotificationService
 from app.services.manufacturer_order_service import ManufacturerOrderService
 from app.services.manufacturer_portal_service import ManufacturerPortalService
 from app.services.manufacturer_service import ManufacturerService
@@ -110,6 +116,13 @@ def get_app_setting_repository(
     return AppSettingRepository(db)
 
 
+def get_manufacturer_notification_settings_repository(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> ManufacturerNotificationSettingsRepository:
+    """Get manufacturer notification settings repository."""
+    return ManufacturerNotificationSettingsRepository(db)
+
+
 # Service dependencies
 def get_auth_service(
     user_repo: Annotated[UserRepository, Depends(get_user_repository)],
@@ -157,6 +170,7 @@ def get_email_service() -> EmailService | None:
         from_email=settings.SENDGRID_FROM_EMAIL,
         contact_email=settings.CONTACT_EMAIL,
         admin_base_url=settings.ADMIN_BASE_URL,
+        manufacturer_login_url=settings.MANUFACTURER_LOGIN_URL,
     )
 
 
@@ -166,6 +180,33 @@ def get_external_order_notification_service(
 ) -> ExternalOrderNotificationService:
     """Get external order notification service."""
     return ExternalOrderNotificationService(app_setting_repo, email_service)
+
+
+def get_manufacturer_notification_service(
+    notif_repo: Annotated[
+        ManufacturerNotificationSettingsRepository,
+        Depends(get_manufacturer_notification_settings_repository),
+    ],
+    manufacturer_repo: Annotated[ManufacturerRepository, Depends(get_manufacturer_repository)],
+) -> ManufacturerNotificationService:
+    """Get manufacturer notification settings CRUD service."""
+    return ManufacturerNotificationService(notif_repo, manufacturer_repo)
+
+
+def get_manufacturer_daily_digest_service(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
+    notif_repo: Annotated[
+        ManufacturerNotificationSettingsRepository,
+        Depends(get_manufacturer_notification_settings_repository),
+    ],
+    app_setting_repo: Annotated[AppSettingRepository, Depends(get_app_setting_repository)],
+    email_service: Annotated[EmailService | None, Depends(get_email_service)],
+) -> ManufacturerDailyDigestService:
+    """Get manufacturer daily digest batch service."""
+    return ManufacturerDailyDigestService(
+        db, order_repo, notif_repo, app_setting_repo, email_service
+    )
 
 
 def get_shipment_service(
@@ -330,3 +371,19 @@ async def verify_api_key(
         return x_api_key, order_source.id
 
     raise UnauthorizedError("Invalid API key")
+
+
+# Internal shared-secret authentication (for cron/GitHub Actions triggers)
+async def verify_internal_secret(
+    x_internal_secret: Annotated[str | None, Header(alias="X-Internal-Secret")] = None,
+) -> None:
+    """内部エンドポイント用の共有シークレット認証.
+
+    INTERNAL_API_SECRET が未設定なら内部エンドポイントは無効（403）。
+    ヘッダー X-Internal-Secret が一致しなければ 401。定数時間比較を用いる。
+    """
+    secret = settings.INTERNAL_API_SECRET
+    if not secret:
+        raise ForbiddenError("Internal API is not configured")
+    if not x_internal_secret or not secrets.compare_digest(x_internal_secret, secret):
+        raise UnauthorizedError("Invalid internal secret")

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -11,6 +11,7 @@ from app.routers import (
     company_holidays,
     dashboard,
     external,
+    internal,
     manufacturer_portal,
     manufacturers,
     orders,
@@ -78,6 +79,7 @@ app.include_router(shipments.router, prefix=settings.API_V1_PREFIX)
 app.include_router(chat.router, prefix=settings.API_V1_PREFIX)
 app.include_router(dashboard.router, prefix=settings.API_V1_PREFIX)
 app.include_router(external.router, prefix=settings.API_V1_PREFIX)
+app.include_router(internal.router, prefix=settings.API_V1_PREFIX)
 app.include_router(settings_router.router, prefix=settings.API_V1_PREFIX)
 app.include_router(company_holidays.router, prefix=settings.API_V1_PREFIX)
 

--- a/api/app/models/manufacturer_notification_settings.py
+++ b/api/app/models/manufacturer_notification_settings.py
@@ -1,0 +1,48 @@
+"""Manufacturer notification settings model."""
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, text
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class ManufacturerNotificationSettings(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    """メーカー別の通知設定モデル.
+
+    日次発注ダイジェストメールの宛先（To/CC・各複数可）と有効/無効、および
+    「新規の発注済み」判定の基準となる last_notified_at（ウォーターマーク）を保持する。
+    メーカー 1 件につき 1 行（manufacturer_id は unique）。
+    """
+
+    __tablename__ = "manufacturer_notification_settings"
+
+    manufacturer_id: Mapped[str] = mapped_column(
+        ForeignKey("manufacturers.id", ondelete="CASCADE"),
+        unique=True,
+        index=True,
+    )
+    # メーカー別 ON/OFF
+    daily_digest_enabled: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default=text("false"), nullable=False
+    )
+    # To（複数可）。空の場合は送信時に manufacturer.email をデフォルトにする
+    to_emails: Mapped[list[str]] = mapped_column(
+        ARRAY(String), default=list, server_default=text("'{}'"), nullable=False
+    )
+    # CC（複数可）
+    cc_emails: Mapped[list[str]] = mapped_column(
+        ARRAY(String), default=list, server_default=text("'{}'"), nullable=False
+    )
+    # 新規分判定の基準（ウォーターマーク）。送信成功時のみ実行時刻へ更新する
+    last_notified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    def __repr__(self) -> str:
+        return (
+            "<ManufacturerNotificationSettings("
+            f"manufacturer_id={self.manufacturer_id}, enabled={self.daily_digest_enabled})>"
+        )

--- a/api/app/repositories/app_setting_repository.py
+++ b/api/app/repositories/app_setting_repository.py
@@ -1,6 +1,6 @@
 """App setting repository."""
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.app_setting import AppSetting
@@ -39,3 +39,26 @@ class AppSettingRepository:
         await self._db.flush()
         await self._db.refresh(setting)
         return setting
+
+    async def claim_daily_run(self, key: str, date_str: str) -> bool:
+        """本日分の実行権を原子的に取得する（日次ガード）.
+
+        value を条件付きで date_str に更新する。既に value == date_str
+        （＝本日実行済み）の場合は何も更新せず False を返す。取得できたら True。
+
+        条件付き UPDATE の rowcount を使うことで、外部トリガの多重発火が
+        同時に到達しても本処理を実行するのは 1 回だけに保証する。
+        """
+        # 行が存在しない場合のみ空値で作成（通常はマイグレーションで seed 済み）
+        existing = await self.find_by_key(key)
+        if existing is None:
+            self._db.add(AppSetting(key=key, value=""))
+            await self._db.flush()
+
+        result = await self._db.execute(
+            update(AppSetting)
+            .where(AppSetting.key == key, AppSetting.value != date_str)
+            .values(value=date_str)
+            .returning(AppSetting.key)
+        )
+        return result.first() is not None

--- a/api/app/repositories/manufacturer_notification_settings_repository.py
+++ b/api/app/repositories/manufacturer_notification_settings_repository.py
@@ -1,0 +1,70 @@
+"""Manufacturer notification settings repository."""
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.manufacturer import Manufacturer
+from app.models.manufacturer_notification_settings import ManufacturerNotificationSettings
+
+
+class ManufacturerNotificationSettingsRepository:
+    """Repository for ManufacturerNotificationSettings model."""
+
+    def __init__(self, db: AsyncSession):
+        self._db = db
+
+    async def find_by_manufacturer_id(
+        self, manufacturer_id: str
+    ) -> ManufacturerNotificationSettings | None:
+        """メーカーIDで通知設定を取得する."""
+        result = await self._db.execute(
+            select(ManufacturerNotificationSettings).where(
+                ManufacturerNotificationSettings.manufacturer_id == manufacturer_id
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert(
+        self,
+        manufacturer_id: str,
+        *,
+        daily_digest_enabled: bool,
+        to_emails: list[str],
+        cc_emails: list[str],
+    ) -> ManufacturerNotificationSettings:
+        """通知設定を作成または更新する（last_notified_at は変更しない）."""
+        settings = await self.find_by_manufacturer_id(manufacturer_id)
+        if settings is None:
+            settings = ManufacturerNotificationSettings(manufacturer_id=manufacturer_id)
+            self._db.add(settings)
+        settings.daily_digest_enabled = daily_digest_enabled
+        settings.to_emails = to_emails
+        settings.cc_emails = cc_emails
+        await self._db.flush()
+        await self._db.refresh(settings)
+        return settings
+
+    async def list_enabled_with_manufacturer(
+        self,
+    ) -> list[tuple[ManufacturerNotificationSettings, Manufacturer]]:
+        """通知 ON かつ有効なメーカーの (設定, メーカー) の一覧を返す."""
+        result = await self._db.execute(
+            select(ManufacturerNotificationSettings, Manufacturer)
+            .join(
+                Manufacturer,
+                Manufacturer.id == ManufacturerNotificationSettings.manufacturer_id,
+            )
+            .where(ManufacturerNotificationSettings.daily_digest_enabled.is_(True))
+            .where(Manufacturer.is_active.is_(True))
+            .order_by(Manufacturer.name)
+        )
+        return [(row[0], row[1]) for row in result.all()]
+
+    async def update_last_notified_at(
+        self, settings: ManufacturerNotificationSettings, notified_at: datetime
+    ) -> None:
+        """送信成功時のウォーターマークを更新する."""
+        settings.last_notified_at = notified_at
+        await self._db.flush()

--- a/api/app/repositories/order_repository.py
+++ b/api/app/repositories/order_repository.py
@@ -1,6 +1,6 @@
 """Order repository for database operations."""
 
-from datetime import date
+from datetime import date, datetime
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -239,6 +239,46 @@ class OrderRepository:
 
         result = await self._db.execute(query)
         return [dict(row._mapping) for row in result.all()]
+
+    async def get_new_ordered_summary_by_manufacturer(
+        self,
+        manufacturer_id: str,
+        since: datetime | None = None,
+    ) -> dict[str, int]:
+        """メーカー別の「新規の発注済み」明細サマリーを取得（時間窓フィルタ版）.
+
+        get_ordered_items_summary_by_manufacturer() の時間窓版。
+        対象明細 = OrderItem WHERE Product.manufacturer_id = manufacturer_id
+                   AND OrderItem.status = ORDERED
+                   AND (since が None でなければ OrderItem.created_at > since)
+
+        注: ORDERED は発注時の初期ステータスのため、OrderItem.created_at を
+        「発注済みになった時刻」とみなす。
+
+        Returns:
+            {"ordered_item_count": 明細数, "total_quantity": 合計数量}
+        """
+        from app.models.product import Product
+
+        query = (
+            select(
+                func.count(OrderItem.id).label("ordered_item_count"),
+                func.coalesce(func.sum(OrderItem.quantity), 0).label("total_quantity"),
+            )
+            .select_from(OrderItem)
+            .join(Product, Product.id == OrderItem.product_id)
+            .where(Product.manufacturer_id == manufacturer_id)
+            .where(OrderItem.status == OrderItemStatus.ORDERED.value)
+        )
+        if since is not None:
+            query = query.where(OrderItem.created_at > since)
+
+        result = await self._db.execute(query)
+        row = result.one()
+        return {
+            "ordered_item_count": int(row.ordered_item_count or 0),
+            "total_quantity": int(row.total_quantity or 0),
+        }
 
     async def find_ordered_items_by_manufacturer_detail(
         self,

--- a/api/app/routers/internal.py
+++ b/api/app/routers/internal.py
@@ -1,0 +1,39 @@
+"""Internal API router (protected by a shared secret).
+
+外部トリガ（ホスティングの cron / GitHub Actions 等）から叩くための内部エンドポイント。
+共有シークレット（X-Internal-Secret）で保護する。
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from app.dependencies import (
+    get_manufacturer_daily_digest_service,
+    verify_internal_secret,
+)
+from app.services.manufacturer_daily_digest import ManufacturerDailyDigestService
+
+router = APIRouter(prefix="/internal", tags=["internal"])
+
+
+@router.post("/manufacturer-daily-digest")
+async def run_manufacturer_daily_digest(
+    service: Annotated[
+        ManufacturerDailyDigestService, Depends(get_manufacturer_daily_digest_service)
+    ],
+    _: Annotated[None, Depends(verify_internal_secret)],
+    force: bool = False,
+) -> dict[str, object]:
+    """メーカー日次発注ダイジェストの送信判定・送信を実行する.
+
+    外部トリガが高頻度（例: 5〜15 分毎）で叩く。現在 JST が設定時刻以降かつ
+    本日未実行の場合のみ本処理を実行し、通知 ON かつ新規発注済み ≥ 1 件の
+    メーカーへメールを送る。多重発火でも日次ガードと per-manufacturer の
+    ウォーターマークにより二重送信しない。
+
+    Args:
+        force: True で時刻・日次・マスタスイッチの各ガードを無視して即時送信
+            （手動再実行・テスト用）。
+    """
+    return await service.run_daily_digest(force=force)

--- a/api/app/routers/manufacturers.py
+++ b/api/app/routers/manufacturers.py
@@ -12,6 +12,7 @@ from app.dependencies import (
     get_chat_service,
     get_current_admin,
     get_invoice_service,
+    get_manufacturer_notification_service,
     get_manufacturer_order_service,
     get_manufacturer_service,
     get_order_list_service,
@@ -35,8 +36,13 @@ from app.schemas.manufacturer import (
     ManufacturerResponse,
     ManufacturerUpdate,
 )
+from app.schemas.manufacturer_notification import (
+    ManufacturerNotificationSettingsResponse,
+    ManufacturerNotificationSettingsUpdate,
+)
 from app.services.chat_service import ChatService
 from app.services.invoice_service import InvoiceService
+from app.services.manufacturer_notification import ManufacturerNotificationService
 from app.services.manufacturer_order_service import ManufacturerOrderService
 from app.services.manufacturer_service import ManufacturerService
 from app.services.order_list_service import OrderListService
@@ -160,6 +166,40 @@ async def delete_manufacturer(
 ) -> None:
     """Delete a manufacturer."""
     await service.delete(manufacturer_id)
+
+
+# === メーカー別 通知設定エンドポイント ===
+
+
+@router.get(
+    "/{manufacturer_id}/notification-settings",
+    response_model=ManufacturerNotificationSettingsResponse,
+)
+async def get_manufacturer_notification_settings(
+    manufacturer_id: str,
+    service: Annotated[
+        ManufacturerNotificationService, Depends(get_manufacturer_notification_service)
+    ],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ManufacturerNotificationSettingsResponse:
+    """メーカー別の通知設定を取得する（未登録ならデフォルト値を返す）."""
+    return await service.get_settings(manufacturer_id)
+
+
+@router.put(
+    "/{manufacturer_id}/notification-settings",
+    response_model=ManufacturerNotificationSettingsResponse,
+)
+async def update_manufacturer_notification_settings(
+    manufacturer_id: str,
+    data: ManufacturerNotificationSettingsUpdate,
+    service: Annotated[
+        ManufacturerNotificationService, Depends(get_manufacturer_notification_service)
+    ],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ManufacturerNotificationSettingsResponse:
+    """メーカー別の通知設定（To/CC・ON/OFF）を更新する."""
+    return await service.update_settings(manufacturer_id, data)
 
 
 @router.get("/{manufacturer_id}/order-list")

--- a/api/app/routers/settings.py
+++ b/api/app/routers/settings.py
@@ -25,6 +25,11 @@ from app.services.external_order_notification import (
     NOTIFICATION_RECIPIENTS_KEY,
     validate_setting_value,
 )
+from app.services.manufacturer_notification import (
+    DIGEST_ENABLED_KEY,
+    DIGEST_SEND_TIME_KEY,
+    validate_digest_setting_value,
+)
 from app.utils.exceptions import AppException
 
 router = APIRouter(prefix="/settings", tags=["settings"])
@@ -70,6 +75,13 @@ async def update_setting(
     if key in (NOTIFICATION_ENABLED_KEY, NOTIFICATION_RECIPIENTS_KEY):
         try:
             validate_setting_value(key, data.value)
+        except ValueError as e:
+            raise AppException(422, "VALIDATION_ERROR", str(e)) from None
+
+    # Validate manufacturer daily digest settings (送信時刻・マスタスイッチ).
+    if key in (DIGEST_ENABLED_KEY, DIGEST_SEND_TIME_KEY):
+        try:
+            validate_digest_setting_value(key, data.value)
         except ValueError as e:
             raise AppException(422, "VALIDATION_ERROR", str(e)) from None
 

--- a/api/app/schemas/manufacturer_notification.py
+++ b/api/app/schemas/manufacturer_notification.py
@@ -1,0 +1,30 @@
+"""Manufacturer notification settings schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ManufacturerNotificationSettingsResponse(BaseModel):
+    """メーカー別 通知設定レスポンス."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    manufacturer_id: str
+    daily_digest_enabled: bool
+    # To 未設定時は送信側で manufacturer.email をデフォルトにする
+    to_emails: list[str]
+    cc_emails: list[str]
+    last_notified_at: datetime | None = None
+
+
+class ManufacturerNotificationSettingsUpdate(BaseModel):
+    """メーカー別 通知設定 更新リクエスト.
+
+    メールアドレスの形式・件数はサービス層で検証し、日本語メッセージ付きの
+    422 を返す（フロントの共通エラー envelope に乗せるため）。
+    """
+
+    daily_digest_enabled: bool = False
+    to_emails: list[str] = Field(default_factory=list)
+    cc_emails: list[str] = Field(default_factory=list)

--- a/api/app/services/email_service.py
+++ b/api/app/services/email_service.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from jinja2 import Environment, FileSystemLoader
 from sendgrid import SendGridAPIClient
-from sendgrid.helpers.mail import Content, From, Mail, To
+from sendgrid.helpers.mail import Cc, Content, From, Mail, Personalization, To
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +28,13 @@ class EmailService:
         from_email: str,
         contact_email: str,
         admin_base_url: str = "",
+        manufacturer_login_url: str = "",
     ):
         self._client = SendGridAPIClient(api_key)
         self._from_email = from_email
         self._contact_email = contact_email
         self._admin_base_url = admin_base_url
+        self._manufacturer_login_url = manufacturer_login_url
         self._jinja_env = Environment(
             loader=FileSystemLoader(str(TEMPLATES_DIR)),
             autoescape=True,
@@ -205,6 +207,102 @@ class EmailService:
                 f"Failed to send external order notification for order {order_number}"
             )
             return False
+
+    async def send_manufacturer_daily_digest(
+        self,
+        to_emails: list[str],
+        manufacturer_name: str,
+        item_count: int,
+        total_quantity: int,
+        cc_emails: list[str] | None = None,
+        sent_date: date | None = None,
+    ) -> bool:
+        """Send the daily "ordered items" digest to a manufacturer.
+
+        メーカー宛の日次発注ダイジェスト。新規に発注済みになった明細の
+        件数・合計数量とログインURLを通知する。
+
+        Args:
+            to_emails: 宛先（To、複数可）。呼び出し側で空にならないことを保証する。
+            manufacturer_name: メーカー名（件名に使用）。
+            item_count: 発注中明細数。
+            total_quantity: 合計数量。
+            cc_emails: CC（複数可）。
+            sent_date: 送信日（JST の date）。未指定なら現在の JST 日付。
+
+        Returns:
+            True if sent successfully, False otherwise. Never raises exceptions.
+        """
+        try:
+            send_day = sent_date or datetime.now(JST).date()
+            # 件名の日付は JST・2桁年・月日ゼロ埋めなし（例: 2026/6/16 → 26/6/16）
+            subject = (
+                f"【TOSYO__API発注依頼】{manufacturer_name}様"
+                f"{send_day.year % 100}/{send_day.month}/{send_day.day}"
+            )
+            login_url = self._manufacturer_login_url
+
+            template = self._jinja_env.get_template("manufacturer_daily_digest.html")
+            html_content = template.render(
+                manufacturer_name=manufacturer_name,
+                item_count=item_count,
+                total_quantity=total_quantity,
+                login_url=login_url,
+            )
+            text_content = self._build_manufacturer_daily_digest_text(
+                item_count=item_count,
+                total_quantity=total_quantity,
+                login_url=login_url,
+            )
+
+            message = Mail(from_email=From(self._from_email), subject=subject)
+            personalization = Personalization()
+            for email in to_emails:
+                personalization.add_to(To(email))
+            for email in cc_emails or []:
+                personalization.add_cc(Cc(email))
+            message.add_personalization(personalization)
+            message.content = [
+                Content("text/plain", text_content),
+                Content("text/html", html_content),
+            ]
+
+            response = await asyncio.to_thread(self._client.send, message)
+
+            if response.status_code in (200, 201, 202):
+                logger.info(
+                    "Manufacturer daily digest sent to %s (cc=%d): %d items",
+                    manufacturer_name,
+                    len(cc_emails or []),
+                    item_count,
+                )
+                return True
+            logger.warning(
+                "SendGrid returned status %s for manufacturer daily digest to %s",
+                response.status_code,
+                manufacturer_name,
+            )
+            return False
+        except Exception:
+            logger.exception(
+                "Failed to send manufacturer daily digest to %s", manufacturer_name
+            )
+            return False
+
+    def _build_manufacturer_daily_digest_text(
+        self,
+        item_count: int,
+        total_quantity: int,
+        login_url: str,
+    ) -> str:
+        """Build plain text content for the manufacturer daily digest (画像仕様準拠)."""
+        return (
+            "以下、発注済みの注文があります。\n\n"
+            f"発注中明細数　{item_count} 件\n"
+            f"合計数量　{total_quantity} 点\n\n"
+            f"{login_url}\n"
+            "からログインしてご確認ください。\n"
+        )
 
     def _build_external_order_text(
         self,

--- a/api/app/services/manufacturer_daily_digest.py
+++ b/api/app/services/manufacturer_daily_digest.py
@@ -1,0 +1,179 @@
+"""Manufacturer daily digest — 日次発注ダイジェストメールの送信バッチ.
+
+外部トリガ（cron / GitHub Actions 等）が高頻度で内部エンドポイントを叩く。
+本サービスは「現在 JST が送信時刻以降」かつ「本日未実行」の場合のみ本処理を実行する。
+
+冪等性:
+- 全社日次ガード: app_settings の last_run_date を原子的に claim（多重発火でも 1 回だけ）
+- メーカー別ウォーターマーク: last_notified_at を送信成功時のみ更新（新規分のみ・二重送信防止）
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+from app.services.manufacturer_notification import (
+    DIGEST_ENABLED_KEY,
+    DIGEST_LAST_RUN_DATE_KEY,
+    DIGEST_SEND_TIME_KEY,
+    parse_send_time,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.repositories.app_setting_repository import AppSettingRepository
+    from app.repositories.manufacturer_notification_settings_repository import (
+        ManufacturerNotificationSettingsRepository,
+    )
+    from app.repositories.order_repository import OrderRepository
+    from app.services.email_service import EmailService
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+class ManufacturerDailyDigestService:
+    """メーカー別 日次発注ダイジェストの送信判定・集計・送信を行うバッチサービス."""
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        order_repo: OrderRepository,
+        notif_repo: ManufacturerNotificationSettingsRepository,
+        app_setting_repo: AppSettingRepository,
+        email_service: EmailService | None,
+    ) -> None:
+        self._db = db
+        self._order_repo = order_repo
+        self._notif_repo = notif_repo
+        self._app_setting_repo = app_setting_repo
+        self._email_service = email_service
+
+    async def run_daily_digest(
+        self,
+        *,
+        force: bool = False,
+        now: datetime | None = None,
+    ) -> dict[str, object]:
+        """日次ダイジェストの送信判定と送信を行う.
+
+        Args:
+            force: True の場合、時刻・日次・マスタスイッチの各ガードを無視して即時送信する
+                （手動再実行・テスト用）。
+            now: 現在時刻（テスト用に注入可能）。未指定なら現在時刻を用いる。
+
+        Returns:
+            実行結果のサマリー dict。
+        """
+        now_jst = (now or datetime.now(JST)).astimezone(JST)
+        today_str = now_jst.date().isoformat()
+
+        if not force:
+            skip_reason = await self._check_gates(now_jst, today_str)
+            if skip_reason is not None:
+                return self._result(ran=False, reason=skip_reason)
+            # 日次ガードを確定させ、後続処理が失敗しても本日の再実行はしない
+            await self._db.commit()
+
+        sent: list[str] = []
+        skipped_zero: list[str] = []
+        failed: list[str] = []
+
+        pairs = await self._notif_repo.list_enabled_with_manufacturer()
+        for settings, manufacturer in pairs:
+            summary = await self._order_repo.get_new_ordered_summary_by_manufacturer(
+                manufacturer.id, since=settings.last_notified_at
+            )
+            item_count = summary["ordered_item_count"]
+            if item_count == 0:
+                # 新規の発注済みが 0 件のメーカーは送信しない
+                skipped_zero.append(manufacturer.id)
+                continue
+
+            to_emails = settings.to_emails or (
+                [manufacturer.email] if manufacturer.email else []
+            )
+            if not to_emails:
+                failed.append(manufacturer.id)
+                continue
+
+            ok = False
+            if self._email_service is not None:
+                ok = await self._email_service.send_manufacturer_daily_digest(
+                    to_emails=to_emails,
+                    manufacturer_name=manufacturer.name,
+                    item_count=item_count,
+                    total_quantity=summary["total_quantity"],
+                    cc_emails=settings.cc_emails,
+                    sent_date=now_jst.date(),
+                )
+
+            if ok:
+                # 送信成功時のみウォーターマークを実行時刻へ更新
+                await self._notif_repo.update_last_notified_at(settings, now_jst)
+                sent.append(manufacturer.id)
+            else:
+                failed.append(manufacturer.id)
+
+        await self._db.commit()
+        return self._result(
+            ran=True,
+            reason="ok",
+            run_date=today_str,
+            sent=sent,
+            skipped_zero=skipped_zero,
+            failed=failed,
+        )
+
+    async def _check_gates(self, now_jst: datetime, today_str: str) -> str | None:
+        """送信可否のガードを判定する。スキップすべき理由を返す（送信可なら None）.
+
+        通過した場合、副作用として本日分の日次ガードを claim 済みにする。
+        """
+        # マスタスイッチ
+        enabled = await self._app_setting_repo.find_by_key(DIGEST_ENABLED_KEY)
+        if enabled is None or enabled.value != "true":
+            return "disabled"
+
+        # 送信時刻ガード（現在 JST が送信時刻以降か）
+        send_time_setting = await self._app_setting_repo.find_by_key(DIGEST_SEND_TIME_KEY)
+        if send_time_setting is None or not send_time_setting.value:
+            return "send_time_not_set"
+        if now_jst.time() < parse_send_time(send_time_setting.value):
+            return "before_send_time"
+
+        # 日次ガード（本日実行済みならスキップ）: 原子的 claim
+        claimed = await self._app_setting_repo.claim_daily_run(
+            DIGEST_LAST_RUN_DATE_KEY, today_str
+        )
+        if not claimed:
+            return "already_ran_today"
+
+        return None
+
+    @staticmethod
+    def _result(
+        *,
+        ran: bool,
+        reason: str,
+        run_date: str | None = None,
+        sent: list[str] | None = None,
+        skipped_zero: list[str] | None = None,
+        failed: list[str] | None = None,
+    ) -> dict[str, object]:
+        sent = sent or []
+        skipped_zero = skipped_zero or []
+        failed = failed or []
+        return {
+            "ran": ran,
+            "reason": reason,
+            "run_date": run_date,
+            "sent_count": len(sent),
+            "skipped_zero_count": len(skipped_zero),
+            "failed_count": len(failed),
+            "sent_manufacturer_ids": sent,
+            "skipped_zero_manufacturer_ids": skipped_zero,
+            "failed_manufacturer_ids": failed,
+        }

--- a/api/app/services/manufacturer_notification.py
+++ b/api/app/services/manufacturer_notification.py
@@ -1,0 +1,134 @@
+"""Manufacturer notification settings — 設定キー・バリデーション・CRUD サービス.
+
+メーカー別 日次発注ダイジェストメールの設定を扱う。
+- 全社共通の設定は app_settings（key-value）で管理する（送信時刻・マスタスイッチ・日次ガード）。
+- メーカー別の宛先(To/CC)・ON/OFF は manufacturer_notification_settings テーブルで管理する。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time
+from typing import TYPE_CHECKING
+
+from email_validator import EmailNotValidError, validate_email
+
+from app.schemas.manufacturer_notification import (
+    ManufacturerNotificationSettingsResponse,
+    ManufacturerNotificationSettingsUpdate,
+)
+from app.utils.exceptions import AppException, ManufacturerNotFoundError
+
+if TYPE_CHECKING:
+    from app.repositories.manufacturer_notification_settings_repository import (
+        ManufacturerNotificationSettingsRepository,
+    )
+    from app.repositories.manufacturer_repository import ManufacturerRepository
+
+# app_settings のキー（全社共通）
+DIGEST_ENABLED_KEY = "manufacturer_daily_digest_enabled"
+DIGEST_SEND_TIME_KEY = "manufacturer_daily_digest_send_time"
+DIGEST_LAST_RUN_DATE_KEY = "manufacturer_daily_digest_last_run_date"
+
+# 宛先の上限（To/CC それぞれ）
+MAX_EMAILS = 20
+
+
+def normalize_emails(emails: list[str]) -> list[str]:
+    """前後空白を除去し、空要素を落とし、重複を除いて順序を保つ."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for raw in emails:
+        addr = raw.strip()
+        if not addr or addr in seen:
+            continue
+        seen.add(addr)
+        result.append(addr)
+    return result
+
+
+def validate_emails(emails: list[str]) -> None:
+    """メールアドレスの形式と件数を検証する（不正なら日本語 ValueError）."""
+    if len(emails) > MAX_EMAILS:
+        raise ValueError(f"メールアドレスは最大{MAX_EMAILS}件まで登録できます")
+    for addr in emails:
+        try:
+            validate_email(addr, check_deliverability=False)
+        except EmailNotValidError:
+            raise ValueError(f"メールアドレスの形式が正しくありません: {addr}") from None
+
+
+def parse_send_time(value: str) -> time:
+    """"HH:MM" を time に変換する（不正なら日本語 ValueError）."""
+    try:
+        parsed = datetime.strptime(value.strip(), "%H:%M")
+    except ValueError:
+        raise ValueError('送信時刻は "HH:MM"（24時間表記）で指定してください') from None
+    return parsed.time()
+
+
+def validate_digest_setting_value(key: str, value: str) -> None:
+    """app_settings（メーカー日次通知）の設定値を検証する.
+
+    ルーターでキャッチして 422 に変換する前提で、日本語メッセージ付きの
+    ValueError を送出する。
+    """
+    if key == DIGEST_ENABLED_KEY:
+        if value not in ("true", "false"):
+            raise ValueError('通知の有効/無効は "true" または "false" で指定してください')
+    elif key == DIGEST_SEND_TIME_KEY:
+        parse_send_time(value)
+
+
+class ManufacturerNotificationService:
+    """メーカー別 通知設定の取得・更新（運営ダッシュボード用 CRUD）."""
+
+    def __init__(
+        self,
+        notif_repo: ManufacturerNotificationSettingsRepository,
+        manufacturer_repo: ManufacturerRepository,
+    ) -> None:
+        self._notif_repo = notif_repo
+        self._manufacturer_repo = manufacturer_repo
+
+    async def get_settings(
+        self, manufacturer_id: str
+    ) -> ManufacturerNotificationSettingsResponse:
+        """メーカーの通知設定を取得する（未登録ならデフォルト値を返す）."""
+        await self._require_manufacturer(manufacturer_id)
+        settings = await self._notif_repo.find_by_manufacturer_id(manufacturer_id)
+        if settings is None:
+            return ManufacturerNotificationSettingsResponse(
+                manufacturer_id=manufacturer_id,
+                daily_digest_enabled=False,
+                to_emails=[],
+                cc_emails=[],
+                last_notified_at=None,
+            )
+        return ManufacturerNotificationSettingsResponse.model_validate(settings)
+
+    async def update_settings(
+        self,
+        manufacturer_id: str,
+        data: ManufacturerNotificationSettingsUpdate,
+    ) -> ManufacturerNotificationSettingsResponse:
+        """メーカーの通知設定を更新する（last_notified_at は保持）."""
+        await self._require_manufacturer(manufacturer_id)
+        to_emails = normalize_emails(data.to_emails)
+        cc_emails = normalize_emails(data.cc_emails)
+        try:
+            validate_emails(to_emails)
+            validate_emails(cc_emails)
+        except ValueError as e:
+            raise AppException(422, "VALIDATION_ERROR", str(e)) from None
+        settings = await self._notif_repo.upsert(
+            manufacturer_id,
+            daily_digest_enabled=data.daily_digest_enabled,
+            to_emails=to_emails,
+            cc_emails=cc_emails,
+        )
+        return ManufacturerNotificationSettingsResponse.model_validate(settings)
+
+    async def _require_manufacturer(self, manufacturer_id: str) -> None:
+        manufacturer = await self._manufacturer_repo.find_by_id(manufacturer_id)
+        if manufacturer is None:
+            raise ManufacturerNotFoundError(manufacturer_id)

--- a/api/app/templates/manufacturer_daily_digest.html
+++ b/api/app/templates/manufacturer_daily_digest.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0; padding:0; background-color:#f5f5f5; font-family:'Helvetica Neue',Arial,'Hiragino Kaku Gothic ProN',sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5; padding:20px 0;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; overflow:hidden;">
+          <!-- Header -->
+          <tr>
+            <td style="background-color:#16a34a; padding:24px 32px; text-align:center;">
+              <h1 style="margin:0; color:#ffffff; font-size:20px; font-weight:bold;">発注済みの注文があります</h1>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              <p style="margin:0 0 24px; font-size:14px; color:#555555; line-height:1.6;">
+                {{ manufacturer_name }} 様<br>
+                以下、発注済みの注文があります。
+              </p>
+              <!-- Summary -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f8fafc; border-radius:6px; margin-bottom:24px;">
+                <tr>
+                  <td style="padding:20px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="padding:6px 0; font-size:13px; color:#666666; width:120px;">発注中明細数</td>
+                        <td style="padding:6px 0; font-size:16px; color:#333333; font-weight:bold;">{{ item_count }} 件</td>
+                      </tr>
+                      <tr>
+                        <td style="padding:6px 0; font-size:13px; color:#666666;">合計数量</td>
+                        <td style="padding:6px 0; font-size:16px; color:#333333; font-weight:bold;">{{ total_quantity }} 点</td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 8px; text-align:center;">
+                <a href="{{ login_url }}" style="display:inline-block; background-color:#16a34a; color:#ffffff; font-size:14px; text-decoration:none; padding:12px 24px; border-radius:6px;">ログインして確認する</a>
+              </p>
+              <p style="margin:16px 0 0; font-size:13px; color:#666666; line-height:1.6; text-align:center;">
+                <a href="{{ login_url }}" style="color:#16a34a;">{{ login_url }}</a><br>
+                からログインしてご確認ください。
+              </p>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background-color:#f8fafc; padding:20px 32px; text-align:center; border-top:1px solid #e5e7eb;">
+              <p style="margin:0; font-size:12px; color:#999999;">TOSYO__API 発注依頼</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/api/tests/integration/test_manufacturer_daily_digest_flow.py
+++ b/api/tests/integration/test_manufacturer_daily_digest_flow.py
@@ -1,0 +1,186 @@
+"""Integration test for the manufacturer daily digest end-to-end flow (requires DB).
+
+実際の DB に対して集計クエリ・原子的な日次 claim・ウォーターマーク更新を検証する。
+メール送信は依存性オーバーライドでモックする。
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings as app_settings
+from app.dependencies import get_email_service
+from app.main import app
+
+
+@pytest.fixture
+def internal_headers(monkeypatch):
+    monkeypatch.setattr(app_settings, "INTERNAL_API_SECRET", "test-internal-secret")
+    return {"X-Internal-Secret": "test-internal-secret"}
+
+
+@pytest.fixture
+def mock_email():
+    email = MagicMock()
+    email.send_manufacturer_daily_digest = AsyncMock(return_value=True)
+    app.dependency_overrides[get_email_service] = lambda: email
+    yield email
+    app.dependency_overrides.pop(get_email_service, None)
+
+
+@pytest.fixture
+async def seeded_manufacturer(db_session: AsyncSession):
+    mid = str(uuid.uuid4())
+    pid = str(uuid.uuid4())
+    oid = str(uuid.uuid4())
+    iid = str(uuid.uuid4())
+
+    await db_session.execute(
+        text(
+            "INSERT INTO manufacturers (id, name, email, supported_products, unit_prices, "
+            "lead_time_days, daily_order_limit, sharing_method, is_active, created_at, updated_at) "
+            "VALUES (:id, :name, :email, '{tshirt}', '{}', 7, 100, 'portal', true, NOW(), NOW())"
+        ),
+        {"id": mid, "name": f"Digest社{mid[:8]}", "email": "mfr@example.com"},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO products (id, product_type, size, color, position, manufacturer_id, "
+            "cost, lead_time_days, is_active, created_at, updated_at) "
+            "VALUES (:id, 'tshirt', 'M', NULL, NULL, :mid, 500, 7, true, NOW(), NOW())"
+        ),
+        {"id": pid, "mid": mid},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO orders (id, order_number, product_name, quantity, customer_name, "
+            "customer_email, customer_phone, customer_postal_code, customer_address_prefecture, "
+            "customer_address_city, status, ordered_at, total_price, created_at, updated_at) "
+            "VALUES (:id, :num, 'T', 1, 'Cust', 'c@example.com', '090', '100-0001', '東京都', "
+            "'千代田区', 'ordered', NOW(), 0, NOW(), NOW())"
+        ),
+        {"id": oid, "num": f"D-{oid[:8]}"},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO order_items (id, order_id, uid, product_id, product_name, product_type, "
+            "price, quantity, status, created_at, updated_at) "
+            "VALUES (:id, :oid, :uid, :pid, 'T', 'tshirt', 500, 3, 'ordered', NOW(), NOW())"
+        ),
+        {"id": iid, "oid": oid, "uid": iid[:8], "pid": pid},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO manufacturer_notification_settings (id, manufacturer_id, "
+            "daily_digest_enabled, to_emails, cc_emails, created_at, updated_at) "
+            "VALUES (:id, :mid, true, ARRAY['to@example.com']::varchar[], "
+            "ARRAY['cc@example.com']::varchar[], NOW(), NOW())"
+        ),
+        {"id": str(uuid.uuid4()), "mid": mid},
+    )
+    await db_session.commit()
+
+    yield {"manufacturer_id": mid, "item_quantity": 3}
+
+    for table, key in (
+        ("manufacturer_notification_settings", ("manufacturer_id", mid)),
+        ("order_items", ("id", iid)),
+        ("orders", ("id", oid)),
+        ("products", ("id", pid)),
+        ("manufacturers", ("id", mid)),
+    ):
+        await db_session.execute(
+            text(f"DELETE FROM {table} WHERE {key[0]} = :v"), {"v": key[1]}
+        )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_force_run_sends_then_idempotent(
+    client, internal_headers, mock_email, seeded_manufacturer
+):
+    mid = seeded_manufacturer["manufacturer_id"]
+
+    # 1回目（force）: 新規発注済み 3件 → 送信される
+    resp = await client.post(
+        "/api/v1/internal/manufacturer-daily-digest?force=true", headers=internal_headers
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ran"] is True
+    assert mid in body["sent_manufacturer_ids"]
+
+    kwargs = mock_email.send_manufacturer_daily_digest.await_args.kwargs
+    # 明細 1 件・数量 3 → 発注中明細数=1, 合計数量=3
+    assert kwargs["item_count"] == 1
+    assert kwargs["total_quantity"] == 3
+    assert kwargs["to_emails"] == ["to@example.com"]
+    assert kwargs["cc_emails"] == ["cc@example.com"]
+
+    # 2回目（force）: ウォーターマークが進み新規0件 → 0件スキップ（送信されない）
+    mock_email.send_manufacturer_daily_digest.reset_mock()
+    resp2 = await client.post(
+        "/api/v1/internal/manufacturer-daily-digest?force=true", headers=internal_headers
+    )
+    body2 = resp2.json()
+    assert mid in body2["skipped_zero_manufacturer_ids"]
+    assert mid not in body2["sent_manufacturer_ids"]
+    mock_email.send_manufacturer_daily_digest.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_requires_internal_secret(client, mock_email):
+    # INTERNAL_API_SECRET 未設定（既定 ""）→ 403
+    resp = await client.post(
+        "/api/v1/internal/manufacturer-daily-digest",
+        headers={"X-Internal-Secret": "whatever"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_notification_settings_crud_roundtrip(
+    client, auth_headers, seeded_manufacturer
+):
+    mid = seeded_manufacturer["manufacturer_id"]
+
+    # GET: seed 済みの設定が返る
+    resp = await client.get(
+        f"/api/v1/manufacturers/{mid}/notification-settings", headers=auth_headers
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["daily_digest_enabled"] is True
+    assert body["to_emails"] == ["to@example.com"]
+
+    # PUT: 更新（無効化・宛先変更）。空白/重複は正規化される
+    resp = await client.put(
+        f"/api/v1/manufacturers/{mid}/notification-settings",
+        headers=auth_headers,
+        json={
+            "daily_digest_enabled": False,
+            "to_emails": [" new@example.com ", "new@example.com"],
+            "cc_emails": [],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["to_emails"] == ["new@example.com"]
+
+    # GET: 更新が反映されている
+    resp = await client.get(
+        f"/api/v1/manufacturers/{mid}/notification-settings", headers=auth_headers
+    )
+    assert resp.json()["daily_digest_enabled"] is False
+    assert resp.json()["to_emails"] == ["new@example.com"]
+
+    # PUT: 不正なメール → 422（日本語メッセージ）
+    resp = await client.put(
+        f"/api/v1/manufacturers/{mid}/notification-settings",
+        headers=auth_headers,
+        json={"daily_digest_enabled": True, "to_emails": ["not-an-email"], "cc_emails": []},
+    )
+    assert resp.status_code == 422
+    assert "error" in resp.json()

--- a/api/tests/unit/test_email_service_manufacturer_digest.py
+++ b/api/tests/unit/test_email_service_manufacturer_digest.py
@@ -1,0 +1,170 @@
+"""Unit tests for EmailService.send_manufacturer_daily_digest().
+
+SendGrid client is mocked. Covers subject format (JST・2桁年・ゼロ埋めなし),
+To/CC personalization, plain-text body (画像仕様準拠), and success/failure/exception.
+"""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.email_service import EmailService
+
+
+@pytest.fixture
+def email_service():
+    """Create EmailService with a mocked SendGrid client."""
+    with patch("app.services.email_service.SendGridAPIClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        service = EmailService(
+            api_key="test-api-key",
+            from_email="from@example.com",
+            contact_email="support@example.com",
+            manufacturer_login_url="https://pod-admin-beige.vercel.app/manufacturer-login",
+        )
+        yield service, mock_client
+
+
+class TestSendManufacturerDailyDigest:
+    @pytest.mark.asyncio
+    async def test_successful_send_returns_true(self, email_service):
+        service, mock_client = email_service
+        mock_client.send.return_value = MagicMock(status_code=202)
+
+        result = await service.send_manufacturer_daily_digest(
+            to_emails=["a@example.com"],
+            manufacturer_name="メーカーA",
+            item_count=3,
+            total_quantity=7,
+            sent_date=date(2026, 6, 16),
+        )
+
+        assert result is True
+        mock_client.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_subject_format_no_zero_pad(self, email_service):
+        """件名: 【TOSYO__API発注依頼】{名}様{YY/M/D}（2桁年・月日ゼロ埋めなし）."""
+        service, mock_client = email_service
+        mock_client.send.return_value = MagicMock(status_code=202)
+
+        await service.send_manufacturer_daily_digest(
+            to_emails=["a@example.com"],
+            manufacturer_name="メーカーA",
+            item_count=1,
+            total_quantity=1,
+            sent_date=date(2026, 6, 16),
+        )
+
+        subject = mock_client.send.call_args[0][0].subject.get()
+        assert subject == "【TOSYO__API発注依頼】メーカーA様26/6/16"
+
+    @pytest.mark.asyncio
+    async def test_subject_keeps_two_digit_month(self, email_service):
+        service, mock_client = email_service
+        mock_client.send.return_value = MagicMock(status_code=202)
+
+        await service.send_manufacturer_daily_digest(
+            to_emails=["a@example.com"],
+            manufacturer_name="B社",
+            item_count=1,
+            total_quantity=1,
+            sent_date=date(2026, 12, 5),
+        )
+
+        subject = mock_client.send.call_args[0][0].subject.get()
+        assert subject == "【TOSYO__API発注依頼】B社様26/12/5"
+
+    @pytest.mark.asyncio
+    async def test_to_and_cc_personalization(self, email_service):
+        service, mock_client = email_service
+        mock_client.send.return_value = MagicMock(status_code=202)
+
+        await service.send_manufacturer_daily_digest(
+            to_emails=["to1@example.com", "to2@example.com"],
+            manufacturer_name="メーカーA",
+            item_count=2,
+            total_quantity=5,
+            cc_emails=["cc@example.com"],
+            sent_date=date(2026, 6, 16),
+        )
+
+        personalization = mock_client.send.call_args[0][0].get()["personalizations"][0]
+        assert personalization["to"] == [
+            {"email": "to1@example.com"},
+            {"email": "to2@example.com"},
+        ]
+        assert personalization["cc"] == [{"email": "cc@example.com"}]
+
+    @pytest.mark.asyncio
+    async def test_no_cc_when_empty(self, email_service):
+        service, mock_client = email_service
+        mock_client.send.return_value = MagicMock(status_code=202)
+
+        await service.send_manufacturer_daily_digest(
+            to_emails=["to@example.com"],
+            manufacturer_name="メーカーA",
+            item_count=1,
+            total_quantity=1,
+            sent_date=date(2026, 6, 16),
+        )
+
+        personalization = mock_client.send.call_args[0][0].get()["personalizations"][0]
+        assert "cc" not in personalization
+
+    @pytest.mark.asyncio
+    async def test_error_status_returns_false(self, email_service):
+        service, mock_client = email_service
+        mock_client.send.return_value = MagicMock(status_code=500)
+
+        result = await service.send_manufacturer_daily_digest(
+            to_emails=["a@example.com"],
+            manufacturer_name="メーカーA",
+            item_count=1,
+            total_quantity=1,
+            sent_date=date(2026, 6, 16),
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_false(self, email_service):
+        service, mock_client = email_service
+        mock_client.send.side_effect = Exception("network error")
+
+        result = await service.send_manufacturer_daily_digest(
+            to_emails=["a@example.com"],
+            manufacturer_name="メーカーA",
+            item_count=1,
+            total_quantity=1,
+            sent_date=date(2026, 6, 16),
+        )
+
+        assert result is False
+
+
+class TestBuildManufacturerDailyDigestText:
+    def _service(self) -> EmailService:
+        with patch("app.services.email_service.SendGridAPIClient"):
+            return EmailService(
+                api_key="test",
+                from_email="from@example.com",
+                contact_email="support@example.com",
+                manufacturer_login_url="https://example.com/manufacturer-login",
+            )
+
+    def test_body_matches_spec(self):
+        service = self._service()
+        text = service._build_manufacturer_daily_digest_text(
+            item_count=5,
+            total_quantity=12,
+            login_url="https://example.com/manufacturer-login",
+        )
+
+        assert "以下、発注済みの注文があります。" in text
+        assert "発注中明細数　5 件" in text
+        assert "合計数量　12 点" in text
+        assert "https://example.com/manufacturer-login" in text
+        assert "からログインしてご確認ください。" in text

--- a/api/tests/unit/test_internal_auth.py
+++ b/api/tests/unit/test_internal_auth.py
@@ -1,0 +1,33 @@
+"""Unit tests for the internal shared-secret auth dependency."""
+
+import pytest
+
+from app.config import settings as app_settings
+from app.dependencies import verify_internal_secret
+from app.utils.exceptions import ForbiddenError, UnauthorizedError
+
+
+class TestVerifyInternalSecret:
+    @pytest.mark.asyncio
+    async def test_forbidden_when_unconfigured(self, monkeypatch):
+        monkeypatch.setattr(app_settings, "INTERNAL_API_SECRET", "")
+        with pytest.raises(ForbiddenError):
+            await verify_internal_secret("anything")
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_when_missing_header(self, monkeypatch):
+        monkeypatch.setattr(app_settings, "INTERNAL_API_SECRET", "s3cret")
+        with pytest.raises(UnauthorizedError):
+            await verify_internal_secret(None)
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_when_wrong(self, monkeypatch):
+        monkeypatch.setattr(app_settings, "INTERNAL_API_SECRET", "s3cret")
+        with pytest.raises(UnauthorizedError):
+            await verify_internal_secret("wrong")
+
+    @pytest.mark.asyncio
+    async def test_passes_when_correct(self, monkeypatch):
+        monkeypatch.setattr(app_settings, "INTERNAL_API_SECRET", "s3cret")
+        # 例外を送出しなければ OK
+        await verify_internal_secret("s3cret")

--- a/api/tests/unit/test_manufacturer_daily_digest.py
+++ b/api/tests/unit/test_manufacturer_daily_digest.py
@@ -1,0 +1,264 @@
+"""Unit tests for ManufacturerDailyDigestService.
+
+送信判定（マスタスイッチ/送信時刻/日次ガード）・0件スキップ・ウォーターマーク更新・
+冪等性・force フラグ・メールサービス未設定時の挙動を、リポジトリ/メールをモックして検証する。
+"""
+
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.manufacturer_daily_digest import (
+    JST,
+    ManufacturerDailyDigestService,
+)
+from app.services.manufacturer_notification import (
+    DIGEST_ENABLED_KEY,
+    DIGEST_LAST_RUN_DATE_KEY,
+    DIGEST_SEND_TIME_KEY,
+)
+
+# 送信時刻 09:00 を過ぎた JST 時刻
+NOW = datetime(2026, 7, 9, 10, 0, tzinfo=JST)
+TODAY_STR = "2026-07-09"
+
+
+def _setting(value: str | None) -> types.SimpleNamespace | None:
+    return types.SimpleNamespace(value=value) if value is not None else None
+
+
+def _make_app_setting_repo(*, enabled="true", send_time="09:00", claim=True) -> MagicMock:
+    async def find_by_key(key: str):
+        if key == DIGEST_ENABLED_KEY:
+            return _setting(enabled)
+        if key == DIGEST_SEND_TIME_KEY:
+            return _setting(send_time)
+        return None
+
+    repo = MagicMock()
+    repo.find_by_key = AsyncMock(side_effect=find_by_key)
+    repo.claim_daily_run = AsyncMock(return_value=claim)
+    return repo
+
+
+def _manufacturer(mid="m1", name="メーカーA", email="mfr@example.com"):
+    return types.SimpleNamespace(id=mid, name=name, email=email)
+
+
+def _settings(to_emails=None, cc_emails=None, last_notified_at=None):
+    return types.SimpleNamespace(
+        to_emails=to_emails or [],
+        cc_emails=cc_emails or [],
+        last_notified_at=last_notified_at,
+    )
+
+
+def _make_notif_repo(pairs) -> MagicMock:
+    repo = MagicMock()
+    repo.list_enabled_with_manufacturer = AsyncMock(return_value=pairs)
+    repo.update_last_notified_at = AsyncMock()
+    return repo
+
+
+def _make_order_repo(summary_by_id) -> MagicMock:
+    async def get_summary(manufacturer_id, since=None):
+        return summary_by_id.get(
+            manufacturer_id, {"ordered_item_count": 0, "total_quantity": 0}
+        )
+
+    repo = MagicMock()
+    repo.get_new_ordered_summary_by_manufacturer = AsyncMock(side_effect=get_summary)
+    return repo
+
+
+def _make_email_service(result=True) -> MagicMock:
+    svc = MagicMock()
+    svc.send_manufacturer_daily_digest = AsyncMock(return_value=result)
+    return svc
+
+
+def _make_db() -> MagicMock:
+    db = MagicMock()
+    db.commit = AsyncMock()
+    return db
+
+
+def _service(*, app_setting_repo=None, notif_repo=None, order_repo=None, email_service="default", db=None):
+    return ManufacturerDailyDigestService(
+        db or _make_db(),
+        order_repo or _make_order_repo({}),
+        notif_repo or _make_notif_repo([]),
+        app_setting_repo or _make_app_setting_repo(),
+        _make_email_service() if email_service == "default" else email_service,
+    )
+
+
+class TestGates:
+    @pytest.mark.asyncio
+    async def test_skips_when_master_disabled(self):
+        notif_repo = _make_notif_repo([(_settings(), _manufacturer())])
+        service = _service(
+            app_setting_repo=_make_app_setting_repo(enabled="false"), notif_repo=notif_repo
+        )
+
+        result = await service.run_daily_digest(now=NOW)
+
+        assert result["ran"] is False
+        assert result["reason"] == "disabled"
+        notif_repo.list_enabled_with_manufacturer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_before_send_time(self):
+        service = _service(app_setting_repo=_make_app_setting_repo(send_time="23:00"))
+
+        result = await service.run_daily_digest(now=NOW)
+
+        assert result["ran"] is False
+        assert result["reason"] == "before_send_time"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_send_time_missing(self):
+        service = _service(app_setting_repo=_make_app_setting_repo(send_time=None))
+
+        result = await service.run_daily_digest(now=NOW)
+
+        assert result["reason"] == "send_time_not_set"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_ran_today(self):
+        app_repo = _make_app_setting_repo(claim=False)
+        notif_repo = _make_notif_repo([(_settings(), _manufacturer())])
+        service = _service(app_setting_repo=app_repo, notif_repo=notif_repo)
+
+        result = await service.run_daily_digest(now=NOW)
+
+        assert result["ran"] is False
+        assert result["reason"] == "already_ran_today"
+        notif_repo.list_enabled_with_manufacturer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_claims_today_and_commits(self):
+        app_repo = _make_app_setting_repo()
+        db = _make_db()
+        service = _service(app_setting_repo=app_repo, db=db)
+
+        await service.run_daily_digest(now=NOW)
+
+        app_repo.claim_daily_run.assert_called_once_with(DIGEST_LAST_RUN_DATE_KEY, TODAY_STR)
+        assert db.commit.await_count >= 1
+
+
+class TestSending:
+    @pytest.mark.asyncio
+    async def test_sends_and_updates_watermark(self):
+        watermark = datetime(2026, 7, 8, 10, 0, tzinfo=JST)
+        settings = _settings(
+            to_emails=["to@x.com"], cc_emails=["cc@x.com"], last_notified_at=watermark
+        )
+        manufacturer = _manufacturer()
+        notif_repo = _make_notif_repo([(settings, manufacturer)])
+        order_repo = _make_order_repo({"m1": {"ordered_item_count": 3, "total_quantity": 7}})
+        email = _make_email_service(True)
+        service = _service(notif_repo=notif_repo, order_repo=order_repo, email_service=email)
+
+        result = await service.run_daily_digest(now=NOW)
+
+        assert result["ran"] is True
+        assert result["sent_count"] == 1
+        assert result["sent_manufacturer_ids"] == ["m1"]
+        # 集計はウォーターマーク以降（新規分のみ）
+        order_repo.get_new_ordered_summary_by_manufacturer.assert_awaited_once_with(
+            "m1", since=watermark
+        )
+        # 宛先・件数・合計・送信日が渡る
+        kwargs = email.send_manufacturer_daily_digest.call_args.kwargs
+        assert kwargs["to_emails"] == ["to@x.com"]
+        assert kwargs["cc_emails"] == ["cc@x.com"]
+        assert kwargs["item_count"] == 3
+        assert kwargs["total_quantity"] == 7
+        assert kwargs["manufacturer_name"] == "メーカーA"
+        assert kwargs["sent_date"] == NOW.date()
+        # 送信成功時のみウォーターマークを実行時刻へ更新
+        notif_repo.update_last_notified_at.assert_awaited_once_with(settings, NOW)
+
+    @pytest.mark.asyncio
+    async def test_skips_zero_item_manufacturer(self):
+        settings = _settings(to_emails=["to@x.com"])
+        notif_repo = _make_notif_repo([(settings, _manufacturer())])
+        order_repo = _make_order_repo({"m1": {"ordered_item_count": 0, "total_quantity": 0}})
+        email = _make_email_service()
+        service = _service(notif_repo=notif_repo, order_repo=order_repo, email_service=email)
+
+        result = await service.run_daily_digest(now=NOW)
+
+        assert result["sent_count"] == 0
+        assert result["skipped_zero_count"] == 1
+        assert result["skipped_zero_manufacturer_ids"] == ["m1"]
+        email.send_manufacturer_daily_digest.assert_not_called()
+        notif_repo.update_last_notified_at.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_manufacturer_email_when_to_empty(self):
+        settings = _settings(to_emails=[])  # 未設定
+        notif_repo = _make_notif_repo([(settings, _manufacturer(email="fallback@x.com"))])
+        order_repo = _make_order_repo({"m1": {"ordered_item_count": 1, "total_quantity": 1}})
+        email = _make_email_service(True)
+        service = _service(notif_repo=notif_repo, order_repo=order_repo, email_service=email)
+
+        await service.run_daily_digest(now=NOW)
+
+        kwargs = email.send_manufacturer_daily_digest.call_args.kwargs
+        assert kwargs["to_emails"] == ["fallback@x.com"]
+
+    @pytest.mark.asyncio
+    async def test_failed_send_keeps_watermark(self):
+        settings = _settings(to_emails=["to@x.com"])
+        notif_repo = _make_notif_repo([(settings, _manufacturer())])
+        order_repo = _make_order_repo({"m1": {"ordered_item_count": 2, "total_quantity": 4}})
+        email = _make_email_service(result=False)  # 送信失敗
+        service = _service(notif_repo=notif_repo, order_repo=order_repo, email_service=email)
+
+        result = await service.run_daily_digest(now=NOW)
+
+        assert result["failed_count"] == 1
+        assert result["sent_count"] == 0
+        notif_repo.update_last_notified_at.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_email_service_marks_failed(self):
+        settings = _settings(to_emails=["to@x.com"])
+        notif_repo = _make_notif_repo([(settings, _manufacturer())])
+        order_repo = _make_order_repo({"m1": {"ordered_item_count": 2, "total_quantity": 4}})
+        service = _service(notif_repo=notif_repo, order_repo=order_repo, email_service=None)
+
+        result = await service.run_daily_digest(now=NOW)
+
+        assert result["failed_count"] == 1
+        notif_repo.update_last_notified_at.assert_not_called()
+
+
+class TestForce:
+    @pytest.mark.asyncio
+    async def test_force_bypasses_gates(self):
+        # マスタスイッチ off でも force なら送信する
+        app_repo = _make_app_setting_repo(enabled="false")
+        settings = _settings(to_emails=["to@x.com"])
+        notif_repo = _make_notif_repo([(settings, _manufacturer())])
+        order_repo = _make_order_repo({"m1": {"ordered_item_count": 5, "total_quantity": 9}})
+        email = _make_email_service(True)
+        service = _service(
+            app_setting_repo=app_repo,
+            notif_repo=notif_repo,
+            order_repo=order_repo,
+            email_service=email,
+        )
+
+        result = await service.run_daily_digest(force=True, now=NOW)
+
+        assert result["ran"] is True
+        assert result["sent_count"] == 1
+        # ガードは評価されない
+        app_repo.find_by_key.assert_not_called()
+        app_repo.claim_daily_run.assert_not_called()

--- a/api/tests/unit/test_manufacturer_notification.py
+++ b/api/tests/unit/test_manufacturer_notification.py
@@ -1,0 +1,147 @@
+"""Unit tests for manufacturer notification settings validation and CRUD service."""
+
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.schemas.manufacturer_notification import ManufacturerNotificationSettingsUpdate
+from app.services.manufacturer_notification import (
+    DIGEST_ENABLED_KEY,
+    DIGEST_SEND_TIME_KEY,
+    ManufacturerNotificationService,
+    normalize_emails,
+    parse_send_time,
+    validate_digest_setting_value,
+    validate_emails,
+)
+from app.utils.exceptions import AppException, ManufacturerNotFoundError
+
+
+class TestNormalizeEmails:
+    def test_strips_and_drops_empty(self):
+        assert normalize_emails([" a@example.com ", "", "  "]) == ["a@example.com"]
+
+    def test_dedupes_preserving_order(self):
+        assert normalize_emails(["a@example.com", "b@example.com", "a@example.com"]) == [
+            "a@example.com",
+            "b@example.com",
+        ]
+
+
+class TestValidateEmails:
+    def test_accepts_valid(self):
+        validate_emails(["a@example.com", "b@example.com"])
+
+    def test_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            validate_emails(["not-an-email"])
+
+    def test_rejects_too_many(self):
+        with pytest.raises(ValueError):
+            validate_emails([f"user{i}@example.com" for i in range(21)])
+
+
+class TestParseSendTime:
+    def test_parses_hhmm(self):
+        t = parse_send_time("09:30")
+        assert (t.hour, t.minute) == (9, 30)
+
+    def test_accepts_single_digit_hour(self):
+        # strptime("%H:%M") は "9:30" を 09:30 として受理する（正当な時刻）
+        assert parse_send_time("9:30").hour == 9
+
+    def test_rejects_invalid(self):
+        for bad in ["24:00", "12:60", "abc", "09-30", ""]:
+            with pytest.raises(ValueError):
+                parse_send_time(bad)
+
+
+class TestValidateDigestSettingValue:
+    def test_enabled_accepts_true_false(self):
+        validate_digest_setting_value(DIGEST_ENABLED_KEY, "true")
+        validate_digest_setting_value(DIGEST_ENABLED_KEY, "false")
+
+    def test_enabled_rejects_other(self):
+        with pytest.raises(ValueError):
+            validate_digest_setting_value(DIGEST_ENABLED_KEY, "yes")
+
+    def test_send_time_accepts_valid(self):
+        validate_digest_setting_value(DIGEST_SEND_TIME_KEY, "09:00")
+
+    def test_send_time_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            validate_digest_setting_value(DIGEST_SEND_TIME_KEY, "9am")
+
+
+def _make_manufacturer_repo(exists: bool) -> MagicMock:
+    repo = MagicMock()
+    manufacturer = types.SimpleNamespace(id="m1", name="メーカーA") if exists else None
+    repo.find_by_id = AsyncMock(return_value=manufacturer)
+    return repo
+
+
+class TestManufacturerNotificationService:
+    @pytest.mark.asyncio
+    async def test_get_returns_defaults_when_absent(self):
+        notif_repo = MagicMock()
+        notif_repo.find_by_manufacturer_id = AsyncMock(return_value=None)
+        service = ManufacturerNotificationService(notif_repo, _make_manufacturer_repo(True))
+
+        result = await service.get_settings("m1")
+
+        assert result.manufacturer_id == "m1"
+        assert result.daily_digest_enabled is False
+        assert result.to_emails == []
+        assert result.cc_emails == []
+        assert result.last_notified_at is None
+
+    @pytest.mark.asyncio
+    async def test_get_raises_when_manufacturer_missing(self):
+        notif_repo = MagicMock()
+        service = ManufacturerNotificationService(notif_repo, _make_manufacturer_repo(False))
+
+        with pytest.raises(ManufacturerNotFoundError):
+            await service.get_settings("missing")
+
+    @pytest.mark.asyncio
+    async def test_update_normalizes_and_persists(self):
+        saved = types.SimpleNamespace(
+            manufacturer_id="m1",
+            daily_digest_enabled=True,
+            to_emails=["a@example.com"],
+            cc_emails=["c@example.com"],
+            last_notified_at=None,
+        )
+        notif_repo = MagicMock()
+        notif_repo.upsert = AsyncMock(return_value=saved)
+        service = ManufacturerNotificationService(notif_repo, _make_manufacturer_repo(True))
+
+        data = ManufacturerNotificationSettingsUpdate(
+            daily_digest_enabled=True,
+            to_emails=[" a@example.com ", "a@example.com"],  # 重複・空白
+            cc_emails=["c@example.com"],
+        )
+        result = await service.update_settings("m1", data)
+
+        assert result.daily_digest_enabled is True
+        # 正規化された値で upsert される
+        kwargs = notif_repo.upsert.call_args.kwargs
+        assert kwargs["to_emails"] == ["a@example.com"]
+        assert kwargs["cc_emails"] == ["c@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_invalid_email(self):
+        notif_repo = MagicMock()
+        notif_repo.upsert = AsyncMock()
+        service = ManufacturerNotificationService(notif_repo, _make_manufacturer_repo(True))
+
+        data = ManufacturerNotificationSettingsUpdate(
+            daily_digest_enabled=True,
+            to_emails=["not-an-email"],
+        )
+        with pytest.raises(AppException) as exc:
+            await service.update_settings("m1", data)
+
+        assert exc.value.status_code == 422
+        notif_repo.upsert.assert_not_called()

--- a/docs/manufacturer-daily-digest.md
+++ b/docs/manufacturer-daily-digest.md
@@ -1,0 +1,146 @@
+# メーカー日次発注通知（デイリーダイジェスト）
+
+登録したメールアドレスへ、**メーカーごとの「発注済み」内容を毎日定時に自動送信**する仕組みです。
+メーカーは通知を受け取り、`manufacturer-login` からログインして内容を確認します。
+
+- 送信対象は「前回送信以降に新しく発注済みになった明細」のみ（新規分のみ）
+- 新規の発注済みが 0 件のメーカーには送信しません
+- 送信時刻は**全社共通・1 日 1 回**（運営ダッシュボードから変更可能）
+- 宛先（To/CC・各複数可）と有効/無効は**メーカーごと**に設定
+
+---
+
+## 運営ダッシュボードでの設定
+
+### 全社共通（設定画面）
+
+`設定` 画面の「メーカー日次発注通知」カードで設定します。
+
+| 項目 | 対応する app_settings キー | 説明 |
+|---|---|---|
+| 日次通知を有効にする（全体） | `manufacturer_daily_digest_enabled` | マスタスイッチ。OFF の間は誰にも送信されません |
+| 送信時刻（JST・全社共通） | `manufacturer_daily_digest_send_time` | `HH:MM`。この時刻を過ぎた最初のトリガで 1 日 1 回送信。変更は翌日以降に反映（コード変更・再デプロイ不要） |
+
+> `manufacturer_daily_digest_last_run_date` は日次ガード用に自動更新される内部値です（手動編集不要）。
+
+### メーカー別（各メーカーの編集画面）
+
+`メーカー編集` 画面の「発注通知メール（日次）」カードで設定します。
+
+- **このメーカーへの日次通知を有効にする**（ON/OFF）
+- **宛先（To）**: 複数可。**未登録の場合はメーカーのメールアドレスに送信**されます
+- **CC**: 複数可
+
+---
+
+## メール仕様
+
+- **件名**: `【TOSYO__API発注依頼】{メーカー名}様{YY/M/D}`
+  - 日付は送信日・JST・2 桁年・月日はゼロ埋めなし（例: 2026/6/16 → `26/6/16`）
+- **本文**:
+
+  ```
+  以下、発注済みの注文があります。
+
+  発注中明細数　{件数} 件
+  合計数量　{数量} 点
+
+  https://pod-admin-beige.vercel.app/manufacturer-login
+  からログインしてご確認ください。
+  ```
+
+ログイン URL は環境変数 `MANUFACTURER_LOGIN_URL` で変更できます（既定値は上記）。
+
+---
+
+## 定時実行（外部トリガ → 内部 API）
+
+pod-admin にはスケジューラが無いため、**外部トリガが内部エンドポイントを高頻度で叩く**方式です。
+エンドポイントは「現在 JST ≥ 送信時刻 かつ 本日未実行」の場合のみ本処理を実行します。
+
+### 内部エンドポイント
+
+```
+POST /api/v1/internal/manufacturer-daily-digest
+Header: X-Internal-Secret: <INTERNAL_API_SECRET>
+Query:  force=true|false   （任意。true で時刻・日次ガードを無視して即時送信＝手動テスト用）
+```
+
+- 認証は共有シークレット（環境変数 `INTERNAL_API_SECRET`）。未設定なら **403**（無効）。
+- 高頻度（例: 5〜15 分毎）で叩いて問題ありません。**多重発火でも二重送信しません**
+  （全社日次ガード `last_run_date` の原子的 claim ＋ メーカー別ウォーターマーク `last_notified_at`）。
+
+レスポンス例:
+
+```json
+{
+  "ran": true,
+  "reason": "ok",
+  "run_date": "2026-07-09",
+  "sent_count": 2,
+  "skipped_zero_count": 1,
+  "failed_count": 0,
+  "sent_manufacturer_ids": ["..."],
+  "skipped_zero_manufacturer_ids": ["..."],
+  "failed_manufacturer_ids": []
+}
+```
+
+`ran: false` の `reason`: `disabled` / `send_time_not_set` / `before_send_time` / `already_ran_today`。
+
+### 必要な環境変数（API 側）
+
+| 変数 | 説明 |
+|---|---|
+| `INTERNAL_API_SECRET` | 内部エンドポイントの共有シークレット。例: `openssl rand -hex 32` |
+| `MANUFACTURER_LOGIN_URL` | メール本文のログイン URL（任意。既定値あり） |
+
+### トリガの設定例
+
+#### A. GitHub Actions（同梱: `.github/workflows/manufacturer-daily-digest.yml`）
+
+リポジトリの `Settings → Secrets and variables → Actions` で設定:
+
+- Variables: `API_BASE_URL` = `https://<your-app>.railway.app`
+- Secrets: `INTERNAL_API_SECRET` = API と同じ値
+
+15 分ごとに自動実行され、`Run workflow` から `force` 指定での手動送信も可能です。
+
+> 注: GitHub Actions の cron は UTC 実行かつ高負荷時に遅延することがありますが、
+> 送信可否は API 側が JST・日次ガードで判定するため運用上問題ありません。
+
+#### B. 汎用 cron / ホスティングのスケジューラ
+
+```bash
+*/10 * * * * curl -sS -X POST \
+  "https://<your-app>.railway.app/api/v1/internal/manufacturer-daily-digest" \
+  -H "X-Internal-Secret: ${INTERNAL_API_SECRET}"
+```
+
+#### 手動テスト（即時送信）
+
+```bash
+curl -sS -X POST \
+  "https://<your-app>.railway.app/api/v1/internal/manufacturer-daily-digest?force=true" \
+  -H "X-Internal-Secret: ${INTERNAL_API_SECRET}"
+```
+
+---
+
+## 集計仕様（新規分のみ）
+
+メーカー `m` について:
+
+- 対象明細 = `OrderItem` WHERE `Product.manufacturer_id = m.id`
+  AND `status = ORDERED` AND `created_at > COALESCE(last_notified_at, '-infinity')`
+- **発注中明細数** = 対象明細の件数、**合計数量** = Σ `quantity`
+- 送信**成功時のみ** `last_notified_at` を実行時刻に更新（失敗時は次回再送対象として残す）
+
+> `ORDERED` は発注時の初期ステータスのため、`OrderItem.created_at` を「発注済みになった時刻」とみなします。
+> 日時はすべて JST で扱います。
+
+## 将来拡張（今回スコープ外）
+
+- メーカーごとに異なる送信時刻（現状は全社共通）
+- メーカーポータル側からの自己設定（現状は運営ダッシュボードのみ）
+- 発注済み以外のステータス（製造中／納入済み等）の通知

--- a/web/src/app/(dashboard)/manufacturers/[id]/page.tsx
+++ b/web/src/app/(dashboard)/manufacturers/[id]/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft } from "lucide-react";
 import { PageContainer } from "@/components/layout/page-container";
 import { LoadingSpinner } from "@/components/common/loading-spinner";
 import { ManufacturerForm } from "@/features/manufacturers/components/manufacturer-form";
+import { ManufacturerNotificationSettingsCard } from "@/features/manufacturers/components/manufacturer-notification-settings";
 import { apiClient } from "@/lib/api/client";
 import type { Manufacturer } from "@/types/api";
 
@@ -64,11 +65,17 @@ export default function ManufacturerDetailPage() {
         </Button>
       }
     >
-      <ManufacturerForm
-        manufacturer={manufacturer}
-        onSuccess={handleSuccess}
-        onCancel={handleCancel}
-      />
+      <div className="space-y-6">
+        <ManufacturerForm
+          manufacturer={manufacturer}
+          onSuccess={handleSuccess}
+          onCancel={handleCancel}
+        />
+        <ManufacturerNotificationSettingsCard
+          manufacturerId={manufacturer.id}
+          manufacturerEmail={manufacturer.email}
+        />
+      </div>
     </PageContainer>
   );
 }

--- a/web/src/app/(dashboard)/settings/page.tsx
+++ b/web/src/app/(dashboard)/settings/page.tsx
@@ -3,14 +3,13 @@
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { toast } from "sonner";
-import { Trash2, Plus, X } from "lucide-react";
+import { Trash2, Plus } from "lucide-react";
 import { PageContainer } from "@/components/layout/page-container";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
-import { Badge } from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -20,6 +19,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { PageLoading } from "@/components/common/loading-spinner";
+import { EmailListInput } from "@/components/common/email-list-input";
 import { apiClient } from "@/lib/api/client";
 import type {
   AppSettingListResponse,
@@ -29,7 +29,9 @@ import type {
 
 const NOTIFICATION_ENABLED_KEY = "external_order_notification_enabled";
 const NOTIFICATION_RECIPIENTS_KEY = "external_order_notification_recipients";
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const DIGEST_ENABLED_KEY = "manufacturer_daily_digest_enabled";
+const DIGEST_SEND_TIME_KEY = "manufacturer_daily_digest_send_time";
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 function parseRecipients(value: string | undefined): string[] {
   if (!value) return [];
@@ -47,10 +49,15 @@ export default function SettingsPage() {
   // 外部注文の通知
   const [notificationEnabled, setNotificationEnabled] = useState(false);
   const [recipients, setRecipients] = useState<string[]>([]);
-  const [newRecipient, setNewRecipient] = useState("");
   const [notificationInitialized, setNotificationInitialized] = useState(false);
   const [isSavingNotification, setIsSavingNotification] = useState(false);
   const [notificationError, setNotificationError] = useState<string | null>(null);
+
+  // メーカー日次発注通知（全社共通）
+  const [digestEnabled, setDigestEnabled] = useState(false);
+  const [digestSendTime, setDigestSendTime] = useState("09:00");
+  const [digestInitialized, setDigestInitialized] = useState(false);
+  const [isSavingDigest, setIsSavingDigest] = useState(false);
 
   // 休日追加フォーム
   const [newHolidayDate, setNewHolidayDate] = useState("");
@@ -87,6 +94,19 @@ export default function SettingsPage() {
     }
   }, [settingsData, notificationInitialized]);
 
+  // メーカー日次発注通知の初回反映
+  useEffect(() => {
+    if (settingsData && !digestInitialized) {
+      const enabledSetting = settingsData.items.find((s) => s.key === DIGEST_ENABLED_KEY);
+      setDigestEnabled(enabledSetting?.value === "true");
+      const sendTimeSetting = settingsData.items.find((s) => s.key === DIGEST_SEND_TIME_KEY);
+      if (sendTimeSetting?.value) {
+        setDigestSendTime(sendTimeSetting.value);
+      }
+      setDigestInitialized(true);
+    }
+  }, [settingsData, digestInitialized]);
+
   // 休日一覧取得
   const {
     data: holidaysData,
@@ -116,26 +136,6 @@ export default function SettingsPage() {
     }
   };
 
-  const handleAddRecipient = () => {
-    const email = newRecipient.trim();
-    if (!email) return;
-    if (!EMAIL_REGEX.test(email)) {
-      setNotificationError(`メールアドレスの形式が正しくありません: ${email}`);
-      return;
-    }
-    if (recipients.includes(email)) {
-      setNotificationError("既に登録されているメールアドレスです");
-      return;
-    }
-    setRecipients([...recipients, email]);
-    setNewRecipient("");
-    setNotificationError(null);
-  };
-
-  const handleRemoveRecipient = (email: string) => {
-    setRecipients(recipients.filter((r) => r !== email));
-  };
-
   const handleSaveNotification = async () => {
     setIsSavingNotification(true);
     setNotificationError(null);
@@ -156,6 +156,30 @@ export default function SettingsPage() {
       toast.error(message);
     } finally {
       setIsSavingNotification(false);
+    }
+  };
+
+  const handleSaveDigest = async () => {
+    if (!TIME_REGEX.test(digestSendTime)) {
+      toast.error("送信時刻は HH:MM（24時間表記）で指定してください");
+      return;
+    }
+    setIsSavingDigest(true);
+    try {
+      await apiClient(`/settings/${DIGEST_ENABLED_KEY}`, {
+        method: "PUT",
+        body: { value: digestEnabled ? "true" : "false" },
+      });
+      await apiClient(`/settings/${DIGEST_SEND_TIME_KEY}`, {
+        method: "PUT",
+        body: { value: digestSendTime },
+      });
+      toast.success("メーカー日次発注通知の設定を更新しました");
+      mutateSettings();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "更新に失敗しました");
+    } finally {
+      setIsSavingDigest(false);
     }
   };
 
@@ -261,49 +285,15 @@ export default function SettingsPage() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="recipient-email">通知先メールアドレス</Label>
-              <p className="text-sm text-muted-foreground">
-                複数登録できます。入力して「追加」を押すか Enter で登録してください。
-              </p>
-              <div className="flex items-end gap-3">
-                <Input
-                  id="recipient-email"
-                  type="email"
-                  placeholder="例: staff@example.com"
-                  value={newRecipient}
-                  onChange={(e) => setNewRecipient(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      handleAddRecipient();
-                    }
-                  }}
-                />
-                <Button onClick={handleAddRecipient} variant="secondary" size="sm">
-                  <Plus className="h-4 w-4 mr-1" />
-                  追加
-                </Button>
-              </div>
-
-              {recipients.length > 0 ? (
-                <div className="flex flex-wrap gap-2 pt-1">
-                  {recipients.map((email) => (
-                    <Badge key={email} variant="secondary" className="gap-1 pr-1">
-                      {email}
-                      <button
-                        type="button"
-                        aria-label={`${email} を削除`}
-                        onClick={() => handleRemoveRecipient(email)}
-                        className="rounded-full p-0.5 hover:bg-muted-foreground/20"
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </Badge>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">通知先が登録されていません。</p>
-              )}
+              <EmailListInput
+                id="recipient-email"
+                label="通知先メールアドレス"
+                description="複数登録できます。入力して「追加」を押すか Enter で登録してください。"
+                emails={recipients}
+                onChange={setRecipients}
+                placeholder="例: staff@example.com"
+                emptyText="通知先が登録されていません。"
+              />
 
               {notificationEnabled && recipients.length === 0 && (
                 <p className="text-sm text-amber-600">
@@ -323,6 +313,46 @@ export default function SettingsPage() {
               size="sm"
             >
               {isSavingNotification ? "保存中..." : "保存"}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* メーカー日次発注通知（全社共通） */}
+        <Card>
+          <CardHeader>
+            <CardTitle>メーカー日次発注通知</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              毎日決まった時刻に、新規の発注済み明細があるメーカーへ発注通知メールを送信します。
+              宛先や有効/無効はメーカーごとに各メーカーの編集画面で設定します。
+            </p>
+
+            <div className="flex items-center gap-3">
+              <Switch
+                id="digest-enabled"
+                checked={digestEnabled}
+                onCheckedChange={setDigestEnabled}
+              />
+              <Label htmlFor="digest-enabled">日次通知を有効にする（全体）</Label>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="digest-send-time">送信時刻（JST・全社共通）</Label>
+              <p className="text-sm text-muted-foreground">
+                この時刻を過ぎた最初のタイミングで、1 日 1 回送信されます。変更は翌日以降の送信に反映されます。
+              </p>
+              <Input
+                id="digest-send-time"
+                type="time"
+                value={digestSendTime}
+                onChange={(e) => setDigestSendTime(e.target.value)}
+                className="w-32"
+              />
+            </div>
+
+            <Button onClick={handleSaveDigest} disabled={isSavingDigest} size="sm">
+              {isSavingDigest ? "保存中..." : "保存"}
             </Button>
           </CardContent>
         </Card>

--- a/web/src/components/common/email-list-input.tsx
+++ b/web/src/components/common/email-list-input.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, X } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface EmailListInputProps {
+  id: string;
+  label: string;
+  description?: string;
+  emails: string[];
+  onChange: (emails: string[]) => void;
+  placeholder: string;
+  emptyText: string;
+}
+
+/**
+ * バッジ形式で複数メールアドレスを追加・削除できる入力欄。
+ * 追加時に形式・重複を検証し、エラーはコンポーネント内部で表示する。
+ */
+export function EmailListInput({
+  id,
+  label,
+  description,
+  emails,
+  onChange,
+  placeholder,
+  emptyText,
+}: EmailListInputProps) {
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAdd = () => {
+    const email = input.trim();
+    if (!email) return;
+    if (!EMAIL_REGEX.test(email)) {
+      setError(`メールアドレスの形式が正しくありません: ${email}`);
+      return;
+    }
+    if (emails.includes(email)) {
+      setError("既に登録されているメールアドレスです");
+      return;
+    }
+    onChange([...emails, email]);
+    setInput("");
+    setError(null);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      <div className="flex items-end gap-3">
+        <Input
+          id={id}
+          type="email"
+          placeholder={placeholder}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleAdd();
+            }
+          }}
+        />
+        <Button type="button" onClick={handleAdd} variant="secondary" size="sm">
+          <Plus className="h-4 w-4 mr-1" />
+          追加
+        </Button>
+      </div>
+
+      {emails.length > 0 ? (
+        <div className="flex flex-wrap gap-2 pt-1">
+          {emails.map((email) => (
+            <Badge key={email} variant="secondary" className="gap-1 pr-1">
+              {email}
+              <button
+                type="button"
+                aria-label={`${email} を削除`}
+                onClick={() => onChange(emails.filter((x) => x !== email))}
+                className="rounded-full p-0.5 hover:bg-muted-foreground/20"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">{emptyText}</p>
+      )}
+
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/manufacturers/components/manufacturer-notification-settings.tsx
+++ b/web/src/features/manufacturers/components/manufacturer-notification-settings.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { EmailListInput } from "@/components/common/email-list-input";
+import { apiClient } from "@/lib/api/client";
+import type { ManufacturerNotificationSettings } from "@/types/api";
+
+interface ManufacturerNotificationSettingsCardProps {
+  manufacturerId: string;
+  manufacturerEmail: string;
+}
+
+/** メーカー別の日次発注通知設定（ON/OFF・To/CC）を編集するカード. */
+export function ManufacturerNotificationSettingsCard({
+  manufacturerId,
+  manufacturerEmail,
+}: ManufacturerNotificationSettingsCardProps) {
+  const { data, mutate } = useSWR<ManufacturerNotificationSettings>(
+    `/manufacturers/${manufacturerId}/notification-settings`,
+    apiClient,
+  );
+
+  const [enabled, setEnabled] = useState(false);
+  const [toEmails, setToEmails] = useState<string[]>([]);
+  const [ccEmails, setCcEmails] = useState<string[]>([]);
+  const [initialized, setInitialized] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (data && !initialized) {
+      setEnabled(data.daily_digest_enabled);
+      setToEmails(data.to_emails);
+      setCcEmails(data.cc_emails);
+      setInitialized(true);
+    }
+  }, [data, initialized]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await apiClient(`/manufacturers/${manufacturerId}/notification-settings`, {
+        method: "PUT",
+        body: {
+          daily_digest_enabled: enabled,
+          to_emails: toEmails,
+          cc_emails: ccEmails,
+        },
+      });
+      toast.success("通知設定を更新しました");
+      mutate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "更新に失敗しました");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>発注通知メール（日次）</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          毎日決まった時刻に、新規の発注済み明細があるメーカーへ通知メールを送信します。
+          送信時刻は「設定」画面で全社共通として設定します。
+        </p>
+
+        <div className="flex items-center gap-3">
+          <Switch id="digest-enabled" checked={enabled} onCheckedChange={setEnabled} />
+          <Label htmlFor="digest-enabled">このメーカーへの日次通知を有効にする</Label>
+        </div>
+
+        <EmailListInput
+          id="digest-to-emails"
+          label="宛先（To）"
+          description={`複数登録できます。未登録の場合はメーカーのメールアドレス（${manufacturerEmail}）に送信されます。`}
+          emails={toEmails}
+          onChange={setToEmails}
+          placeholder="例: maker@example.com"
+          emptyText={`未登録（メーカーのメールアドレス ${manufacturerEmail} に送信されます）`}
+        />
+
+        <EmailListInput
+          id="digest-cc-emails"
+          label="CC"
+          description="複数登録できます。"
+          emails={ccEmails}
+          onChange={setCcEmails}
+          placeholder="例: cc@example.com"
+          emptyText="CC は登録されていません。"
+        />
+
+        <Button onClick={handleSave} disabled={isSaving} size="sm">
+          {isSaving ? "保存中..." : "保存"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -302,6 +302,21 @@ export interface ManufacturerListResponse {
   limit: number;
 }
 
+// メーカー別 通知設定（日次発注ダイジェストメール）
+export interface ManufacturerNotificationSettings {
+  manufacturer_id: string;
+  daily_digest_enabled: boolean;
+  to_emails: string[];
+  cc_emails: string[];
+  last_notified_at: string | null;
+}
+
+export interface ManufacturerNotificationSettingsUpdate {
+  daily_digest_enabled: boolean;
+  to_emails: string[];
+  cc_emails: string[];
+}
+
 // Product types
 export type ProductType =
   | "acrylic_keychain"


### PR DESCRIPTION
## 概要

**Intent Spec:** #80

メーカー別「発注済み」内容の**日次メール通知**を実装しました。毎日決まった時刻に、通知 ON かつ「新規の発注済み」明細が 1 件以上あるメーカーへ、発注中明細数・合計数量とログイン URL を含むメールを自動送信します。宛先(To/CC・各複数可)と ON/OFF はメーカー別、送信時刻は全社共通で、運営ダッシュボードから設定できます（コード変更・再デプロイ不要）。

### なぜこの変更が必要か

メーカーは「発注済み」の注文が入ったことを能動的に知る手段がなく、管理画面を都度確認する必要がありました。日次で自動通知することで、メーカーが `manufacturer-login` からログインして速やかに対応できるようにします。既存の「外部注文の受付通知メール」(#73/#74) の設定・送信パターンを踏襲・拡張しています。

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | mypy（新規モジュール）/ tsc（`src/`）ともにエラー 0 |
| リンター | ✅ | ruff（新規・変更ファイル）/ eslint（変更ファイル）パス |
| ユニットテスト | ✅ | 新規 62 件パス（集計・送信判定・冪等・0件スキップ・件名/本文/CC・内部認証・設定バリデーション） |
| 統合テスト | ✅ | 実 PostgreSQL 16 でマイグレーション適用＋3 件パス（集計クエリ・原子的日次ガード・ウォーターマーク・CRUD ラウンドトリップ） |
| 仕様適合 | ✅ | 受け入れ基準 9/9 カバー |
| AI意味レビュー | ✅ | `/simplify max`（reuse / simplification / efficiency / altitude）→ 重複 2 点を修正 |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| 送信時刻(JST)に日次実行・ON かつ新規≥1 のメーカーのみ届く | `test_manufacturer_daily_digest.py::TestGates/TestSending`, `test_..._flow.py` | ✅ |
| 新規発注済み 0 件のメーカーには送信されない | `TestSending::test_skips_zero_item_manufacturer`, `test_..._flow.py` | ✅ |
| 件名・本文が画像仕様通り | `test_email_service_manufacturer_digest.py` | ✅ |
| To/CC・ON/OFF を運営ダッシュボードで設定でき送信に反映 | `test_manufacturer_notification.py`, `test_..._flow.py::..._crud_roundtrip` | ✅ |
| 送信時刻を変更でき翌日以降に反映 | 設定バリデーション＋`_check_gates`（`before_send_time`/`already_ran_today`） | ✅ |
| 同日二重送信が起きない（冪等）／多重トリガでも安全 | `TestGates::test_skips_when_already_ran_today`, `claim_daily_run`, `test_..._flow.py` | ✅ |
| 集計は「前回送信以降に発注済み」に限定 | `get_new_ordered_summary_by_manufacturer(since)`, 2 回目実行で 0 件 | ✅ |
| 日時はすべて JST | サービス／メールの JST 処理 | ✅ |
| 単体／統合テスト | 上記一式 | ✅ |

## スクリーンショット

本環境では UI の自動撮影は未実施です。追加 UI は以下の 2 箇所です。

| 画面 | 追加内容 |
|------|---------|
| メーカー編集 `(dashboard)/manufacturers/[id]` | 「発注通知メール（日次）」カード（ON/OFF・To/CC 複数入力） |
| 設定 `(dashboard)/settings` | 「メーカー日次発注通知」カード（全社共通の有効化・送信時刻） |

## レビューのポイント

- **冪等性**: 全社日次ガード（`app_settings.last_run_date` の条件付き `UPDATE ... RETURNING` による原子的 claim）＋ メーカー別ウォーターマーク（`last_notified_at`、送信成功時のみ更新）で、5〜15 分毎の多重トリガでも二重送信しない設計です。
- **新規分のみ集計**: `OrderItem.status = ORDERED` かつ `created_at > last_notified_at` を集計します（`ORDERED` は発注時の初期ステータスのため `created_at` を発注時刻とみなす）。
- **定時実行**: pod-admin にスケジューラが無いため「外部トリガ → 認証付き内部 API」方式。`INTERNAL_API_SECRET`（共有シークレット）で保護。GitHub Actions ワークフローと手順ドキュメントを同梱しています。
- **既存パターンの踏襲**: `EmailService` / `app_settings` / 設定バリデーションは #73/#74 を踏襲。フロントのメール複数入力は共有コンポーネント `EmailListInput` に抽出し、既存の設定画面もこれを利用するようリファクタしました。

## 追加が必要な環境変数

- `INTERNAL_API_SECRET`: 内部エンドポイントの共有シークレット（未設定なら 403 で無効）
- `MANUFACTURER_LOGIN_URL`: メール本文のログイン URL（任意・既定値あり）

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017pc5ugADWnSW8PT9VEHfc4)_