### PR TITLE
fix(alembic): マイグレーション多重ヘッドを解消（#89×#82 を単一ヘッド化）

### DIFF
--- a/api/alembic/versions/1cabebecdc5c_merge_mfr_notif_settings_and_order_.py
+++ b/api/alembic/versions/1cabebecdc5c_merge_mfr_notif_settings_and_order_.py
@@ -1,0 +1,26 @@
+"""merge mfr_notif_settings and order_deadline_time heads
+
+Revision ID: 1cabebecdc5c
+Revises: add_mfr_notif_settings, add_order_deadline_time
+Create Date: 2026-07-17 18:45:48.449613
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1cabebecdc5c'
+down_revision: Union[str, None] = ('add_mfr_notif_settings', 'add_order_deadline_time')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## 概要

PR #89（`add_mfr_notif_settings`）と PR #82（`add_order_deadline_time`）が、いずれも同じ親 `add_manufacturing_data` から分岐しており、Alembic のヘッドが **2 つ** になっていました。

```
add_manufacturing_data ─┬─ add_mfr_notif_settings            (head① / #89)
                        └─ unify_status_preparing_order
                              └─ add_order_deadline_time      (head② / #82)
```

本番 API の起動時 `alembic upgrade head` が **"Multiple head revisions are present"** で失敗し、コンテナが crash（本番 502）しました。

本 PR は両ヘッドを親に持つ**空のマージリビジョン** `1cabebecdc5c` を追加して単一ヘッド化し、解消します。

## なぜ必要か

- 本番は `railway up` で復旧済みですが、当マイグレーションは**ローカルのみ**に存在し main には未反映でした。
- このままだと次に別マイグレーションを追加した際に**再び多重ヘッドとなり本番が crash** します。恒久対策として main に取り込みます。

## 変更内容

- `api/alembic/versions/1cabebecdc5c_merge_mfr_notif_settings_and_order_.py`（upgrade/downgrade とも no-op のマージポイント）

## 検証

- 実 PostgreSQL 16 で `alembic upgrade head` が全マイグレーション＋両ブランチ＋マージポイントを通過し、単一ヘッド `1cabebecdc5c (mergepoint)` に到達することを確認。
- 本番反映後、内部エンドポイント疎通を GitHub Actions トリガーで確認（`HTTP 200 / {"ran":false,"reason":"disabled"}` — 認証・ルート・マスタスイッチガードが正常動作）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)