### PR TITLE
fix: illustrator-vm 投入ペイロードを実VMのProcessRequest形式に修正（v2生成が本番で失敗する不具合）

### DIFF
--- a/api/app/services/illustrator_vm_client.py
+++ b/api/app/services/illustrator_vm_client.py
@@ -114,28 +114,50 @@ class IllustratorVmClient:
     ) -> str:
         """製造データ生成ジョブを投入し、job_id を返す.
 
-        images は {layer_type: PNGバイト列}。base64 エンコードして送信する。
+        images は {layer_type: PNGバイト列}。VM の ProcessRequest 形式に整形して送る:
+        - 単一画像モード(single): image_data(base64) + image_filename
+        - 複数画像モード(multi):  images = [{type, data(base64), filename}, ...]
         """
         if not images:
             raise IllustratorVmError("at least one source image is required")
 
-        payload = {
+        # order_id は VM の必須フィールド（string）。呼び出し側が未指定なら空文字で満たす。
+        payload: dict[str, object] = {
             "product_type": product_type,
             "size": size,
             "variant": variant,
-            "input_mode": input_mode,
-            "order_id": order_id,
-            "images": {
-                layer: base64.b64encode(content).decode("ascii")
-                for layer, content in images.items()
-            },
+            "order_id": order_id or "",
         }
+
+        if input_mode == "single":
+            # 単一画像商品(tshirt/tote): 1枚を image_data として送る。
+            layer, content = self._pick_single_image(images)
+            payload["image_data"] = base64.b64encode(content).decode("ascii")
+            payload["image_filename"] = f"{layer}.png"
+        else:
+            # 複数画像商品(keychain/stand/sticker): ImageInput の配列。
+            payload["images"] = [
+                {
+                    "type": layer,
+                    "data": base64.b64encode(content).decode("ascii"),
+                    "filename": f"{layer}.png",
+                }
+                for layer, content in images.items()
+            ]
 
         data = await self._request_json("POST", "/api/process", json=payload)
         job_id = data.get("job_id") or data.get("id")
         if not job_id:
             raise IllustratorVmError(f"submit response missing job_id: {data}")
         return str(job_id)
+
+    @staticmethod
+    def _pick_single_image(images: dict[str, bytes]) -> tuple[str, bytes]:
+        """単一画像モードで送る1枚を決める（design 優先、次に color、無ければ任意）."""
+        for preferred in ("design", "color"):
+            if preferred in images:
+                return preferred, images[preferred]
+        return next(iter(images.items()))
 
     async def get_status(self, job_id: str) -> VmJobStatus:
         """ジョブの現在ステータスを取得する."""

--- a/api/app/services/manufacturing_data_service.py
+++ b/api/app/services/manufacturing_data_service.py
@@ -274,6 +274,7 @@ class ManufacturingDataService:
                 variant=mapping.variant,
                 input_mode=mapping.input_mode,
                 images=images,
+                order_id=md.id,
             )
             md.vm_job_id = job_id
             await self._md_repo.update(md)

--- a/api/tests/unit/test_illustrator_vm_client.py
+++ b/api/tests/unit/test_illustrator_vm_client.py
@@ -45,12 +45,51 @@ class TestSubmit:
             variant="clear",
             input_mode="multi",
             images={"color": b"\x89PNG-color", "cutline": b"\x89PNG-cut"},
+            order_id="md-1",
         )
         assert job_id == "job-1"
         assert captured["path"] == "/api/process"
