### PR TITLE
feat: FileStorage の GCS 対応（本番=Railway でのファイル永続化）

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -20,14 +20,15 @@ CORS_ORIGINS=["http://localhost:3000","https://pod-admin-beige.vercel.app"]
 UPLOAD_DIR=uploads
 MAX_UPLOAD_SIZE=104857600
 
-# File Storage (GCS) — 本番=Railway でのファイル永続化
-# GCS_BUCKET が空ならローカル保存を継続（既定）。設定すると製造データ/チャット添付/
-# 出荷ファイルが GCS に永続化され、再デプロイをまたいで保持される。
-GCS_BUCKET=
+# File Storage (GCS) — ローカル/本番ともに GCS でファイル永続化
+# ローカル開発も本番と同様に GCS を使う。バケットは本番と分けること
+# （例: 本番=pod-admin-prod / ローカル=pod-admin-dev）。
+# GCS_BUCKET を空にした場合のみローカル保存へフォールバック（CI/オフライン用）。
+GCS_BUCKET=pod-admin-dev
 # サービスアカウント鍵JSON文字列（JSON全体を1行で。空なら ADC へフォールバック）
 GCS_CREDENTIALS_JSON=
-# バケット内のキー前置（任意の名前空間。例: prod）
-GCS_PREFIX=
+# バケット内のキー前置（任意の名前空間。例: 本番=prod / ローカル=dev）
+GCS_PREFIX=dev
 
 # Email (SendGrid)
 SENDGRID_API_KEY=

--- a/api/.env.example
+++ b/api/.env.example
@@ -20,6 +20,15 @@ CORS_ORIGINS=["http://localhost:3000","https://pod-admin-beige.vercel.app"]
 UPLOAD_DIR=uploads
 MAX_UPLOAD_SIZE=104857600
 
+# File Storage (GCS) — 本番=Railway でのファイル永続化
+# GCS_BUCKET が空ならローカル保存を継続（既定）。設定すると製造データ/チャット添付/
+# 出荷ファイルが GCS に永続化され、再デプロイをまたいで保持される。
+GCS_BUCKET=
+# サービスアカウント鍵JSON文字列（JSON全体を1行で。空なら ADC へフォールバック）
+GCS_CREDENTIALS_JSON=
+# バケット内のキー前置（任意の名前空間。例: prod）
+GCS_PREFIX=
+
 # Email (SendGrid)
 SENDGRID_API_KEY=
 SENDGRID_FROM_EMAIL=

--- a/api/DEPLOY.md
+++ b/api/DEPLOY.md
@@ -65,6 +65,65 @@ curl https://<your-app>.railway.app/health
 open https://<your-app>.railway.app/api/v1/docs
 ```
 
+## ファイル永続化（GCS）
+
+Railway のローカルディスクは**再デプロイ/再起動で消える**ため、本番では製造データ
+（.ai/.pdf）・チャット添付・出荷ファイルを Google Cloud Storage（GCS）に永続化する。
+`GCS_BUCKET` を設定すると全 `FileStorage` が GCS 経由になり、未設定ならローカル保存を
+継続する（既定・挙動不変）。アクセスはサーバ経由（`get()` で bytes 取得）のため、バケットは
+非公開のままでよく、署名URLも不要。
+
+### 1. GCS バケット作成
+
+- リージョン: `asia-northeast1`（illustrator-vm と同一）
+- アクセス制御: Uniform bucket-level access
+- 公開設定: 非公開（Public access prevention: on）
+
+```bash
+gcloud storage buckets create gs://<your-bucket> \
+  --location=asia-northeast1 \
+  --uniform-bucket-level-access \
+  --public-access-prevention
+```
+
+### 2. サービスアカウント作成 → バケットに権限付与
+
+当該バケットに `roles/storage.objectAdmin` を付与する（バケット単位でスコープ）。
+
+```bash
+gcloud iam service-accounts create pod-admin-storage \
+  --display-name="pod-admin GCS storage"
+
+gcloud storage buckets add-iam-policy-binding gs://<your-bucket> \
+  --member="serviceAccount:pod-admin-storage@<project>.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+```
+
+### 3. JSON 鍵を作成し Railway に設定
+
+```bash
+gcloud iam service-accounts keys create key.json \
+  --iam-account=pod-admin-storage@<project>.iam.gserviceaccount.com
+```
+
+Railway Dashboard → プロジェクト → Variables タブで以下を設定 → 再デプロイ:
+
+| 変数名 | 値 |
+|--------|-----|
+| `GCS_BUCKET` | 作成したバケット名（例: `pod-admin-prod`） |
+| `GCS_CREDENTIALS_JSON` | `key.json` の中身（JSON 全体を1行で貼り付け） |
+| `GCS_PREFIX` | 任意の名前空間（例: `prod`。未設定可） |
+
+> `GCS_CREDENTIALS_JSON` が空の場合は ADC（Application Default Credentials）へ
+> フォールバックする（GCE / ワークロードID 環境向け）。Railway は GCP ワークロードID
+> 非対応のため、鍵 JSON をシークレットとして保持する。
+
+### 4. ローカル開発
+
+`GCS_BUCKET` を空のままにすればローカル保存（`UPLOAD_DIR`）を継続する。GCS を検証したい
+場合のみ `GCS_BUCKET` を設定する（認証は `GCS_CREDENTIALS_JSON` か `gcloud auth
+application-default login` による ADC）。
+
 ## 再デプロイ
 
 コード変更後:

--- a/api/DEPLOY.md
+++ b/api/DEPLOY.md
@@ -67,11 +67,15 @@ open https://<your-app>.railway.app/api/v1/docs
 
 ## ファイル永続化（GCS）
 
