### PR TITLE
【改善】発注CSV・配送CSVの「商品種類」表示を発注リスト形式に統一 (#79)

### DIFF
--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -27,7 +27,11 @@ from app.schemas.manufacturer import (
     AllManufacturerOrderItemListResponse,
 )
 from app.utils.exceptions import NotFoundError, NoOrderedItemsError
-from app.utils.order_list_generator import OrderListGenerator, get_product_type_name
+from app.utils.order_list_generator import (
+    OrderListGenerator,
+    format_product_detail,
+    get_product_type_name,
+)
 from app.utils.stand_file_config import load_stand_file
 from app.utils.zip_builder import ZipBuilder
 
@@ -485,14 +489,12 @@ class ManufacturerOrderService:
                 ordered_date = item.get("ordered_date")
 
                 # Build product detail: {商品種類} - {サイズ} - {位置} - {色}
-                detail_parts = [product_type_name]
-                if item.get("size"):
-                    detail_parts.append(item["size"])
-                if item.get("position"):
-                    detail_parts.append(item["position"])
-                if item.get("color"):
-                    detail_parts.append(item["color"])
-                product_detail = " - ".join(detail_parts)
+                product_detail = format_product_detail(
+                    item_product_type,
+                    item.get("size"),
+                    item.get("position"),
+                    item.get("color"),
+                )
 
                 # MMDDを注文日から計算
                 mmdd = ordered_date.strftime("%m%d") if ordered_date else ""

--- a/api/app/services/shipment_service.py
+++ b/api/app/services/shipment_service.py
@@ -40,6 +40,7 @@ from app.schemas.shipment import (
 )
 from app.utils.exceptions import InvalidStatusTransitionError, NotFoundError, ValidationError
 from app.utils.file_storage import FileStorage
+from app.utils.order_list_generator import format_product_detail
 from app.utils.zip_builder import ZipBuilder
 
 import chardet
@@ -906,18 +907,6 @@ class ShipmentService:
             updated_at=shipment.updated_at,
         )
 