-        # base64 でエンコードされて送られる
-        assert "color" in captured["body"]["images"]
-        assert captured["body"]["images"]["color"] != "\x89PNG-color"
+        body = captured["body"]
+        # 実VM ProcessRequest: images は ImageInput の「配列」（dict ではない）
+        assert isinstance(body["images"], list)
+        by_type = {img["type"]: img for img in body["images"]}
+        assert set(by_type) == {"color", "cutline"}
+        # 各要素は type / data(base64) / filename を持つ
+        import base64
+
+        assert by_type["color"]["data"] == base64.b64encode(b"\x89PNG-color").decode()
+        assert by_type["color"]["filename"]
+        # 単一画像フィールドは付けない / order_id と variant を送る
+        assert "image_data" not in body
+        assert body["order_id"] == "md-1"
+        assert body["variant"] == "clear"
+
+    @pytest.mark.asyncio
+    async def test_submit_single_image_uses_image_data(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(202, json={"job_id": "job-2"})
+
+        import base64
+
+        await _client(handler).submit(
+            product_type="tshirt",
+            size="M",
+            variant=None,
+            input_mode="single",
+            images={"design": b"\x89PNG-design"},
+            order_id="md-2",
+        )
+        body = captured["body"]
+        # 実VM: 単一画像モードは image_data + image_filename（images 配列は送らない）
+        assert body["image_data"] == base64.b64encode(b"\x89PNG-design").decode()
+        assert body["image_filename"]
+        assert "images" not in body
+        assert body["order_id"] == "md-2"
 
     @pytest.mark.asyncio
     async def test_submit_missing_job_id_raises(self):

--- a/api/tests/unit/test_manufacturing_data_service.py
+++ b/api/tests/unit/test_manufacturing_data_service.py
@@ -231,6 +231,8 @@ class TestGenerateDriver:
         assert md.file_size == len(b"AI-BYTES")
         assert md.attempts == 1
         assert md.vm_job_id == "job-9"
+        # VM 必須の order_id に製造データ行の id を渡す（トレーサビリティ）
+        assert vm_client.submit.call_args.kwargs["order_id"] == md.id
 
     @pytest.mark.asyncio
     async def test_vm_failure_marks_failed_with_message(self):


### PR DESCRIPTION
## 概要
外部注文v2（#76 / #77）の製造データ生成が、**実稼働中の illustrator-vm に対して必ず失敗する**不具合を修正します。実VM（`illustrator-vm-preview`, GCP）へ実際にジョブを投げて検証する中で判明しました。

## 不具合
`IllustratorVmClient.submit()` が送るペイロードが、実VMの `ProcessRequest` スキーマ（`/openapi.json`）と一致していませんでした。VMは未接続の状態で実装されていたための想定ズレです。

実VMに現行形式を投げると **HTTP 422**（実測）:
```
loc=["body","images"]  msg="Input should be a valid list"
```

| | 実VMが要求 | 修正前クライアント |
|---|---|---|
| 複数画像(keychain/stand/sticker) | `images: [{type, data(base64), filename}, …]`（配列）＋`variant` | `images: {layer: b64}`（dict）＋`input_mode` |
| 単一画像(tshirt/tote) | `image_data` + `image_filename` | `images: {layer: b64}` |
| order_id | **必須(string)** | `None` を送信 |

**影響**: この形式ではあらゆるVM投入が422で弾かれ、生成行が必ず `failed` になります。ネットワーク・環境変数・スキーマ・発注ゲートが全て正しくても、**v2の製造データ生成が本番で一切成功しません**。

## 修正
実VMの `/openapi.json` 準拠に `submit()` を書き換え:
- **複数画像**: `images` を `ImageInput` の配列 `[{type, data, filename}]` に
- **単一画像**: `image_data` + `image_filename` に（`images` は送らない。`input_mode` で分岐）
- **order_id**: VM必須のため送信（`generate()` は `md.id` を渡す）
- 実VM未定義の `input_mode` はペイロードから除去

## 検証（実VMでE2E）
`http://34.84.121.166:8000` へ**修正後の形式**で実投入し、両モードとも完走を確認:
- 単一(tshirt): `202 → completed(~72s) → download` = **PDF**（`application/pdf`, 352KB）
- 複数(keychain): `202 → completed(~60s) → download` = **AI**（1.15MB）
- 参考: 修正前形式（`images`=dict）は同VMで **422** を実測（不具合の再現）

## テスト
- `test_illustrator_vm_client.py`: 送信ペイロード形式（配列/`image_data`/`order_id`）を実VMスキーマに合わせて更新・追加
- `test_manufacturing_data_service.py`: `generate()` が `order_id=md.id` を渡すことを検証
- 変更ファイルの ruff クリーン / 新規mypyエラーなし / 新規failureゼロ（既存の先行失敗は不変）

🤖 Generated with [Claude Code](https://claude.com/claude-code)