-Railway のローカルディスクは**再デプロイ/再起動で消える**ため、本番では製造データ
-（.ai/.pdf）・チャット添付・出荷ファイルを Google Cloud Storage（GCS）に永続化する。
-`GCS_BUCKET` を設定すると全 `FileStorage` が GCS 経由になり、未設定ならローカル保存を
-継続する（既定・挙動不変）。アクセスはサーバ経由（`get()` で bytes 取得）のため、バケットは
+Railway のローカルディスクは**再デプロイ/再起動で消える**ため、製造データ（.ai/.pdf）・
+チャット添付・出荷ファイルを Google Cloud Storage（GCS）に永続化する。**ローカル開発も
+本番と同様に GCS を使い、バケットは本番と分ける**（例: 本番 `pod-admin-prod` /
+ローカル `pod-admin-dev`）。`GCS_BUCKET` を空にした場合のみローカル保存へフォールバック
+する（CI/オフライン用）。アクセスはサーバ経由（`get()` で bytes 取得）のため、バケットは
 非公開のままでよく、署名URLも不要。
+
+以下は本番（`pod-admin-prod`）の手順。**ローカル用（`pod-admin-dev`）も同じ手順で
+別バケット・別サービスアカウントを用意する**（→ 手順4）。
 
 ### 1. GCS バケット作成
 
@@ -118,11 +122,25 @@ Railway Dashboard → プロジェクト → Variables タブで以下を設定 
 > フォールバックする（GCE / ワークロードID 環境向け）。Railway は GCP ワークロードID
 > 非対応のため、鍵 JSON をシークレットとして保持する。
 
-### 4. ローカル開発
+### 4. ローカル開発（本番と別バケットで GCS を使う）
 
-`GCS_BUCKET` を空のままにすればローカル保存（`UPLOAD_DIR`）を継続する。GCS を検証したい
-場合のみ `GCS_BUCKET` を設定する（認証は `GCS_CREDENTIALS_JSON` か `gcloud auth
-application-default login` による ADC）。
+ローカルも本番と同様に GCS を使う。上の手順1〜2を**別バケット・別サービスアカウント**で
+繰り返す（例: バケット `pod-admin-dev`、SA `pod-admin-storage-dev`）。鍵 JSON を作成し、
+`api/.env`（`api/.env.example` をコピー）に設定する:
+
+```bash
+# api/.env
+GCS_BUCKET=pod-admin-dev
+GCS_CREDENTIALS_JSON={"type":"service_account", ... }   # dev SA 鍵 JSON を1行で
+GCS_PREFIX=dev
+```
+
+`docker compose up`（`api/docker-compose.yml`）は上記を api コンテナへそのまま渡す。
+Docker を使わずローカル実行する場合は `GCS_CREDENTIALS_JSON` の代わりに
+`gcloud auth application-default login` による ADC でも可（`GCS_CREDENTIALS_JSON` 空）。
+
+> オフライン作業や CI など GCS を使わない場合のみ `GCS_BUCKET` を空にする
+> （その場合は `UPLOAD_DIR` へローカル保存にフォールバック）。
 
 ## 再デプロイ
 

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -47,9 +47,11 @@ class Settings(BaseSettings):
     UPLOAD_DIR: str = "uploads"
     MAX_UPLOAD_SIZE: int = 100 * 1024 * 1024  # 100MB
 
-    # File Storage (GCS) — 本番=Railway でのファイル永続化
+    # File Storage (GCS) — ローカル/本番ともに GCS でファイル永続化
     # Railway のローカルディスクは再デプロイで消えるため、製造データ/チャット添付/出荷
-    # ファイルを GCS に永続化する。GCS_BUCKET が空ならローカル保存を継続（既定・挙動不変）。
+    # ファイルを GCS に永続化する。ローカル開発も本番と同様に GCS を使い、バケットは
+    # 本番と分ける（例: prod / dev）。GCS_BUCKET が空の場合のみローカル保存へ
+    # フォールバックする（CI/オフライン用）。
     GCS_BUCKET: str = ""
     # サービスアカウント鍵JSON文字列（Railway シークレット想定）。空なら ADC へフォールバック。
     GCS_CREDENTIALS_JSON: str = ""

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -47,6 +47,15 @@ class Settings(BaseSettings):
     UPLOAD_DIR: str = "uploads"
     MAX_UPLOAD_SIZE: int = 100 * 1024 * 1024  # 100MB
 
+    # File Storage (GCS) — 本番=Railway でのファイル永続化
+    # Railway のローカルディスクは再デプロイで消えるため、製造データ/チャット添付/出荷
+    # ファイルを GCS に永続化する。GCS_BUCKET が空ならローカル保存を継続（既定・挙動不変）。
+    GCS_BUCKET: str = ""
+    # サービスアカウント鍵JSON文字列（Railway シークレット想定）。空なら ADC へフォールバック。
+    GCS_CREDENTIALS_JSON: str = ""
+    # バケット内のキー前置（任意の名前空間。例: "prod"）。DBの file_path は非依存のまま。
+    GCS_PREFIX: str = ""
+
     # Email (SendGrid)
     SENDGRID_API_KEY: str = ""
     SENDGRID_FROM_EMAIL: str = ""

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -29,16 +29,16 @@ from app.services.external_service import ExternalService
 from app.services.illustrator_vm_client import IllustratorVmClient
 from app.services.invoice_service import InvoiceService
 from app.services.manufacturer_order_service import ManufacturerOrderService
-from app.services.manufacturing_data_service import ManufacturingDataService
 from app.services.manufacturer_portal_service import ManufacturerPortalService
 from app.services.manufacturer_service import ManufacturerService
+from app.services.manufacturing_data_service import ManufacturingDataService
 from app.services.order_image_service import OrderImageService
 from app.services.order_list_service import OrderListService
 from app.services.order_service import OrderService
 from app.services.product_service import ProductService
 from app.services.shipment_service import ShipmentService
 from app.utils.exceptions import ForbiddenError, UnauthorizedError
