### PR TITLE
Merge Alembic migration heads for notifications and order deadline

### DIFF
--- a/api/alembic/versions/merge_notif_deadline_heads.py
+++ b/api/alembic/versions/merge_notif_deadline_heads.py
@@ -1,0 +1,26 @@
+"""merge mfr_notif_settings and order_deadline_time heads
+
+Revision ID: merge_notif_deadline_heads
+Revises: add_mfr_notif_settings, add_order_deadline_time
+Create Date: 2026-07-17 08:34:20.545256
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'merge_notif_deadline_heads'
+down_revision: Union[str, None] = ('add_mfr_notif_settings', 'add_order_deadline_time')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## 概要

**Intent Spec:** <!-- Issue番号 -->

### なぜこの変更が必要か

複数の並行開発により、Alembic マイグレーションに 2 つの独立したヘッドが生成されました：
- `add_mfr_notif_settings`: 製造委託先通知設定機能
- `add_order_deadline_time`: 受注期限時刻機能

これらのマイグレーションを統合するため、マージコミットを作成します。

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | Alembic スキーマ定義 |
| リンター | ✅ | |
| ユニットテスト | ✅ | マイグレーション検証 |
| 統合テスト | ✅ | |
| 仕様適合 | ✅ | |
| AI意味レビュー | ✅ | |

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| AC-001: マイグレーションヘッドの統合 | Alembic upgrade | ✅ |

## レビューのポイント

- Alembic マージマイグレーションは空の `upgrade()` / `downgrade()` を含みます（両親のマイグレーションが既に適用済みの場合）
- 今後のマイグレーションは単一のヘッドから派生します

https://claude.ai/code/session_01JuGGgp6CDi9oiTzgzFqwE8