-    def _format_product_type(self, product_type: str) -> str:
-        """Convert product_type to Japanese display name."""
-        type_map = {
-            "acrylic_keychain": "アクリルキーホルダー",
-            "acrylic_stand": "アクリルスタンド",
-            "sticker": "ステッカー",
-            "tote_bag": "トートバッグ",
-            "mug": "マグカップ",
-            "tshirt": "Tシャツ",
-        }
-        return type_map.get(product_type, product_type)
-
     async def export_csv(
         self,
         shipment_ids: list[str] | None = None,
@@ -1022,7 +1011,10 @@ class ShipmentService:
                 order.order_number,  # 1. 注文番号
                 order.customer_name,  # 2. お客様氏名
                 item.product_name,  # 3. 商品名
-                self._format_product_type(item.product_type),  # 4. 商品種類
+                # 4. 商品種類: {商品種類} - {サイズ} - {位置} - {色}（発注リストと統一）
+                format_product_detail(
+                    item.product_type, item.size, item.position, item.color
+                ),
                 str(item.quantity),  # 5. 数量
                 item.uid or "",  # 6. 商品番号（アイテムUID）
                 order.customer_phone,  # 7. お届け先電話番号

--- a/api/app/utils/order_list_generator.py
+++ b/api/app/utils/order_list_generator.py
@@ -24,6 +24,32 @@ def get_product_type_name(product_type: str) -> str:
     return PRODUCT_TYPE_NAMES.get(product_type, product_type)
 
 
+def format_product_detail(
+    product_type: str,
+    size: str | None = None,
+    position: str | None = None,
+    color: str | None = None,
+) -> str:
+    """Build the product detail string: {商品種類} - {サイズ} - {位置} - {色}.
+
+    Elements without a value (size / position / color が null/空) are skipped so
+    no extra separators appear. The product type name is resolved via
+    get_product_type_name (e.g. acrylic_stand -> アクリルフィギュア).
+
+    Examples:
+        Tシャツ - L - 正面 - 白
+        ステッカー - 100x100mm - ホワイト  (position 無し)
+    """
+    detail_parts = [get_product_type_name(product_type)]
+    if size:
+        detail_parts.append(size)
+    if position:
+        detail_parts.append(position)
+    if color:
+        detail_parts.append(color)
+    return " - ".join(detail_parts)
+
+
 class OrderListGenerator:
     """CSV generator for manufacturer order lists (発注リスト)."""
 
@@ -89,23 +115,17 @@ class OrderListGenerator:
             color = item.get("color", "")
             cost = item.get("cost", 0)
 
-            # Get product type name (use argument if provided, else from item)
+            # Get product type (use argument if provided, else from item)
             item_product_type = product_type or item.get("product_type", "")
-            product_type_name = get_product_type_name(item_product_type)
 
             # Format date as "MM月DD日"
             formatted_date = ordered_date.strftime("%m月%d日") if ordered_date else ""
             mmdd = ordered_date.strftime("%m%d") if ordered_date else ""
 
             # Build product detail: {商品種類} - {サイズ} - {位置} - {色}
-            detail_parts = [product_type_name]
-            if size:
-                detail_parts.append(size)
-            if position:
-                detail_parts.append(position)
-            if color:
-                detail_parts.append(color)
-            product_detail = " - ".join(detail_parts)
+            product_detail = format_product_detail(
+                item_product_type, size, position, color
+            )
 
             # Build seal text: {商品種類}【個数】{個数}個_{注文番号}_{製品番号}_{MMDD}
             seal_text = f"{product_detail}【個数】{quantity}個_{order_number}_{uid}_{mmdd}"
@@ -184,15 +204,13 @@ class OrderListGenerator:
             ordered_date: datetime | None = item.get("ordered_date")
             order_number = item.get("order_number", "")
             uid = item.get("uid", "")
-            product_name = item.get("product_name", "")
             quantity = item.get("quantity", 1)
             size = item.get("size", "")
             position = item.get("position", "")
             color = item.get("color", "")
 
-            # Get product type name
+            # Get product type (use argument if provided, else from item)
             item_product_type = product_type or item.get("product_type", "")
-            product_type_name = get_product_type_name(item_product_type)
 
             # Format date as "M月D日" (no zero-padding)
             if ordered_date:
@@ -203,14 +221,9 @@ class OrderListGenerator:
                 mmdd = ""
 
             # Build product detail: {商品種類} - {サイズ} - {位置} - {色}
-            detail_parts = [product_type_name]
-            if size:
-                detail_parts.append(size)
-            if position:
-                detail_parts.append(position)
-            if color:
-                detail_parts.append(color)
-            product_detail = " - ".join(detail_parts)
+            product_detail = format_product_detail(
+                item_product_type, size, position, color
+            )
 
             # Build seal text: {商品種類}【個数】{個数}個_{注文番号}_{製品番号}_{MMDD}
             seal_text = f"{product_detail}【個数】{quantity}個_{order_number}_{uid}_{mmdd}"

--- a/api/tests/unit/test_shipment_export_csv.py
+++ b/api/tests/unit/test_shipment_export_csv.py
@@ -101,13 +101,23 @@ def create_mock_order_item(
     product_type: str = "acrylic_keychain",
     quantity: int = 1,
     uid: str | None = "ITEM-001",
+    size: str | None = None,
+    position: str | None = None,
+    color: str | None = None,
 ) -> MagicMock:
-    """Create a mock OrderItem."""
+    """Create a mock OrderItem.
+
+    size / position / color はデフォルト None（MagicMock の自動属性生成で
+    truthy にならないよう明示的に設定する）。
+    """
     item = MagicMock(spec=OrderItem)
     item.product_name = product_name
     item.product_type = product_type
     item.quantity = quantity
     item.uid = uid
+    item.size = size
+    item.position = position
+    item.color = color
     return item
 
 
@@ -409,3 +419,53 @@ class TestShipmentExportCsvColumn18:
         assert row[14] == "千代田区1-1-1"  # 配送元住所2
         assert row[15] == "テストビル101"  # 配送元住所3
         assert row[16] == "テスト配送元"  # 配送元氏名
+
+
+class TestShipmentExportCsvProductDetail:
+    """Issue #79: 4列目「商品種類」を発注リストと同形式に統一.
+
+    形式: {商品種類} - {サイズ} - {位置} - {色}（半角 " - " 区切り、
+    空要素はスキップ）。商品タイプ名は発注リスト（get_product_type_name）に
+    一致させる（特に acrylic_stand -> アクリルフィギュア、not アクリルスタンド）。
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "product_type,size,position,color,expected",
+        [
+            # 全要素あり
+            ("tshirt", "L", "正面", "白", "Tシャツ - L - 正面 - 白"),
+            # 空要素（position 無し）はスキップし余分な区切りを出さない
+            ("sticker", "100x100mm", None, "ホワイト", "ステッカー - 100x100mm - ホワイト"),
+            # acrylic_stand は発注リストと一致する「アクリルフィギュア」
+            ("acrylic_stand", "100mm", None, "クリア", "アクリルフィギュア - 100mm - クリア"),
+            # サイズ/位置/色が全て無い場合は商品タイプ名のみ
+            ("tote_bag", None, None, None, "トートバッグ"),
+        ],
+        ids=["full_tshirt", "skip_empty_position", "acrylic_stand_figure_name", "type_name_only"],
+    )
+    async def test_product_detail_column_format(
+        self,
+        shipment_service,
+        mock_shipment_repo,
+        product_type,
+        size,
+        position,
+        color,
+        expected,
+    ):
+        """4列目「商品種類」が {商品種類} - {サイズ} - {位置} - {色} 形式で出力される."""
+        order_item = create_mock_order_item(
+            product_type=product_type, size=size, position=position, color=color
+        )
+        order = create_mock_order(
+            order_items=[order_item],
+            order_source=create_mock_order_source(),
+        )
+        shipment = create_mock_shipment(shipment_items=[("si-001", order)])
+        mock_shipment_repo.find_by_id.return_value = shipment
+
+        csv_bytes, _ = await shipment_service.export_csv(["shipment-001"])
+
+        _, data_rows = parse_csv_bytes(csv_bytes)
+        assert data_rows[0][3] == expected

--- a/web/src/app/(dashboard)/purchase-orders/all/page.tsx
+++ b/web/src/app/(dashboard)/purchase-orders/all/page.tsx
@@ -31,6 +31,7 @@ import { useAllManufacturerOrderItems } from "@/features/purchase-orders/hooks/u
 import { useManufacturers } from "@/features/manufacturers/hooks/use-manufacturers";
 import { apiClient } from "@/lib/api/client";
 import { getManufacturerOrderStatusUpdateOptions } from "@/constants/status";
+import { formatProductDetailForCsv } from "@/features/purchase-orders/utils/format-product-detail";
 import type { AllManufacturerOrderItem } from "@/types/api";
 
 // デバウンスフック
@@ -49,14 +50,6 @@ function useDebounce<T>(value: T, delay: number): T {
 
   return debouncedValue;
 }
-
-const productTypeLabels: Record<string, string> = {
-  acrylic_keychain: "アクリルキーホルダー",
-  acrylic_stand: "アクリルスタンド",
-  sticker: "ステッカー",
-  tote_bag: "トートバッグ",
-  tshirt: "Tシャツ",
-};
 
 const statusLabels: Record<string, string> = {
   ordered: "発注済み",
@@ -195,7 +188,7 @@ export default function AllPurchaseOrdersPage() {
       item.order_number,
       item.uid || "",
       item.product_name,
-      productTypeLabels[item.product_type] || item.product_type,
+      formatProductDetailForCsv(item),
       statusLabels[item.status] || item.status,
       item.quantity.toString(),
       item.price.toString(),

--- a/web/src/features/purchase-orders/utils/format-product-detail.ts
+++ b/web/src/features/purchase-orders/utils/format-product-detail.ts
@@ -1,0 +1,51 @@
+/**
+ * 発注明細CSV用の「商品種類」列フォーマッタ。
+ *
+ * 発注リスト（バックエンド order_list_generator）と同じ
+ * `{商品種類} - {サイズ} - {位置} - {色}` 形式（半角 " - " 区切り、
+ * 値が無い要素はスキップ）で組み立てる。
+ *
+ * 商品タイプ名はバックエンドの PRODUCT_TYPE_NAMES に一致させる
+ * （特に acrylic_stand -> アクリルフィギュア）。画面表示ラベルとは
+ * 別物なので注意（画面側は「アクリルスタンド」表記を維持する）。
+ */
+
+// バックエンド app/utils/order_list_generator.py の PRODUCT_TYPE_NAMES と一致させる
+export const CSV_PRODUCT_TYPE_LABELS: Record<string, string> = {
+  acrylic_keychain: "アクリルキーホルダー",
+  acrylic_stand: "アクリルフィギュア",
+  sticker: "ステッカー",
+  tote_bag: "トートバッグ",
+  mug: "マグカップ",
+  tshirt: "Tシャツ",
+};
+
+/** 商品タイプコードから発注リスト準拠の日本語名を得る。 */
+export function getCsvProductTypeName(productType: string): string {
+  return CSV_PRODUCT_TYPE_LABELS[productType] ?? productType;
+}
+
+export interface ProductDetailParts {
+  product_type: string;
+  size: string | null;
+  position: string | null;
+  color: string | null;
+}
+
+/**
+ * 「商品種類」列の文字列を組み立てる: {商品種類} - {サイズ} - {位置} - {色}。
+ * size / position / color が null/空 の要素はスキップし、余分な区切りを出さない。
+ *
+ * @example
+ *   formatProductDetailForCsv({ product_type: "tshirt", size: "L", position: "正面", color: "白" })
+ *   // => "Tシャツ - L - 正面 - 白"
+ *   formatProductDetailForCsv({ product_type: "sticker", size: "100x100mm", position: null, color: "ホワイト" })
+ *   // => "ステッカー - 100x100mm - ホワイト"
+ */
+export function formatProductDetailForCsv(item: ProductDetailParts): string {
+  const parts = [getCsvProductTypeName(item.product_type)];
+  if (item.size) parts.push(item.size);
+  if (item.position) parts.push(item.position);
+  if (item.color) parts.push(item.color);
+  return parts.join(" - ");
+}

--- a/web/tests/unit/issue-79-csv-product-detail.test.ts
+++ b/web/tests/unit/issue-79-csv-product-detail.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #79: 発注CSV・配送CSVの「商品種類」表示を発注リストの形式に統一
+ *
+ * 発注明細CSV（発注画面）の「商品タイプ」列を発注リストと同じ
+ * `{商品種類} - {サイズ} - {位置} - {色}` 形式（半角 " - " 区切り、空要素スキップ）に
+ * 統一する。商品タイプ名は発注リストに一致（acrylic_stand -> アクリルフィギュア）。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  formatProductDetailForCsv,
+  getCsvProductTypeName,
+  CSV_PRODUCT_TYPE_LABELS,
+} from "@/features/purchase-orders/utils/format-product-detail";
+
+describe("formatProductDetailForCsv", () => {
+  it("Tシャツ（サイズ/位置/色あり）を 'Tシャツ - L - 正面 - 白' に整形する", () => {
+    expect(
+      formatProductDetailForCsv({
+        product_type: "tshirt",
+        size: "L",
+        position: "正面",
+        color: "白",
+      })
+    ).toBe("Tシャツ - L - 正面 - 白");
+  });
+
+  it("空要素（position 無し）はスキップし余分な区切りを出さない", () => {
+    expect(
+      formatProductDetailForCsv({
+        product_type: "sticker",
+        size: "100x100mm",
+        position: null,
+        color: "ホワイト",
+      })
+    ).toBe("ステッカー - 100x100mm - ホワイト");
+  });
+
+  it("acrylic_stand は発注リストに一致する『アクリルフィギュア』で出力する", () => {
+    const result = formatProductDetailForCsv({
+      product_type: "acrylic_stand",
+      size: "100mm",
+      position: null,
+      color: "クリア",
+    });
+    expect(result).toBe("アクリルフィギュア - 100mm - クリア");
+  });
+
+  it("サイズ/位置/色が全て null の場合は商品タイプ名のみを出力する", () => {
+    expect(
+      formatProductDetailForCsv({
+        product_type: "tote_bag",
+        size: null,
+        position: null,
+        color: null,
+      })
+    ).toBe("トートバッグ");
+  });
+
+  it("空文字列も値なし扱いでスキップする", () => {
+    expect(
+      formatProductDetailForCsv({
+        product_type: "tshirt",
+        size: "",
+        position: "",
+        color: "白",
+      })
+    ).toBe("Tシャツ - 白");
+  });
+
+  it("未知の商品タイプはコードをそのまま先頭に使う", () => {
+    expect(
+      formatProductDetailForCsv({
+        product_type: "unknown_type",
+        size: "S",
+        position: null,
+        color: null,
+      })
+    ).toBe("unknown_type - S");
+  });
+});
+
+describe("getCsvProductTypeName / CSV_PRODUCT_TYPE_LABELS", () => {
+  it("発注リスト（バックエンド PRODUCT_TYPE_NAMES）と同じ対応表を持つ", () => {
+    expect(CSV_PRODUCT_TYPE_LABELS).toEqual({
+      acrylic_keychain: "アクリルキーホルダー",
+      acrylic_stand: "アクリルフィギュア",
+      sticker: "ステッカー",
+      tote_bag: "トートバッグ",
+      mug: "マグカップ",
+      tshirt: "Tシャツ",
+    });
+  });
+
+  it("未知タイプはコードをそのまま返す", () => {
+    expect(getCsvProductTypeName("something_new")).toBe("something_new");
+  });
+});


### PR DESCRIPTION
## 概要

**Intent Spec:** #79

### なぜこの変更が必要か

発注明細CSV（発注画面）と配送CSV（配送画面）の「商品種類」列が「基本の商品タイプ名のみ」（例: `ステッカー`）を出力しており、発注リスト（`order_list_generator`）の `{商品種類} - {サイズ} - {位置} - {色}` 形式（例: `Tシャツ - L - 正面 - 白`）と表記が揃っていなかった。3帳票で表記を統一する。

`AllManufacturerOrderItem`（フロント）／`OrderItem`（バック）ともに `size` / `position` / `color` を保持しているため、追加のデータ取得は不要（表示組み立てのみの変更）。

### 変更内容

- **backend**: 3箇所に重複していた連結ロジックを `order_list_generator.format_product_detail()` ヘルパーに集約し、`order_list_generator`（CSV/XLSX）・`manufacturer_order_service`・`shipment_service` で再利用。
  - `shipment_service._append_order_rows` の4列目「商品種類」を新形式に変更し、未使用化した `_format_product_type` を削除。
  - 商品タイプ名は `get_product_type_name` に統一（`acrylic_stand` → `アクリルフィギュア`）。
- **frontend**: `formatProductDetailForCsv()` ヘルパーを追加し、`purchase-orders/all` の `handleExportCSV` で使用。CSV出力列のみ変更（画面表示ラベルは従来通り「アクリルスタンド」を維持）。
- 連結規則は発注リストに一致：**半角 ` - ` 区切り**、値が無い要素（`size`/`position`/`color` が null/空）は**スキップ**。

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | 変更/新規ファイルは新規エラーなし。既存テストファイルの型エラー26件は本PR対象外・不変 |
| リンター | ✅ | 変更ソースは ruff クリーン（`order_list_generator` の未使用変数 F841 を1件解消）／ eslint クリーン |
| ユニットテスト | ✅ | 追加分は全通過（backend +4 / frontend +8）。既存の未関連failは本PRで件数不変（44/8件） |
| 統合テスト | ➖ | 本PR対象外（E2E未実施） |
| 仕様適合 | ✅ | AC 7/7 カバー |
| AI意味レビュー | ✅ | `/simplify max`（reuse / simplification / efficiency / altitude の4観点）実施・反映 |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| 発注明細CSVが `Tシャツ - L - 正面 - 白` 形式 | `issue-79-csv-product-detail.test.ts` | ✅ |
| 配送CSVが同形式 | `test_shipment_export_csv.py::...[full_tshirt]` | ✅ |
| 空要素スキップ（`ステッカー - 100x100mm - ホワイト`） | 上記両テスト `[skip_empty_position]` / 空要素ケース | ✅ |
| `acrylic_stand` → `アクリルフィギュア -…`（発注リストと完全一致） | 両テスト `[acrylic_stand_figure_name]` + 既存 `test_order_list_generator` | ✅ |
| 区切りは半角 ` - ` | 全フォーマットテスト | ✅ |
| 既存CSVテスト更新＋発注CSV(フロント)テスト追加 | `test_shipment_export_csv.py` 更新 / `issue-79-...` 追加 | ✅ |
| 画面表示ラベルに回帰なし | `feat-0018-all-manufacturer-orders.test.tsx`（22件）通過 | ✅ |

## レビューのポイント

- 連結ロジックを `format_product_detail` に一本化し、既存の重複（`order_list_generator` ×2・`manufacturer_order_service` ×1）を増やさず解消しています（発注リストの出力文字列は不変・既存テストで担保）。
- CSV出力列**のみ**を対象とし、画面表示ラベル・CSVの列構成/列順は変更していません。フロントのCSV用ラベル（`アクリルフィギュア`）は画面表示ラベル（`アクリルスタンド`）と意図的に別物です。
- 既存の失敗テスト（backend 44件 / frontend 8件）は本変更前から存在する未関連のもので、件数は不変です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PY1pwN47az8c4i1ddZW7hr)_