-from app.utils.file_storage import FileStorage, LocalFileStorage
+from app.utils.file_storage import FileStorage, build_file_storage
 from app.utils.security import decode_token
 
 
@@ -120,6 +120,12 @@ def get_manufacturing_data_repository(
     return ManufacturingDataRepository(db)
 
 
+# File storage dependency
+def get_file_storage() -> FileStorage:
+    """Get file storage (GCS if GCS_BUCKET is set, otherwise local)."""
+    return build_file_storage(settings)
+
+
 # Service dependencies
 def get_auth_service(
     user_repo: Annotated[UserRepository, Depends(get_user_repository)],
@@ -181,7 +187,7 @@ def get_external_order_notification_service(
 def get_shipment_service(
     shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
     order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
-    file_storage: Annotated[FileStorage, Depends(lambda: LocalFileStorage(settings.UPLOAD_DIR))],
+    file_storage: Annotated[FileStorage, Depends(get_file_storage)],
     order_source_repo: Annotated[OrderSourceRepository, Depends(get_order_source_repository)],
     email_service: Annotated[EmailService | None, Depends(get_email_service)],
 ) -> ShipmentService:
@@ -194,7 +200,7 @@ def get_shipment_service(
 def get_chat_service(
     chat_repo: Annotated[ChatRepository, Depends(get_chat_repository)],
     manufacturer_repo: Annotated[ManufacturerRepository, Depends(get_manufacturer_repository)],
-    file_storage: Annotated[FileStorage, Depends(lambda: LocalFileStorage(settings.UPLOAD_DIR))],
+    file_storage: Annotated[FileStorage, Depends(get_file_storage)],
 ) -> ChatService:
     """Get chat service."""
     return ChatService(chat_repo, manufacturer_repo, file_storage)
@@ -219,9 +225,7 @@ def get_manufacturer_order_service(
     order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
     manufacturer_repo: Annotated[ManufacturerRepository, Depends(get_manufacturer_repository)],
     shipment_repo: Annotated[ShipmentRepository, Depends(get_shipment_repository)],
-    file_storage: Annotated[
-        FileStorage, Depends(lambda: LocalFileStorage(settings.UPLOAD_DIR))
-    ],
+    file_storage: Annotated[FileStorage, Depends(get_file_storage)],
 ) -> ManufacturerOrderService:
     """Get manufacturer order service."""
     return ManufacturerOrderService(
@@ -239,13 +243,14 @@ def get_manufacturing_data_service(
     md_repo: Annotated[ManufacturingDataRepository, Depends(get_manufacturing_data_repository)],
     order_repo: Annotated[OrderRepository, Depends(get_order_repository)],
     vm_client: Annotated[IllustratorVmClient | None, Depends(get_illustrator_vm_client)],
+    file_storage: Annotated[FileStorage, Depends(get_file_storage)],
 ) -> ManufacturingDataService:
     """Get manufacturing data service."""
     return ManufacturingDataService(
         md_repo=md_repo,
         order_repo=order_repo,
         session=db,
-        file_storage=LocalFileStorage(settings.UPLOAD_DIR),
+        file_storage=file_storage,
         vm_client=vm_client,
     )
 
@@ -278,12 +283,6 @@ def get_invoice_service(
 ) -> InvoiceService:
     """Get invoice service."""
     return InvoiceService(manufacturer_repo, order_repo)
-
-
-# File storage dependency
-def get_file_storage() -> FileStorage:
-    """Get file storage."""
-    return LocalFileStorage(settings.UPLOAD_DIR)
 
 
 # Authentication dependencies

--- a/api/app/services/manufacturing_data_service.py
+++ b/api/app/services/manufacturing_data_service.py
@@ -28,7 +28,7 @@ from app.schemas.manufacturing_data import (
 )
 from app.services.illustrator_vm_client import IllustratorVmClient, IllustratorVmError
 from app.utils.exceptions import ConflictError, NotFoundError
-from app.utils.file_storage import FileStorage, LocalFileStorage
+from app.utils.file_storage import FileStorage, build_file_storage
 from app.utils.mfg_product_mapping import MfgMappingError, build_vm_mapping
 from app.utils.url_guard import validate_source_url
 
@@ -365,7 +365,7 @@ class ManufacturingDataService:
 
     async def _save_file(self, content: bytes, filename: str) -> str:
         """生成物を FileStorage に保存し、保存先パスを返す."""
-        storage = self._file_storage or LocalFileStorage(settings.UPLOAD_DIR)
+        storage = self._file_storage or build_file_storage(settings)
         return await storage.save(_BytesUpload(content, filename), prefix=_STORAGE_PREFIX)
 
     # === 管理API（リクエストスコープ） ===
@@ -433,7 +433,7 @@ async def run_generation(md_id: str) -> None:
             md_repo=ManufacturingDataRepository(session),
             order_repo=OrderRepository(session),
             session=session,
-            file_storage=LocalFileStorage(settings.UPLOAD_DIR),
+            file_storage=build_file_storage(settings),
             vm_client=IllustratorVmClient.from_settings(settings),
         )
         try:

--- a/api/app/utils/file_storage.py
+++ b/api/app/utils/file_storage.py
@@ -1,13 +1,32 @@
-"""File storage utilities."""
+"""File storage utilities.
 
+`FileStorage` を抽象化し、ローカル（開発）と GCS（本番=Railway）を切り替える。
+
+- ローカル: `LocalFileStorage`。`UPLOAD_DIR` 配下に保存。
+- GCS: `GCSFileStorage`。公式 `google-cloud-storage`（同期）を `asyncio.to_thread`
+  でラップしてイベントループを塞がない。`GCS_PREFIX` を内部で前置するため、DB に持つ
+  `file_path`（＝ save が返す相対キー）はバックエンド非依存で共通。
+- 生成先は `build_file_storage(settings)` に集約。`GCS_BUCKET` があれば GCS、無ければ
+  ローカル（既定・挙動不変）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
 import os
+import posixpath
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Protocol
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any, Protocol
 from uuid import uuid4
 
 import aiofiles
 import aiofiles.os
+
+if TYPE_CHECKING:
+    from app.config import Settings
 
 
 class UploadFile(Protocol):
@@ -17,6 +36,26 @@ class UploadFile(Protocol):
 
     def read(self) -> bytes: ...
     def seek(self, offset: int) -> None: ...
+
+
+def generate_stored_filename(original_filename: str | None) -> str:
+    """保存用の一意なファイル名を生成する（拡張子は元ファイルから保持）.
+
+    Local/GCS で同一命名を使うため、モジュール関数として共通化する。
+    書式: ``{timestamp}_{uuid8}{ext}``（例: ``20260710_121530_1a2b3c4d.pdf``）。
+    """
+    ext = os.path.splitext(original_filename)[1] if original_filename else ""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    unique_id = str(uuid4())[:8]
+    return f"{timestamp}_{unique_id}{ext}"
+
+
+async def _read_upload(file: UploadFile) -> bytes:
+    """UploadFile から内容を読む（同期/非同期の read 両対応）."""
+    content = file.read()
+    if hasattr(content, "__await__"):
+        content = await content
+    return content
 
 
 class FileStorage(ABC):
@@ -53,20 +92,9 @@ class LocalFileStorage(FileStorage):
         """Get the full filesystem path."""
         return os.path.join(self.base_dir, path)
 
-    def _generate_filename(self, original_filename: str | None) -> str:
-        """Generate a unique filename preserving the extension."""
-        if original_filename:
-            _, ext = os.path.splitext(original_filename)
-        else:
-            ext = ""
-
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        unique_id = str(uuid4())[:8]
-        return f"{timestamp}_{unique_id}{ext}"
-
     async def save(self, file: UploadFile, prefix: str = "") -> str:
         """Save a file and return the relative path."""
-        filename = self._generate_filename(file.filename)
+        filename = generate_stored_filename(file.filename)
         relative_path = os.path.join(prefix, filename)
         full_path = self._get_full_path(relative_path)
 
@@ -75,10 +103,7 @@ class LocalFileStorage(FileStorage):
         if dir_path:
             os.makedirs(dir_path, exist_ok=True)
 
-        # Read content (handle both sync and async)
-        content = file.read()
-        if hasattr(content, "__await__"):
-            content = await content
+        content = await _read_upload(file)
 
         # Write file
         async with aiofiles.open(full_path, "wb") as f:
@@ -108,3 +133,108 @@ class LocalFileStorage(FileStorage):
         """Check if a file exists."""
         full_path = self._get_full_path(path)
         return await aiofiles.os.path.exists(full_path)
+
+
+class GCSFileStorage(FileStorage):
+    """Google Cloud Storage storage implementation.
+
+    公式 `google-cloud-storage`（同期API）を `asyncio.to_thread` でラップし、
+    イベントループを塞がずに使う。`save` が返す相対キーは Local と共通（DBの
+    `file_path` は非依存）で、GCS のオブジェクト名は内部で `prefix`（`GCS_PREFIX`）
+    を前置して構成する。
+
+    `client` を注入可能にしてテストを実 GCS 非依存にする（フェイククライアント）。
+    """
+
+    def __init__(self, bucket: str, client: Any, prefix: str = ""):
+        self._bucket_name = bucket
+        self._client = client
+        # 名前空間プレフィックス。余分な区切りを正規化してキー結合を安定させる。
+        self._prefix = prefix.strip("/")
+
+    def _blob_name(self, path: str) -> str:
+        """相対キーを GCS オブジェクト名（prefix 前置）に変換する."""
+        key = path.strip("/")
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    def _get_blob(self, path: str) -> Any:
+        """対象 blob ハンドルを返す（同期。to_thread から呼ぶ）."""
+        bucket = self._client.bucket(self._bucket_name)
+        return bucket.blob(self._blob_name(path))
+
+    async def save(self, file: UploadFile, prefix: str = "") -> str:
+        """Save a file and return the backend-independent relative path."""
+        filename = generate_stored_filename(file.filename)
+        # 相対キーは POSIX 区切りで統一（GCS キーは常に "/" 区切り）。
+        relative_path = posixpath.join(prefix, filename)
+        content = await _read_upload(file)
+
+        def _upload() -> None:
+            self._get_blob(relative_path).upload_from_string(content)
+
+        await asyncio.to_thread(_upload)
+        return relative_path
+
+    async def delete(self, path: str) -> bool:
+        """Delete a file. Returns True if deleted, False if not found."""
+        from google.api_core.exceptions import NotFound
+
+        def _delete() -> bool:
+            try:
+                self._get_blob(path).delete()
+                return True
+            except NotFound:
+                return False
+
+        return await asyncio.to_thread(_delete)
+
+    async def get(self, path: str) -> bytes | None:
+        """Get file content. Returns None if not found."""
+        from google.api_core.exceptions import NotFound
+
+        def _download() -> bytes | None:
+            try:
+                data: bytes = self._get_blob(path).download_as_bytes()
+            except NotFound:
+                return None
+            return data
+
+        return await asyncio.to_thread(_download)
+
+    async def exists(self, path: str) -> bool:
+        """Check if a file exists."""
+
+        def _exists() -> bool:
+            return bool(self._get_blob(path).exists())
+
+        return await asyncio.to_thread(_exists)
+
+
+@lru_cache(maxsize=1)
+def _build_gcs_client(credentials_json: str) -> Any:
+    """GCS クライアントを構築する（プロセス内で1つを再利用）.
+
+    `storage.Client` は生成コスト（認証・コネクションプール確立）が高く再利用が推奨
+    されるため、認証情報をキーにキャッシュする。`credentials_json`（SA鍵JSON文字列）
+    があればそれで認証し、空なら ADC（ローカル/GCE のデフォルト認証）へフォールバックする。
+    """
+    from google.cloud import storage
+
+    if credentials_json:
+        info = json.loads(credentials_json)
+        return storage.Client.from_service_account_info(info)
+    return storage.Client()
+
+
+def build_file_storage(settings: Settings) -> FileStorage:
+    """設定に応じて FileStorage 実装を返す単一ファクトリ.
+
+    `GCS_BUCKET` があれば GCS、無ければローカル（既定・挙動不変）。
+    """
+    if settings.GCS_BUCKET:
+        return GCSFileStorage(
+            bucket=settings.GCS_BUCKET,
+            client=_build_gcs_client(settings.GCS_CREDENTIALS_JSON),
+            prefix=settings.GCS_PREFIX,
+        )
+    return LocalFileStorage(settings.UPLOAD_DIR)

--- a/api/app/utils/file_storage.py
+++ b/api/app/utils/file_storage.py
@@ -1,13 +1,14 @@
 """File storage utilities.
 
-`FileStorage` を抽象化し、ローカル（開発）と GCS（本番=Railway）を切り替える。
+`FileStorage` を抽象化する。ローカル/本番ともに GCS を使い（バケットは分ける）、
+`GCS_BUCKET` 未設定時のみローカル保存へフォールバックする（CI/オフライン用）。
 
-- ローカル: `LocalFileStorage`。`UPLOAD_DIR` 配下に保存。
 - GCS: `GCSFileStorage`。公式 `google-cloud-storage`（同期）を `asyncio.to_thread`
   でラップしてイベントループを塞がない。`GCS_PREFIX` を内部で前置するため、DB に持つ
   `file_path`（＝ save が返す相対キー）はバックエンド非依存で共通。
+- ローカル: `LocalFileStorage`。`UPLOAD_DIR` 配下に保存（フォールバック）。
 - 生成先は `build_file_storage(settings)` に集約。`GCS_BUCKET` があれば GCS、無ければ
-  ローカル（既定・挙動不変）。
+  ローカル。
 """
 
 from __future__ import annotations
@@ -229,7 +230,7 @@ def _build_gcs_client(credentials_json: str) -> Any:
 def build_file_storage(settings: Settings) -> FileStorage:
     """設定に応じて FileStorage 実装を返す単一ファクトリ.
 
-    `GCS_BUCKET` があれば GCS、無ければローカル（既定・挙動不変）。
+    `GCS_BUCKET` があれば GCS、無ければローカル（フォールバック）。
     """
     if settings.GCS_BUCKET:
         return GCSFileStorage(

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       - SECRET_KEY=dev-secret-key-change-in-production
       - DEBUG=true
       - CORS_ORIGINS=["http://localhost:3000"]
+      # ファイルストレージ（GCS）: ローカル開発も本番と同様に GCS を使う（バケットは分ける）。
+      # api/.env に dev 用のバケット/認証情報を設定する（未設定ならローカル保存にフォールバック）。
+      - GCS_BUCKET=${GCS_BUCKET:-}
+      - GCS_CREDENTIALS_JSON=${GCS_CREDENTIALS_JSON:-}
+      - GCS_PREFIX=${GCS_PREFIX:-}
     depends_on:
       db:
         condition: service_healthy

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "sendgrid>=6.11.0",
     # Japanese holidays
     "jpholiday>=0.1.9",
+    # Cloud Storage (本番=Railway でのファイル永続化。未設定なら未使用)
+    "google-cloud-storage>=2.18.0",
 ]
 
 [project.optional-dependencies]

--- a/api/tests/unit/test_file_storage.py
+++ b/api/tests/unit/test_file_storage.py
@@ -2,12 +2,18 @@
 
 import os
 import tempfile
-from io import BytesIO
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from google.api_core.exceptions import NotFound
 
-from app.utils.file_storage import LocalFileStorage
+from app.utils.file_storage import (
+    GCSFileStorage,
+    LocalFileStorage,
+    build_file_storage,
+    generate_stored_filename,
+)
 
 
 @pytest.fixture
@@ -123,3 +129,224 @@ async def test_exists(file_storage, temp_upload_dir):
 
     assert await file_storage.exists(test_path) is True
     assert await file_storage.exists("nonexistent.txt") is False
+
+
+# ---------------------------------------------------------------------------
+# GCSFileStorage
+# ---------------------------------------------------------------------------
+
+
+class _FakeBlob:
+    """In-memory stand-in for a google.cloud.storage Blob."""
+
+    def __init__(self, store: dict[str, bytes], name: str) -> None:
+        self._store = store
+        self._name = name
+
+    def upload_from_string(self, data: bytes) -> None:
+        self._store[self._name] = bytes(data)
+
+    def download_as_bytes(self) -> bytes:
+        if self._name not in self._store:
+            raise NotFound(f"blob {self._name} not found")
+        return self._store[self._name]
+
+    def delete(self) -> None:
+        if self._name not in self._store:
+            raise NotFound(f"blob {self._name} not found")
+        del self._store[self._name]
+
+    def exists(self) -> bool:
+        return self._name in self._store
+
+
+class _FakeBucket:
+    def __init__(self, store: dict[str, bytes]) -> None:
+        self._store = store
+
+    def blob(self, name: str) -> _FakeBlob:
+        return _FakeBlob(self._store, name)
+
+
+class _FakeGCSClient:
+    """In-memory fake of google.cloud.storage.Client (no real GCS)."""
+
+    def __init__(self) -> None:
+        # bucket name -> {blob name: bytes}
+        self.buckets: dict[str, dict[str, bytes]] = {}
+
+    def bucket(self, name: str) -> _FakeBucket:
+        return _FakeBucket(self.buckets.setdefault(name, {}))
+
+
+def _mock_upload(filename: str, content: bytes) -> MagicMock:
+    """Build a mock UploadFile matching FileStorage.save's expectations."""
+    mock_file = MagicMock()
+    mock_file.filename = filename
+    mock_file.read = MagicMock(return_value=content)
+    mock_file.seek = MagicMock()
+    return mock_file
+
+
+@pytest.fixture
+def fake_gcs_client():
+    """Fresh in-memory fake GCS client."""
+    return _FakeGCSClient()
+
+
+@pytest.fixture
+def gcs_storage(fake_gcs_client):
+    """GCSFileStorage backed by the fake client (bucket 'test-bucket')."""
+    return GCSFileStorage(bucket="test-bucket", client=fake_gcs_client)
+
+
+@pytest.mark.asyncio
+async def test_gcs_save_and_get_roundtrip(gcs_storage, fake_gcs_client):
+    """save() uploads to GCS and get() returns the same bytes."""
+    content = b"manufacturing data .ai bytes"
+    saved_path = await gcs_storage.save(_mock_upload("design.ai", content), "manufacturing_data/")
+
+    # Backend-independent relative key (no leading prefix in the returned path).
+    assert saved_path.startswith("manufacturing_data/")
+    assert saved_path.endswith(".ai")
+
+    # Stored under the same key inside the bucket (no GCS_PREFIX configured here).
+    assert fake_gcs_client.buckets["test-bucket"][saved_path] == content
+
+    # Round trip via get().
+    assert await gcs_storage.get(saved_path) == content
+
+
+@pytest.mark.asyncio
+async def test_gcs_get_nonexistent_returns_none(gcs_storage):
+    """get() returns None when the object does not exist."""
+    assert await gcs_storage.get("manufacturing_data/missing.ai") is None
+
+
+@pytest.mark.asyncio
+async def test_gcs_delete(gcs_storage):
+    """delete() removes an existing object and reports True."""
+    saved_path = await gcs_storage.save(_mock_upload("a.pdf", b"pdf"), "shipments/1/")
+
+    assert await gcs_storage.delete(saved_path) is True
+    assert await gcs_storage.exists(saved_path) is False
+
+
+@pytest.mark.asyncio
+async def test_gcs_delete_nonexistent_returns_false(gcs_storage):
+    """delete() returns False when the object is missing."""
+    assert await gcs_storage.delete("chat/missing.png") is False
+
+
+@pytest.mark.asyncio
+async def test_gcs_exists(gcs_storage):
+    """exists() reflects whether the object is present."""
+    saved_path = await gcs_storage.save(_mock_upload("x.png", b"png"), "chat/")
+
+    assert await gcs_storage.exists(saved_path) is True
+    assert await gcs_storage.exists("chat/nope.png") is False
+
+
+@pytest.mark.asyncio
+async def test_gcs_prefix_is_prepended_to_object_name(fake_gcs_client):
+    """GCS_PREFIX is prepended to the stored object name but not the returned key."""
+    storage = GCSFileStorage(bucket="test-bucket", client=fake_gcs_client, prefix="prod")
+    content = b"prefixed"
+
+    saved_path = await storage.save(_mock_upload("f.ai", content), "manufacturing_data/")
+
+    # Returned key stays namespace-free (DB.file_path is backend-independent).
+    assert saved_path.startswith("manufacturing_data/")
+    # Object is physically stored under the prefixed name.
+    assert fake_gcs_client.buckets["test-bucket"][f"prod/{saved_path}"] == content
+    # And the same relative key round-trips through get()/exists().
+    assert await storage.get(saved_path) == content
+    assert await storage.exists(saved_path) is True
+
+
+# ---------------------------------------------------------------------------
+# build_file_storage factory
+# ---------------------------------------------------------------------------
+
+
+def _settings(**overrides):
+    """Minimal settings stub for the factory (duck-typed, no env required)."""
+    base = {
+        "UPLOAD_DIR": "uploads",
+        "GCS_BUCKET": "",
+        "GCS_CREDENTIALS_JSON": "",
+        "GCS_PREFIX": "",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_factory_returns_local_when_no_bucket():
+    """No GCS_BUCKET -> LocalFileStorage (default, behavior unchanged)."""
+    storage = build_file_storage(_settings(UPLOAD_DIR="/data/uploads"))
+
+    assert isinstance(storage, LocalFileStorage)
+    assert storage.base_dir == "/data/uploads"
+
+
+def test_factory_returns_gcs_when_bucket_set(monkeypatch):
+    """GCS_BUCKET set -> GCSFileStorage, wired with bucket/prefix (no real client)."""
+    fake_client = _FakeGCSClient()
+    monkeypatch.setattr(
+        "app.utils.file_storage._build_gcs_client", lambda credentials_json: fake_client
+    )
+
+    storage = build_file_storage(_settings(GCS_BUCKET="my-bucket", GCS_PREFIX="prod"))
+
+    assert isinstance(storage, GCSFileStorage)
+    assert storage._bucket_name == "my-bucket"
+    assert storage._prefix == "prod"
+    assert storage._client is fake_client
+
+
+def test_gcs_client_is_cached_per_process(monkeypatch):
+    """_build_gcs_client reuses one client (no per-request rebuild/auth)."""
+    import google.cloud.storage as gcs_storage
+
+    from app.utils import file_storage
+
+    constructed: list[object] = []
+
+    def _fake_client_ctor(*args, **kwargs):
+        client = object()
+        constructed.append(client)
+        return client
+
+    monkeypatch.setattr(gcs_storage, "Client", _fake_client_ctor)
+    file_storage._build_gcs_client.cache_clear()
+    try:
+        first = file_storage._build_gcs_client("")
+        second = file_storage._build_gcs_client("")
+        assert first is second  # same client reused
+        assert len(constructed) == 1  # constructed exactly once
+    finally:
+        file_storage._build_gcs_client.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# generate_stored_filename helper
+# ---------------------------------------------------------------------------
+
+
+def test_generate_stored_filename_preserves_extension():
+    """The generated name keeps the original extension."""
+    assert generate_stored_filename("photo.PNG").endswith(".PNG")
+    assert generate_stored_filename("archive.tar.gz").endswith(".gz")
+
+
+def test_generate_stored_filename_without_extension():
+    """A name without an extension yields a bare timestamp_uuid."""
+    name = generate_stored_filename(None)
+    assert "." not in name
+    # timestamp(15 chars: YYYYMMDD_HHMMSS) + "_" + uuid8
+    assert len(name.split("_")) == 3
+
+
+def test_generate_stored_filename_is_unique():
+    """Two calls produce distinct names (uuid component)."""
+    assert generate_stored_filename("a.pdf") != generate_stored_filename("a.pdf")

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -254,6 +254,67 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -521,6 +582,112 @@ woff = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
     { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
     { name = "zopfli" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/b9/e370d86fea3da13ec0256df30323dd26c0cb9c8c85f0c6ec42ac9df0106b/google_auth-2.55.2.tar.gz", hash = "sha256:97ae7790ff740f2bc9db60eb864a7804f4ac19f5f02c38b3d942f2fea6e9b9ae", size = 361414, upload-time = "2026-07-07T18:43:21.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/c6/02eb5a337ac316a4c30c012e747bad5cea36e1a876efecdf80865541f7d8/google_auth-2.55.2-py3-none-any.whl", hash = "sha256:d715f265f2cafc6a5f1bf0dc19870d20e3119f6f6682785a250bce3d03d38a3b", size = 256778, upload-time = "2026-07-07T18:43:19.52Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/ac/60b4cb0a6c8c6bb7cedb8971ba5e34a94096acf76e2cc242bcf1e6fc5c49/google_cloud_storage-3.12.1.tar.gz", hash = "sha256:1d81491c7663bc26c5056d00b834356f2253b910ef467f9cf9928a87fca1e04b", size = 17339353, upload-time = "2026-07-08T17:03:59.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/ca176e95bafac0fe7befeee7e0420e686de147571cd2908e308c5fe71bda/google_cloud_storage-3.12.1-py3-none-any.whl", hash = "sha256:9297ae0c2ce3f5400b1f2bb3a3e6d2cd256614366e03cd30600871df8e903afb", size = 340845, upload-time = "2026-07-08T17:03:31.418Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -970,6 +1137,7 @@ dependencies = [
     { name = "chardet" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "jpholiday" },
@@ -1015,6 +1183,7 @@ requires-dist = [
     { name = "chardet", specifier = ">=5.0.0" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "google-cloud-storage", specifier = ">=2.18.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jpholiday", specifier = ">=0.1.9" },
@@ -1049,12 +1218,51 @@ dev = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/44/767757fd2cdd4a60d7e4440d9f7b491d6131103d313638d2c03e06c268fb/proto_plus-1.28.1.tar.gz", hash = "sha256:832e68e7fe064cf90ab153b6e5eb935b27891bb89aaeb68b115e9b702f6cb168", size = 57166, upload-time = "2026-07-08T17:04:02.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/34/2f2b57dbfd145b995a29847a16b0903fce5ef6ad3c7aad740a609c5d3678/proto_plus-1.28.1-py3-none-any.whl", hash = "sha256:6660f5f1970874bdcfc3088b435188a36a37bd3596668f7d726417c4ae8cfbed", size = 50408, upload-time = "2026-07-08T17:03:34.532Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1329,6 +1537,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rsa"
 version = "4.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1494,6 +1717,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

**Intent Spec:** #85

### なぜこの変更が必要か

外部注文v2（#76 / #77）の製造データ生成物（.ai/.pdf）は既定の `LocalFileStorage` ＝ **Railway コンテナのローカルディスク**に保存される。Railway のファイルシステムは**再デプロイ/再起動で消える**ため、「生成物は 72h 経過後も参照可」という要件を本番で満たせない（チャット添付・出荷ファイルも同じ抽象・同じローカル保存のため同様に消失する）。

`FileStorage` を **GCS（Google Cloud Storage）で永続化**できるようにする。**ローカル/本番ともに GCS を使い、バケットは本番と分ける**（例: 本番 `pod-admin-prod` / ローカル `pod-admin-dev`）。`GCS_BUCKET` を空にした場合のみローカル保存へフォールバック（CI/オフライン用）。

---

## ⚠️ 本番で動作させるために必要な作業

このコードは env 駆動で用意してあり、**GCS バケット/サービスアカウントは未整備**のため、本番反映には以下の手動作業が必要です（詳細コマンドは `api/DEPLOY.md`「ファイル永続化（GCS）」）。

1. **本番 GCS バケット作成** — リージョン `asia-northeast1`（illustrator-vm と同一）、Uniform bucket-level access、**非公開**（public access prevention: on）。例: `pod-admin-prod`。
2. **サービスアカウント作成 → バケットに IAM 付与** — 当該バケットに `roles/storage.objectAdmin` を**バケット単位スコープ**で付与。
3. **JSON 鍵を作成**（`gcloud iam service-accounts keys create`）。
4. **Railway（FastAPI / production）に環境変数を設定 → 再デプロイ**
   - `GCS_BUCKET` = `pod-admin-prod`
   - `GCS_CREDENTIALS_JSON` = 鍵 JSON 全体を1行で（Railway は GCP ワークロードID非対応のためシークレットとして保持。空なら ADC フォールバック）
   - `GCS_PREFIX` = 任意（例 `prod`。未設定可）
5. **本番動作確認（受け入れ条件の手動項目）** — 製造データを生成 → GCS バケットにオブジェクトが作成されること、**再デプロイ後も `get()` で参照できること**を確認。
6. **ローカル開発用に dev バケット/SA を別途用意** — 上記1〜3を別バケット（`pod-admin-dev`）・別 SA で繰り返し、`api/.env` に `GCS_BUCKET`/`GCS_CREDENTIALS_JSON`/`GCS_PREFIX=dev` を設定（`docker compose up` がコンテナへ渡す）。Docker 非使用時は ADC（`gcloud auth application-default login`）でも可。
7. **依存反映** — `google-cloud-storage` を `pyproject.toml` に追加済み。イメージ再ビルド or `uv sync` で反映される。

> コード・設計・自動テスト（フェイク GCS クライアント）で担保済みですが、**実バケットでの save→get 往復と再デプロイ後の参照のみ CI では検証できない**ため、上記5が唯一の手動確認点です。

---

## 主な変更

- **`GCSFileStorage(FileStorage)`** を追加（`save`/`get`/`delete`/`exists`）。公式 `google-cloud-storage`（同期）を `asyncio.to_thread` でラップしイベントループを塞がない。`client` 注入可能でテストは実 GCS 非依存。
- **単一ファクトリ `build_file_storage(settings)`** を追加。`GCS_BUCKET` があれば GCS・無ければ `LocalFileStorage`（フォールバック）。**直接生成していた 7 箇所を集約**（DI の `get_file_storage` / 製造データサービスの fallback・`run_generation`）。
- ファイル名生成（`{timestamp}_{uuid}{ext}`）とアップロード読取を**共通ヘルパへ切り出し**、Local/GCS で同一命名。`save` が返すのは**バックエンド非依存の相対キー**（DB の `file_path` はそのまま。GCS 側は内部で `GCS_PREFIX` を前置）。
- 設定追加: `GCS_BUCKET` / `GCS_CREDENTIALS_JSON`（空なら ADC）/ `GCS_PREFIX`。
- **ローカルも本番同様に GCS を使う**（バケット分離）。`docker-compose.yml` が GCS 変数を api コンテナへ渡し、`.env.example` を GCS 標準構成に更新。
- `storage.Client` は生成コスト（認証・コネクションプール確立）が高いため **`lru_cache` でプロセス内再利用**（リクエスト毎の再構築を回避）。
- `pyproject.toml` に `google-cloud-storage` を追加。本番/ローカル手順を `api/DEPLOY.md` / `api/.env.example` に明記。

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | 新規コードは mypy エラーゼロ（`file_storage.py` の既存 aiofiles スタブ未導入・`LocalFileStorage` の no-any-return は本PR対象外・増減なし） |
| リンター | ✅ | 変更コードは ruff クリーン（`dependencies.py` の既存 B008×3 は未変更の認証関数由来） |
| ユニットテスト | ✅ | `tests/unit/test_file_storage.py` 19 passed。**新規テスト失敗ゼロ**（全体は既存の環境依存 44 failed のみで増減なし: 420→432 passed） |
| 統合テスト | — | 未実施（DB 要）。ファイルストレージ層はユニット＋フェイク GCS クライアントで担保 |
| 仕様適合 | ✅ | AC 6/7 を自動テストでカバー（残 1 は本番デプロイ後の手動確認、上記「必要な作業」5） |
| AI意味レビュー | ✅ | `/simplify max`（reuse / simplification / efficiency / altitude の 4 観点）実施・反映済み |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| `GCS_BUCKET` 設定時、生成物が GCS に保存され `get()` で取得（save→get 往復） | `test_gcs_save_and_get_roundtrip` | ✅ |
| `GCS_BUCKET` 未設定時は `LocalFileStorage` で動作（フォールバック） | `test_factory_returns_local_when_no_bucket` ＋ 既存 Local テスト | ✅ |
| 全経路がファクトリ経由で GCS/ローカルを切替 | 7 箇所を `build_file_storage` に集約 ＋ ファクトリ切替テスト | ✅ |
| `GCSFileStorage` の save/get/delete/exists ユニット（フェイク GCS） | `test_gcs_save_and_get_roundtrip` / `..._get_nonexistent...` / `..._delete` / `..._delete_nonexistent...` / `..._exists` / `..._prefix_is_prepended...` | ✅ |
| ファクトリ切替（bucket 有→GCS / 無→Local）ユニット | `test_factory_returns_gcs_when_bucket_set` / `test_factory_returns_local_when_no_bucket` | ✅ |
| 本番（Railway）で再デプロイ後も直前生成の製造データが `get()` で参照可 | 設計上 GCS 永続化で担保。実バケット/SA 整備後に手動確認（上記「必要な作業」5） | ⏳ 手動 |
| 変更ファイルの ruff クリーン・新規テスト失敗ゼロ | ruff / pytest | ✅ |

## スクリーンショット

なし（バックエンドのみ、UI 変更なし）。

## レビューのポイント

- **ファクトリ集約**: 本番参照でストレージ実装を直接生成する箇所が `build_file_storage` の 1 箇所のみになっているか（旧 7 箇所は DI／サービス／背景タスク経由に集約）。
- **相対キーのバックエンド非依存性**: `save` が返すキーに `GCS_PREFIX` を含めず、DB の `file_path` を不変に保つ設計（前置は `GCSFileStorage` 内部の `_blob_name` のみ）。移行は対象外（Railway は元々消えるため新規ファイルのみ GCS へ）。
- **ローカル/本番のバケット分離**: `docker-compose.yml` の GCS 変数受け渡し＋ `api/.env` の dev バケット設定で、ローカルも本番同様に GCS を使う。
- **クライアント再利用**: `storage.Client` をリクエスト毎に作らず `lru_cache` でプロセス内共有（`test_gcs_client_is_cached_per_process`）。

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)