### PR TITLE
fix: GCS保存時に拡張子からContent-Typeを付与（text/plain固定を解消）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,13 @@ logs/
 # Uploads (runtime generated)
 api/uploads/
 
+# Credentials / secrets (never commit)
+key.json
+*-key.json
+service-account*.json
+gcp-*-key.json
+*-credentials.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/api/app/utils/file_storage.py
+++ b/api/app/utils/file_storage.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import mimetypes
 import os
 import posixpath
 from abc import ABC, abstractmethod
@@ -49,6 +50,19 @@ def generate_stored_filename(original_filename: str | None) -> str:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     unique_id = str(uuid4())[:8]
     return f"{timestamp}_{unique_id}{ext}"
+
+
+# mimetypes が環境依存で取りこぼす拡張子を明示マップ（.ai は Illustrator=PostScript系）。
+_EXTRA_CONTENT_TYPES = {".ai": "application/postscript"}
+
+
+def guess_content_type(filename: str | None) -> str:
+    """ファイル名の拡張子から Content-Type を推定する（不明時は octet-stream）."""
+    ext = os.path.splitext(filename or "")[1].lower()
+    if ext in _EXTRA_CONTENT_TYPES:
+        return _EXTRA_CONTENT_TYPES[ext]
+    ctype, _ = mimetypes.guess_type(filename or "")
+    return ctype or "application/octet-stream"
 
 
 async def _read_upload(file: UploadFile) -> bytes:
@@ -169,9 +183,12 @@ class GCSFileStorage(FileStorage):
         # 相対キーは POSIX 区切りで統一（GCS キーは常に "/" 区切り）。
         relative_path = posixpath.join(prefix, filename)
         content = await _read_upload(file)
+        content_type = guess_content_type(filename)
 
         def _upload() -> None:
-            self._get_blob(relative_path).upload_from_string(content)
+            self._get_blob(relative_path).upload_from_string(
+                content, content_type=content_type
+            )
 
         await asyncio.to_thread(_upload)
         return relative_path

--- a/api/tests/unit/test_file_storage.py
+++ b/api/tests/unit/test_file_storage.py
@@ -139,12 +139,16 @@ async def test_exists(file_storage, temp_upload_dir):
 class _FakeBlob:
     """In-memory stand-in for a google.cloud.storage Blob."""
 
-    def __init__(self, store: dict[str, bytes], name: str) -> None:
+    def __init__(
+        self, store: dict[str, bytes], ctypes: dict[str, str | None], name: str
+    ) -> None:
         self._store = store
+        self._ctypes = ctypes
         self._name = name
 
-    def upload_from_string(self, data: bytes) -> None:
+    def upload_from_string(self, data: bytes, content_type: str | None = None) -> None:
         self._store[self._name] = bytes(data)
+        self._ctypes[self._name] = content_type
 
     def download_as_bytes(self) -> bytes:
         if self._name not in self._store:
@@ -161,11 +165,14 @@ class _FakeBlob:
 
 
 class _FakeBucket:
-    def __init__(self, store: dict[str, bytes]) -> None:
+    def __init__(
+        self, store: dict[str, bytes], ctypes: dict[str, str | None]
+    ) -> None:
         self._store = store
+        self._ctypes = ctypes
 
     def blob(self, name: str) -> _FakeBlob:
-        return _FakeBlob(self._store, name)
+        return _FakeBlob(self._store, self._ctypes, name)
 
 
 class _FakeGCSClient:
@@ -174,9 +181,14 @@ class _FakeGCSClient:
     def __init__(self) -> None:
         # bucket name -> {blob name: bytes}
         self.buckets: dict[str, dict[str, bytes]] = {}
+        # bucket name -> {blob name: content_type}
+        self.content_types: dict[str, dict[str, str | None]] = {}
 
     def bucket(self, name: str) -> _FakeBucket:
-        return _FakeBucket(self.buckets.setdefault(name, {}))
+        return _FakeBucket(
+            self.buckets.setdefault(name, {}),
+            self.content_types.setdefault(name, {}),
+        )
 
 
 def _mock_upload(filename: str, content: bytes) -> MagicMock:
@@ -215,6 +227,28 @@ async def test_gcs_save_and_get_roundtrip(gcs_storage, fake_gcs_client):
 
     # Round trip via get().
     assert await gcs_storage.get(saved_path) == content
+
+
+@pytest.mark.asyncio
+async def test_gcs_save_sets_content_type_from_extension(gcs_storage, fake_gcs_client):
+    """save() sets an accurate Content-Type from the file extension (not text/plain)."""
+    cases = {
+        "art.pdf": "application/pdf",
+        "design.ai": "application/postscript",
+        "thumb.png": "image/png",
+    }
+    for filename, expected in cases.items():
+        saved = await gcs_storage.save(_mock_upload(filename, b"x"), "manufacturing_data/")
+        assert fake_gcs_client.content_types["test-bucket"][saved] == expected
+
+
+@pytest.mark.asyncio
+async def test_gcs_save_unknown_extension_defaults_to_octet_stream(
+    gcs_storage, fake_gcs_client
+):
+    """Unknown/blank extensions fall back to application/octet-stream."""
+    saved = await gcs_storage.save(_mock_upload("blob.xyzzy", b"x"), "misc/")
+    assert fake_gcs_client.content_types["test-bucket"][saved] == "application/octet-stream"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概要
`GCSFileStorage.save` が `upload_from_string` を **content_type 未指定**で呼んでいたため、GCS オブジェクトの Content-Type が既定の `text/plain` になっていた（本番スモークで生成した PDF が `text/plain` で保存されるのを確認）。

アクセスはサーバ経由 `get()`（bytes取得）のため**機能影響はない**が、メタデータとして不正確。ブラウザ直リンクや将来の署名URL配信で誤ったTypeになる余地があるため修正。

## 変更
- `guess_content_type(filename)` を追加（`mimetypes` ＋ `.ai=application/postscript` の明示マップ。不明拡張子は `application/octet-stream`）。
- `GCSFileStorage.save()` で拡張子から Content-Type を推定し `upload_from_string(..., content_type=...)` に渡す。
- テストのフェイク GCS クライアントを content_type 記録対応にし、`pdf/ai/png/未知拡張子` の Content-Type を検証（実 GCS 非依存）。

## テスト / 品質
- `tests/unit/test_file_storage.py` **21 passed**（新規: content-type 2 件）。
- 変更ファイルの ruff クリーン・新規 mypy エラーゼロ（`file_storage.py` は origin/main と同数の既存4件のみ）。
- 既存 GCS テスト（save/get/delete/exists/prefix 等）に回帰なし。

## 補足
- 本 PR は挙動非依存の小改善。GCS 永続化本体は #86 で導入済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)