### PR TITLE
feat: 製造データの元画像をシステム上で差し替えられるようにする

### DIFF
--- a/api/alembic/versions/add_source_image_replacement.py
+++ b/api/alembic/versions/add_source_image_replacement.py
@@ -1,0 +1,41 @@
+"""add source image replacement audit columns to manufacturing_data
+
+Revision ID: add_src_img_replacement
+Revises: 1cabebecdc5c
+Create Date: 2026-07-26
+
+製造データの元画像（PNGレイヤー）を管理画面から差し替えられるようにするための追加:
+- source_images_replaced_at: 最後に差し替えた時刻（NULL = 外部受注のまま）
+- source_images_replaced_by: 差し替えた管理ユーザーのメール
+
+`source_images`（JSONB）自体はスキーマ変更なし。差し替え済みレイヤーは
+`url` の代わりに `file_path`（FileStorage 上のキー）を持つ形式で保存する。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_src_img_replacement"
+down_revision: str | None = "1cabebecdc5c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "manufacturing_data",
+        sa.Column("source_images_replaced_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "manufacturing_data",
+        sa.Column("source_images_replaced_by", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("manufacturing_data", "source_images_replaced_by")
+    op.drop_column("manufacturing_data", "source_images_replaced_at")

--- a/api/app/models/manufacturing_data.py
+++ b/api/app/models/manufacturing_data.py
@@ -8,9 +8,10 @@ illustrator-vm（Product Manufacturing API）で生成した製造データ（.a
 純関数であり order_id には依存しないため、この単位でのキャッシュ再利用は妥当。
 """
 
+from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -65,8 +66,16 @@ class ManufacturingData(Base, UUIDPrimaryKeyMixin, TimestampMixin):
         String(20), default=MfgDataStatus.PENDING.value, index=True
     )
 
-    # 使用したレイヤーURL群（[{"layer_type": "color", "url": "..."}, ...]）
+    # 使用したレイヤー群。外部受注由来は {"layer_type": "color", "url": "..."}、
+    # 管理画面から差し替えたものは {"layer_type": "color", "file_path": "...", "filename": "..."}。
     source_images: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
+    # 元画像を管理画面から差し替えた最終時刻（未差し替えは NULL = 外部受注のまま）
+    source_images_replaced_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # 差し替えた管理ユーザー（ユーザー削除後も履歴が残るようメールを保持）
+    source_images_replaced_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # illustrator-vm のジョブID
     vm_job_id: Mapped[str | None] = mapped_column(String(100), nullable=True)

--- a/api/app/routers/manufacturing_data.py
+++ b/api/app/routers/manufacturing_data.py
@@ -1,15 +1,16 @@
 """Manufacturing data router (admin).
 
-製造データの状態一覧・手動リトライを提供する。
+製造データの状態一覧・手動リトライ・再作成、および元画像（PNGレイヤー）の差し替えを提供する。
 """
 
 from typing import Annotated
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Query, Response, UploadFile
 
 from app.dependencies import get_current_admin, get_manufacturing_data_service
 from app.models.user import User
 from app.schemas.manufacturing_data import (
+    ManufacturingDataDetailResponse,
     ManufacturingDataListResponse,
     ManufacturingDataResponse,
 )
@@ -38,6 +39,16 @@ async def list_manufacturing_data(
     )
 
 
+@router.get("/{mfg_data_id}", response_model=ManufacturingDataDetailResponse)
+async def get_manufacturing_data(
+    mfg_data_id: str,
+    service: Annotated[ManufacturingDataService, Depends(get_manufacturing_data_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> ManufacturingDataDetailResponse:
+    """製造データ詳細を取得する（元画像レイヤーの由来つき一覧を含む）."""
+    return await service.get_detail(mfg_data_id)
+
+
 @router.post("/{mfg_data_id}/retry", response_model=ManufacturingDataResponse)
 async def retry_manufacturing_data(
     mfg_data_id: str,
@@ -62,3 +73,51 @@ async def regenerate_manufacturing_data(
     409（ConflictError）で拒否する。生成中の行も進行中ジョブと競合させないため拒否する。
     """
     return await service.regenerate(mfg_data_id, background_tasks)
+
+
+@router.post("/{mfg_data_id}/source-images", response_model=ManufacturingDataDetailResponse)
+async def replace_source_images(
+    mfg_data_id: str,
+    background_tasks: BackgroundTasks,
+    service: Annotated[ManufacturingDataService, Depends(get_manufacturing_data_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+    color: Annotated[UploadFile | None, File()] = None,
+    cutline: Annotated[UploadFile | None, File()] = None,
+    white: Annotated[UploadFile | None, File()] = None,
+    design: Annotated[UploadFile | None, File()] = None,
+) -> ManufacturingDataDetailResponse:
+    """元画像（PNGレイヤー）を差し替えて製造データを再生成する.
+
+    差し替えたいレイヤー種別と同名のファイル項目に PNG を指定する（複数指定可。1リクエスト
+    で差し替えて再生成は1回だけ起動する）。差し替えられるのは行が既に持つレイヤー種別のみ。
+
+    再作成と同じゲートを適用し、生成中／製造中・納入済みの注文と共有されている製造データは
+    409 で拒否する。
+    """
+    uploads = {
+        "color": color,
+        "cutline": cutline,
+        "white": white,
+        "design": design,
+    }
+    return await service.replace_source_images(
+        mfg_data_id,
+        {layer: file for layer, file in uploads.items() if file is not None},
+        replaced_by=current_user.email,
+        background_tasks=background_tasks,
+    )
+
+
+@router.get("/{mfg_data_id}/source-images/{layer_type}")
+async def download_source_image(
+    mfg_data_id: str,
+    layer_type: str,
+    service: Annotated[ManufacturingDataService, Depends(get_manufacturing_data_service)],
+    current_user: Annotated[User, Depends(get_current_admin)],
+) -> Response:
+    """差し替え済み元画像を取得する（プレビュー用）.
+
+    外部受注由来（URL のみ）のレイヤーは pod-admin 側に実体を持たないため 404 を返す。
+    """
+    content = await service.get_source_image(mfg_data_id, layer_type)
+    return Response(content=content, media_type="image/png")

--- a/api/app/schemas/manufacturer.py
+++ b/api/app/schemas/manufacturer.py
@@ -135,8 +135,10 @@ class ManufacturerOrderItemResponse(BaseModel):
     expected_delivery_date: date | None = None  # 納品予定日（未設定の旧データは None）
     # 製造データ状態（v2）: None なら製造データ不要（v1）。ready 以外は発注不可。
     manufacturing_status: str | None = None
-    # 紐づく製造データ ID（v2）。GUI からの再作成に使用。None なら v1。
+    # 紐づく製造データ ID（v2）。GUI からの再作成・元画像差し替えに使用。None なら v1。
     manufacturing_data_id: str | None = None
+    # 元画像を管理画面から差し替えた時刻（None = 外部受注のまま）
+    source_images_replaced_at: datetime | None = None
 
 
 class ManufacturerOrderItemListResponse(BaseModel):

--- a/api/app/schemas/manufacturing_data.py
+++ b/api/app/schemas/manufacturing_data.py
@@ -1,8 +1,23 @@
 """Manufacturing data schemas."""
 
 from datetime import datetime
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from app.utils.mfg_product_mapping import LayerType
+
+
+class SourceImageLayer(BaseModel):
+    """製造データ1レイヤーの元画像（由来つき）."""
+
+    layer_type: LayerType
+    # external: 外部受注が渡した URL / uploaded: 管理画面から差し替えたファイル
+    origin: Literal["external", "uploaded"]
+    # external のときのみ入る取得元URL
+    url: str | None = None
+    # uploaded のときのみ入るアップロード時のファイル名
+    filename: str | None = None
 
 
 class ManufacturingDataResponse(BaseModel):
@@ -22,8 +37,39 @@ class ManufacturingDataResponse(BaseModel):
     file_size: int | None = None
     error_message: str | None = None
     attempts: int
+    # 元画像の差し替え履歴（未差し替えなら None）
+    source_images_replaced_at: datetime | None = None
+    source_images_replaced_by: str | None = None
     created_at: datetime
     updated_at: datetime
+
+
+class ManufacturingDataDetailResponse(ManufacturingDataResponse):
+    """製造データ詳細レスポンス（元画像レイヤー一覧つき）."""
+
+    source_images: list[SourceImageLayer] = []
+
+    @field_validator("source_images", mode="before")
+    @classmethod
+    def _with_origin(cls, value: Any) -> Any:
+        """DB の保存形式（url または file_path）に由来（origin）を付与する.
+
+        レスポンス変換時に再検証されうるため（FastAPI は response_model で dump →
+        validate し直す）、origin 付きの入力はそのまま通す。
+        """
+        if not isinstance(value, list):
+            return value
+        return [
+            {
+                "layer_type": img["layer_type"],
+                "origin": "uploaded" if img.get("file_path") else "external",
+                "url": img.get("url"),
+                "filename": img.get("filename"),
+            }
+            if isinstance(img, dict) and "origin" not in img
+            else img
+            for img in value
+        ]
 
 
 class ManufacturingDataListResponse(BaseModel):

--- a/api/app/schemas/order.py
+++ b/api/app/schemas/order.py
@@ -2,12 +2,12 @@
 
 import datetime as dt
 from datetime import date, datetime
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, computed_field
 
 from app.models.order import OrderStatus
 from app.models.product import ProductType
+from app.utils.mfg_product_mapping import LayerType
 
 
 # Customer info schema
@@ -62,6 +62,8 @@ class MfgDataItemInfo(BaseModel):
     output_filename: str | None = None
     file_size: int | None = None
     error_message: str | None = None
+    # 元画像を管理画面から差し替えた時刻（None = 外部受注のまま）
+    source_images_replaced_at: datetime | None = None
 
 
 class OrderItemResponse(BaseModel):
@@ -120,7 +122,7 @@ class OrderCreate(BaseModel):
 class SourceImage(BaseModel):
     """製造データ生成の元データ（レイヤーPNGのURL）."""
 
-    layer_type: Literal["color", "cutline", "white", "design"]
+    layer_type: LayerType
     url: str = Field(..., min_length=1, max_length=2048)
 
 

--- a/api/app/services/manufacturer_order_service.py
+++ b/api/app/services/manufacturer_order_service.py
@@ -159,6 +159,11 @@ class ManufacturerOrderService:
                         else None
                     ),
                     manufacturing_data_id=order_item.manufacturing_data_id,
+                    source_images_replaced_at=(
+                        order_item.manufacturing_data.source_images_replaced_at
+                        if order_item.manufacturing_data
+                        else None
+                    ),
                 )
             )
             total_quantity += order_item.quantity

--- a/api/app/services/manufacturing_data_service.py
+++ b/api/app/services/manufacturing_data_service.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 
 import httpx
+from fastapi import BackgroundTasks, UploadFile
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,11 +25,12 @@ from app.models.order import OrderItem, OrderItemStatus
 from app.repositories.manufacturing_data_repository import ManufacturingDataRepository
 from app.repositories.order_repository import OrderRepository
 from app.schemas.manufacturing_data import (
+    ManufacturingDataDetailResponse,
     ManufacturingDataListResponse,
     ManufacturingDataResponse,
 )
 from app.services.illustrator_vm_client import IllustratorVmClient, IllustratorVmError
-from app.utils.exceptions import ConflictError, NotFoundError
+from app.utils.exceptions import ConflictError, NotFoundError, ValidationError
 from app.utils.file_storage import FileStorage, build_file_storage
 from app.utils.mfg_product_mapping import MfgMappingError, build_vm_mapping
 from app.utils.url_guard import validate_source_url
@@ -42,16 +45,38 @@ class SourceImageTooLargeError(Exception):
 # 生成済みファイルの保存先プレフィックス（FileStorage 上）
 _STORAGE_PREFIX = "manufacturing_data"
 
+# 差し替えた元データ（PNGレイヤー）の保存先プレフィックス（FileStorage 上）
+_SOURCE_IMAGE_PREFIX = "source_images"
+
 # 元データ（PNGレイヤー）ダウンロードのタイムアウト
 _SOURCE_DOWNLOAD_TIMEOUT = 30.0
 
 # 元データ1レイヤーの既定サイズ上限（settings 未指定時のフォールバック）
 _DEFAULT_SOURCE_MAX_BYTES = 25 * 1024 * 1024  # 25MB
 
+# PNG のシグネチャ。差し替えアップロードが本当に PNG かを中身で確認する
+# （VM は PNG レイヤーしか受け付けないため、拡張子や Content-Type は信用しない）。
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
 
 def _redact_url(url: str) -> str:
     """ログ用にクエリ文字列（署名付きトークン等）を落としたURLを返す."""
     return url.split("?", 1)[0]
+
+
+def _merge_uploaded_layers(
+    current: list[dict[str, str]] | None, intake: list[dict[str, str]] | None
+) -> list[dict[str, str]]:
+    """元データを受注値へ更新する。ただし差し替え済みレイヤーは維持する.
+
+    差し替え済み（file_path つき）レイヤーは管理者が是正した内容なので、外部受注が
+    渡す元の URL では上書きしない。それ以外のレイヤーは最新の受注値を採用する。
+    """
+    uploaded = {img["layer_type"]: img for img in current or [] if img.get("file_path")}
+    refreshed = [uploaded.pop(img["layer_type"], img) for img in intake or []]
+    # 受注値に無くなった差し替え済みレイヤーも失わない
+    return refreshed + list(uploaded.values())
+
 
 # recover_stranded_generations が起動した復旧タスクの強参照を保持する集合。
 # create_task の戻り値を保持しないとタスクが GC で途中消滅しうるため。
@@ -67,7 +92,7 @@ class _BytesUpload:
 
     def __init__(self, content: bytes, filename: str) -> None:
         self._content = content
-        self.filename = filename
+        self.filename: str | None = filename
 
     def read(self) -> bytes:
         return self._content
@@ -141,7 +166,9 @@ class ManufacturingDataService:
         await self._commit()
         return to_generate
 
-    def enqueue_generation(self, background_tasks, md_ids: list[str]) -> None:
+    def enqueue_generation(
+        self, background_tasks: BackgroundTasks, md_ids: list[str]
+    ) -> None:
         """製造データ生成をバックグラウンドで起動する（新規セッションで実行）."""
         for md_id in md_ids:
             background_tasks.add_task(run_generation, md_id)
@@ -172,7 +199,9 @@ class ManufacturingDataService:
             if existing.status == MfgDataStatus.FAILED.value:
                 existing.status = MfgDataStatus.PENDING.value
                 existing.error_message = None
-                existing.source_images = item.source_images
+                existing.source_images = _merge_uploaded_layers(
+                    existing.source_images, item.source_images
+                )
                 await self._md_repo.update(existing)
                 return existing, True
             return existing, False
@@ -320,9 +349,12 @@ class ManufacturingDataService:
     async def _download_source_images(
         self, source_images: list, wanted: set[str]
     ) -> dict[str, bytes]:
-        """必要なレイヤーの PNG を並列ダウンロードする.
+        """必要なレイヤーの PNG を並列取得する.
 
-        個々のレイヤー DL 失敗は fetch 内で握って None を返し、成功したレイヤーだけ集める。
+        差し替え済みレイヤー（file_path つき）は FileStorage から読み、外部受注由来（url）は
+        SSRF ガード付きで HTTP 取得する。
+
+        個々のレイヤー取得失敗は fetch 内で握って None を返し、成功したレイヤーだけ集める。
         必須レイヤー不足の判定は呼び出し側の missing チェックに委ねる。これにより optional
         レイヤー（white 等）の取得失敗で生成全体を落とさない。
         """
@@ -333,7 +365,7 @@ class ManufacturingDataService:
             if self._allowed_source_hosts is not None
             else frozenset(settings.SOURCE_IMAGE_ALLOWED_HOSTS)
         )
-        max_bytes = self._max_source_bytes or settings.SOURCE_IMAGE_MAX_BYTES
+        max_bytes = self._max_bytes()
 
         # redirect 追従は無効（許可外ホストへの 30x リダイレクト経由の SSRF を防ぐ）。
         async with httpx.AsyncClient(
@@ -343,17 +375,21 @@ class ManufacturingDataService:
             async def fetch(img: dict) -> tuple[str, bytes] | None:
                 async with semaphore:
                     try:
-                        # SSRF ガード: 取得前に宛先URLを検証（内部・メタデータ等を遮断）。
-                        validate_source_url(img["url"], allowed_hosts=allowed_hosts)
-                        content = await self._fetch_with_limit(
-                            client, img["url"], max_bytes
-                        )
+                        if img.get("file_path"):
+                            # 差し替え済み: 自前ストレージから読む（外部取得しない）。
+                            content = await self._read_stored_source(img["file_path"])
+                        else:
+                            # SSRF ガード: 取得前に宛先URLを検証（内部・メタデータ等を遮断）。
+                            validate_source_url(img["url"], allowed_hosts=allowed_hosts)
+                            content = await self._fetch_with_limit(
+                                client, img["url"], max_bytes
+                            )
                         return img["layer_type"], content
                     except Exception as exc:  # noqa: BLE001 - 1レイヤーの失敗で全体を止めない（Unsafe/TooLarge含む）
                         logger.warning(
-                            "failed to download source layer %s (%s): %s",
+                            "failed to load source layer %s (%s): %s",
                             img["layer_type"],
-                            _redact_url(img["url"]),
+                            _redact_url(img.get("file_path") or img.get("url", "")),
                             exc,
                         )
                         return None
@@ -379,14 +415,32 @@ class ManufacturingDataService:
                 chunks.append(chunk)
         return b"".join(chunks)
 
+    def _storage(self) -> FileStorage:
+        """FileStorage を解決する（未注入なら settings から構築）."""
+        return self._file_storage or build_file_storage(settings)
+
+    def _max_bytes(self) -> int:
+        """元データ1レイヤーのサイズ上限を解決する（未注入なら settings から）."""
+        return self._max_source_bytes or settings.SOURCE_IMAGE_MAX_BYTES
+
     async def _save_file(self, content: bytes, filename: str) -> str:
         """生成物を FileStorage に保存し、保存先パスを返す."""
-        storage = self._file_storage or build_file_storage(settings)
-        return await storage.save(_BytesUpload(content, filename), prefix=_STORAGE_PREFIX)
+        return await self._storage().save(
+            _BytesUpload(content, filename), prefix=_STORAGE_PREFIX
+        )
+
+    async def _read_stored_source(self, file_path: str) -> bytes:
+        """差し替え済み元データを FileStorage から読む."""
+        content = await self._storage().get(file_path)
+        if content is None:
+            raise FileNotFoundError(f"stored source image not found: {file_path}")
+        return content
 
     # === 管理API（リクエストスコープ） ===
 
-    async def retry(self, md_id: str, background_tasks) -> ManufacturingDataResponse:
+    async def retry(
+        self, md_id: str, background_tasks: BackgroundTasks
+    ) -> ManufacturingDataResponse:
         """失敗した製造データ生成を手動で再駆動する.
 
         retry は failed 行の再実行のみ許可する。製造データ行は
@@ -396,9 +450,7 @@ class ManufacturingDataService:
         だった明細の再ブロックにつながる）。宙吊りになった generating/pending 行は起動時の
         復旧処理（recover_stranded_generations）が再駆動する。
         """
-        md = await self._md_repo.find_by_id(md_id)
-        if md is None:
-            raise NotFoundError("ManufacturingData", md_id)
+        md = await self._require_row(md_id)
         if md.status != MfgDataStatus.FAILED.value:
             raise ConflictError(
                 f"manufacturing data {md_id} is not in a failed state "
@@ -413,46 +465,191 @@ class ManufacturingDataService:
         background_tasks.add_task(run_generation, md_id)
         return ManufacturingDataResponse.model_validate(md)
 
-    async def regenerate(self, md_id: str, background_tasks) -> ManufacturingDataResponse:
+    async def regenerate(
+        self, md_id: str, background_tasks: BackgroundTasks
+    ) -> ManufacturingDataResponse:
         """製造データを手動で再作成（同じ元データで再生成）する（管理者操作）.
 
-        メーカーが製造着手前（参照する明細が全て 発注準備中 / 発注済み）のときのみ許可する。
-        製造データ行は（受注元 × 商品コード × サイズ × バリアント）単位で複数注文に共有される
-        ため、1件でも「製造中」/「納入済み」の注文が参照している場合は、その注文の完成データを
-        壊さないよう再作成を拒否する（ConflictError → 409）。生成中の行も進行中ジョブと競合させ
-        ないため拒否する（ready / failed から実行）。
-
-        許可時は同じ source_images で再生成する: md を pending に戻し、参照する「発注済み」明細を
-        「発注準備中」へ戻したうえでバックグラウンド生成を起動する。生成完了時に generate() が
-        再び「発注済み」へ昇格させる。
+        メーカーが製造着手前（参照する明細が全て 発注準備中 / 発注済み）のときのみ許可する
+        （_assert_rebuildable 参照）。元データは差し替えず、同じ source_images で作り直す。
         """
+        md = await self._require_row(md_id)
+        await self._assert_rebuildable(md)
+        await self._restart_generation(md, background_tasks)
+        return ManufacturingDataResponse.model_validate(md)
+
+    async def get_detail(self, md_id: str) -> ManufacturingDataDetailResponse:
+        """製造データ詳細（元画像レイヤー一覧つき）を取得する."""
+        md = await self._require_row(md_id)
+        return ManufacturingDataDetailResponse.model_validate(md)
+
+    async def replace_source_images(
+        self,
+        md_id: str,
+        uploads: dict[str, UploadFile],
+        *,
+        replaced_by: str | None,
+        background_tasks: BackgroundTasks,
+    ) -> ManufacturingDataDetailResponse:
+        """元画像（PNGレイヤー）を差し替えて製造データを再生成する（管理者操作）.
+
+        Args:
+            uploads: レイヤー種別 -> アップロードされた PNG。
+
+        差し替え可否は regenerate と同じゲート（生成中でない・製造着手済みの注文と共有して
+        いない）で判定する。差し替えは行が既に持つレイヤー種別の置き換えのみ許可する:
+        レイヤー構成が変わるとバリアント（= キャッシュキー）の導出結果まで変わるため。
+
+        アップロードは FileStorage に保存し、source_images の該当レイヤーを file_path 形式へ
+        置き換える。以降の生成は外部 URL ではなく保存したファイルを読む。
+        """
+        md = await self._require_row(md_id)
+        await self._assert_rebuildable(md)
+
+        stored = md.source_images or []
+        if not stored:
+            raise ConflictError(
+                f"manufacturing data {md_id} has no source images to replace"
+            )
+        self._validate_replacement_layers(uploads, stored)
+
+        # 全ファイルを検証してから保存する（一部だけ差し替わった中途半端な状態を作らない）。
+        validated = [
+            (layer_type, file.filename or f"{layer_type}.png",
+             await self._read_png_upload(layer_type, file))
+            for layer_type, file in uploads.items()
+        ]
+        # 保存は並列（GCS の往復を直列に積み上げない）。
+        paths = await asyncio.gather(
+            *(
+                self._storage().save(
+                    _BytesUpload(content, filename), prefix=_SOURCE_IMAGE_PREFIX
+                )
+                for _, filename, content in validated
+            )
+        )
+        replacements = {
+            layer_type: {
+                "layer_type": layer_type,
+                "file_path": path,
+                "filename": filename,
+            }
+            for (layer_type, filename, _), path in zip(validated, paths, strict=True)
+        }
+
+        # JSONB は再代入しないと変更が検知されないため、新しいリストを作って差し替える。
+        md.source_images = [replacements.get(img["layer_type"], img) for img in stored]
+        md.source_images_replaced_at = datetime.now(UTC)
+        md.source_images_replaced_by = replaced_by
+
+        await self._restart_generation(md, background_tasks)
+        logger.info(
+            "source images replaced for manufacturing data %s (layers=%s, by=%s)",
+            md_id,
+            sorted(replacements),
+            replaced_by,
+        )
+        return ManufacturingDataDetailResponse.model_validate(md)
+
+    async def get_source_image(self, md_id: str, layer_type: str) -> bytes:
+        """差し替え済み元画像の内容を返す（プレビュー用）.
+
+        外部受注由来（URL のみ）のレイヤーは pod-admin 側に実体を持たないため 404 とする
+        （フロントは URL へのリンクを表示する）。
+        """
+        md = await self._require_row(md_id)
+        stored = next(
+            (
+                img
+                for img in md.source_images or []
+                if img["layer_type"] == layer_type and img.get("file_path")
+            ),
+            None,
+        )
+        content = await self._storage().get(stored["file_path"]) if stored else None
+        if content is None:
+            raise NotFoundError("SourceImage", f"{md_id}/{layer_type}")
+        return content
+
+    async def _require_row(self, md_id: str) -> ManufacturingData:
+        """製造データ行を取得する（無ければ 404）."""
         md = await self._md_repo.find_by_id(md_id)
         if md is None:
             raise NotFoundError("ManufacturingData", md_id)
+        return md
 
-        # 生成中は再作成不可（進行中の VM ジョブと競合させない）。
+    async def _assert_rebuildable(self, md: ManufacturingData) -> None:
+        """製造データを作り直せる状態か検証する（regenerate / 元画像差し替えで共通）.
+
+        生成中は進行中の VM ジョブと競合させないため拒否する。製造データ行は複数注文で
+        共有されるため、1件でも「製造中」/「納入済み」の注文が参照している場合は、その注文の
+        完成データを壊さないよう拒否する。
+        """
         if md.status == MfgDataStatus.GENERATING.value:
             raise ConflictError(
-                f"manufacturing data {md_id} is currently generating; "
+                f"manufacturing data {md.id} is currently generating; "
                 "regeneration is not allowed while a job is in progress"
             )
-
-        # 共有ゲート: 参照明細に「製造中」/「納入済み」が1件でもあれば再作成不可。
-        if await self._order_repo.has_manufacturing_or_delivered_items(md_id):
+        if await self._order_repo.has_manufacturing_or_delivered_items(md.id):
             raise ConflictError(
-                f"manufacturing data {md_id} is shared with an order already in "
+                f"manufacturing data {md.id} is shared with an order already in "
                 "manufacturing/delivered; regeneration is blocked to protect it"
             )
 
-        # 同じ元データで再生成する。参照する「発注済み」明細は「発注準備中」へ戻す（demote）。
+    async def _restart_generation(
+        self, md: ManufacturingData, background_tasks: BackgroundTasks
+    ) -> None:
+        """行を pending に戻し、参照明細を降格させてバックグラウンド生成を起動する.
+
+        呼び出し側が md に加えた変更（元画像の差し替え等）もここでまとめて永続化する。
+
+        参照する「発注済み」明細は「発注準備中」へ戻す（demote）ことで、未完成の製造データで
+        メーカー発注されるのを防ぐ。生成完了時に generate() が再び「発注済み」へ昇格させる。
+        """
         md.status = MfgDataStatus.PENDING.value
         md.error_message = None
         await self._md_repo.update(md)
-        await self._order_repo.sync_item_status_for_manufacturing_data(md_id, ready=False)
+        await self._order_repo.sync_item_status_for_manufacturing_data(md.id, ready=False)
         await self._commit()
+        background_tasks.add_task(run_generation, md.id)
 
-        background_tasks.add_task(run_generation, md_id)
-        return ManufacturingDataResponse.model_validate(md)
+    @staticmethod
+    def _validate_replacement_layers(
+        uploads: dict[str, UploadFile], stored: list[dict[str, str]]
+    ) -> None:
+        """差し替え対象のレイヤーがこの行に存在するかを検証する.
+
+        レイヤー種別の語彙・重複はエンドポイントのシグネチャ（レイヤーごとの名前付き
+        ファイル項目）が保証するため、ここでは行との突き合わせだけを行う。
+        """
+        if not uploads:
+            raise ValidationError("差し替える元画像を1件以上指定してください")
+
+        stored_layers = {img["layer_type"] for img in stored}
+        # レイヤーの追加・削除はキャッシュキー（導出バリアント）を変えるため許可しない。
+        unknown = sorted(set(uploads) - stored_layers)
+        if unknown:
+            raise ValidationError(
+                f"この製造データに存在しないレイヤー種別です: {unknown} "
+                f"(現在のレイヤー: {sorted(stored_layers)})"
+            )
+
+    async def _read_png_upload(self, layer_type: str, file: UploadFile) -> bytes:
+        """アップロードを読み、サイズ上限と PNG 形式（マジックバイト）を検証する."""
+        max_bytes = self._max_bytes()
+        too_large = (
+            f"元画像のサイズが上限（{max_bytes} bytes）を超えています: {layer_type}"
+        )
+        # multipart を読み終えた時点で size は確定しているため、本文を読む前に弾ける。
+        if file.size is not None and file.size > max_bytes:
+            raise ValidationError(too_large)
+
+        content = await file.read()
+        if len(content) > max_bytes:
+            raise ValidationError(too_large)
+        if not content.startswith(_PNG_SIGNATURE):
+            raise ValidationError(f"元画像は PNG 形式のみ対応しています: {layer_type}")
+        return content
 
     async def list(
         self,

--- a/api/app/utils/mfg_product_mapping.py
+++ b/api/app/utils/mfg_product_mapping.py
@@ -19,12 +19,16 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from typing import Literal
 
 # レイヤー種別
 LAYER_COLOR = "color"
 LAYER_CUTLINE = "cutline"
 LAYER_WHITE = "white"
 LAYER_DESIGN = "design"
+
+# source_images で扱うレイヤー種別（受注スキーマ・製造データスキーマ共通の語彙）
+LayerType = Literal["color", "cutline", "white", "design"]
 
 # 入力モード
 INPUT_MODE_SINGLE = "single"

--- a/api/tests/integration/test_manufacturing_source_image_replacement.py
+++ b/api/tests/integration/test_manufacturing_source_image_replacement.py
@@ -1,0 +1,292 @@
+"""Integration tests for 元画像差し替え API（製造データの元画像アップロード）.
+
+v2 受注で作られた製造データ行に対し、管理画面からの元画像差し替えが
+API -> Service -> FileStorage/DB まで一貫して機能することを検証する。
+
+illustrator-vm は未設定（テスト環境）のため、差し替え後のバックグラウンド生成は最終的に
+failed になる。本テストは同期的に確定する状態（source_images の置き換え・保存・明細の降格・
+拒否条件）のみを検証する。
+"""
+
+import json
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"replaced-color-layer"
+
+
+def _order_number() -> str:
+    """テスト用のユニークな受注番号（7桁数字）."""
+    return f"{uuid4().int % 10**7:07d}"
+
+
+@pytest.fixture
+async def keychain_setup(db_session: AsyncSession):
+    """acrylic_keychain のメーカー・商品マスタ・API キー付き受注元を用意する."""
+    manufacturer_id = str(uuid4())
+    await db_session.execute(
+        text("""
+            INSERT INTO manufacturers (
+                id, name, email, supported_products, unit_prices, lead_time_days,
+                daily_order_limit, sharing_method, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :name, :email, :supported_products, :unit_prices, 5,
+                100, 'portal', true, NOW(), NOW()
+            )
+        """),
+        {
+            "id": manufacturer_id,
+            "name": f"SRCIMG_{manufacturer_id[:8]}",
+            "email": f"srcimg-{manufacturer_id[:8]}@example.com",
+            "supported_products": ["acrylic_keychain"],
+            "unit_prices": json.dumps({"acrylic_keychain": 300}),
+            "lead_time_days": 5,
+        },
+    )
+
+    product_id = str(uuid4())
+    await db_session.execute(
+        text("""
+            INSERT INTO products (
+                id, product_type, size, position, color, manufacturer_id, cost,
+                lead_time_days, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, 'acrylic_keychain', :size, NULL, NULL, :manufacturer_id, 300,
+                5, true, NOW(), NOW()
+            )
+        """),
+        {"id": product_id, "size": f"KC-{product_id[:8]}", "manufacturer_id": manufacturer_id},
+    )
+
+    source_id = str(uuid4())
+    api_key = f"srcimg-api-key-{source_id}"
+    await db_session.execute(
+        text("""
+            INSERT INTO order_sources (
+                id, code, name, api_key, phone, postal_code,
+                address_prefecture, address_city, is_active, created_at, updated_at
+            )
+            VALUES (
+                :id, :code, 'SRCIMG Source', :api_key, '090-1234-5678', '100-0001',
+                '東京都', '千代田区', true, NOW(), NOW()
+            )
+        """),
+        {"id": source_id, "code": f"SRC{source_id[:8].upper()}", "api_key": api_key},
+    )
+    await db_session.commit()
+    yield {"order_source_id": source_id, "api_key": api_key}
+
+
+async def _create_v2_order(
+    client: AsyncClient, db_session: AsyncSession, api_key: str, order_number: str
+) -> dict:
+    """v2 受注を1件作成し、注文IDと紐付いた製造データIDを返す.
+
+    製造データの紐付けは受注レスポンス生成後（prepare_for_order）に確定するため、
+    id は DB から引く。
+    """
+    payload = {
+        "order_number": order_number,
+        "customer": {
+            "name": "山田太郎",
+            "postal_code": "123-4567",
+            "address_prefecture": "東京都",
+            "address_city": "渋谷区1-2-3",
+            "phone": "03-1234-5678",
+            "email": "yamada@example.com",
+        },
+        "items": [
+            {
+                "uid": "2000001",
+                "product_type": "acrylic_keychain",
+                "product_name": "アクリルキーホルダー デザインA",
+                "price": 1200,
+                "quantity": 1,
+                "size": "50x50mm",
+                "color": "アクリル",
+                "product_code": f"RKSYO-{uuid4().hex[:6]}",
+                "source_images": [
+                    {"layer_type": "color", "url": "https://example.com/color.png"},
+                    {"layer_type": "cutline", "url": "https://example.com/cutline.png"},
+                ],
+            }
+        ],
+    }
+    resp = await client.post(
+        "/api/v2/orders", json=payload, headers={"X-API-Key": api_key}
+    )
+    assert resp.status_code == 201, resp.text
+    order_id = resp.json()["id"]
+    mfg_id = (
+        await db_session.execute(
+            text("SELECT manufacturing_data_id FROM order_items WHERE order_id = :oid"),
+            {"oid": order_id},
+        )
+    ).scalar_one()
+    assert mfg_id is not None
+    return {"order_id": order_id, "mfg_id": str(mfg_id)}
+
+
+class TestReplaceSourceImagesAPI:
+    @pytest.mark.asyncio
+    async def test_detail_reports_external_layers_before_replacement(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        keychain_setup: dict,
+        auth_headers: dict,
+    ):
+        created = await _create_v2_order(client, db_session, keychain_setup["api_key"], _order_number())
+
+        resp = await client.get(
+            f"/api/v1/manufacturing-data/{created['mfg_id']}", headers=auth_headers
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["source_images_replaced_at"] is None
+        assert {(ly["layer_type"], ly["origin"]) for ly in body["source_images"]} == {
+            ("color", "external"),
+            ("cutline", "external"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_replace_stores_upload_and_restarts_generation(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        keychain_setup: dict,
+        auth_headers: dict,
+    ):
+        created = await _create_v2_order(client, db_session, keychain_setup["api_key"], _order_number())
+        mfg_id = created["mfg_id"]
+
+        resp = await client.post(
+            f"/api/v1/manufacturing-data/{mfg_id}/source-images",
+            headers=auth_headers,
+            files={"color": ("fixed_color.png", PNG, "image/png")},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "pending"  # 再生成待ちへ戻る
+        assert body["source_images_replaced_at"] is not None
+        assert body["source_images_replaced_by"] == "test-admin@example.com"
+        layers = {ly["layer_type"]: ly for ly in body["source_images"]}
+        assert layers["color"]["origin"] == "uploaded"
+        assert layers["color"]["filename"] == "fixed_color.png"
+        assert layers["cutline"]["origin"] == "external"  # 未指定レイヤーは元のURLのまま
+
+        # DB の source_images が file_path 形式へ置き換わっている
+        stored = (
+            await db_session.execute(
+                text("SELECT source_images FROM manufacturing_data WHERE id = :id"),
+                {"id": mfg_id},
+            )
+        ).scalar_one()
+        by_layer = {img["layer_type"]: img for img in stored}
+        assert by_layer["color"]["file_path"].startswith("source_images/")
+        assert by_layer["cutline"]["url"] == "https://example.com/cutline.png"
+
+        # 保存済み元画像を取得できる（プレビュー用）
+        preview = await client.get(
+            f"/api/v1/manufacturing-data/{mfg_id}/source-images/color", headers=auth_headers
+        )
+        assert preview.status_code == 200
+        assert preview.content == PNG
+
+        # 外部URLのみのレイヤーは実体を持たないため 404
+        missing = await client.get(
+            f"/api/v1/manufacturing-data/{mfg_id}/source-images/cutline", headers=auth_headers
+        )
+        assert missing.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_replace_demotes_referencing_items(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        keychain_setup: dict,
+        auth_headers: dict,
+    ):
+        created = await _create_v2_order(client, db_session, keychain_setup["api_key"], _order_number())
+        # 生成完了済み（発注可能）の状態を作る
+        await db_session.execute(
+            text(
+                "UPDATE manufacturing_data SET status = 'ready', file_path = 'x.ai' "
+                "WHERE id = :id"
+            ),
+            {"id": created["mfg_id"]},
+        )
+        await db_session.execute(
+            text("UPDATE order_items SET status = 'ordered' WHERE order_id = :oid"),
+            {"oid": created["order_id"]},
+        )
+        await db_session.commit()
+
+        resp = await client.post(
+            f"/api/v1/manufacturing-data/{created['mfg_id']}/source-images",
+            headers=auth_headers,
+            files={"color": ("fixed_color.png", PNG, "image/png")},
+        )
+        assert resp.status_code == 200, resp.text
+
+        # 未完成の製造データで発注されないよう、明細は「発注準備中」へ戻る
+        statuses = (
+            await db_session.execute(
+                text("SELECT status FROM order_items WHERE order_id = :oid"),
+                {"oid": created["order_id"]},
+            )
+        ).scalars().all()
+        assert set(statuses) == {"preparing_order"}
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_shared_order_is_in_manufacturing(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        keychain_setup: dict,
+        auth_headers: dict,
+    ):
+        created = await _create_v2_order(client, db_session, keychain_setup["api_key"], _order_number())
+        await db_session.execute(
+            text("UPDATE order_items SET status = 'manufacturing' WHERE order_id = :oid"),
+            {"oid": created["order_id"]},
+        )
+        await db_session.commit()
+
+        resp = await client.post(
+            f"/api/v1/manufacturing-data/{created['mfg_id']}/source-images",
+            headers=auth_headers,
+            files={"color": ("fixed_color.png", PNG, "image/png")},
+        )
+        assert resp.status_code == 409, resp.text
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_png_upload(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        keychain_setup: dict,
+        auth_headers: dict,
+    ):
+        created = await _create_v2_order(client, db_session, keychain_setup["api_key"], _order_number())
+
+        resp = await client.post(
+            f"/api/v1/manufacturing-data/{created['mfg_id']}/source-images",
+            headers=auth_headers,
+            files={"color": ("fake.png", b"GIF89a-not-a-png", "image/png")},
+        )
+        assert resp.status_code == 400, resp.text
+
+    @pytest.mark.asyncio
+    async def test_requires_authentication(self, client: AsyncClient):
+        resp = await client.post(
+            f"/api/v1/manufacturing-data/{uuid4()}/source-images",
+            files={"color": ("fixed_color.png", PNG, "image/png")},
+        )
+        assert resp.status_code == 401, resp.text

--- a/api/tests/unit/test_source_image_replacement.py
+++ b/api/tests/unit/test_source_image_replacement.py
@@ -1,0 +1,458 @@
+"""Unit tests for manufacturing source image replacement (元画像の差し替え)."""
+
+import io
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import UploadFile
+
+from app.models.manufacturing_data import ManufacturingData, MfgDataStatus
+from app.services import manufacturing_data_service as mds
+from app.services.manufacturing_data_service import ManufacturingDataService
+from app.utils.exceptions import ConflictError, NotFoundError, ValidationError
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"payload"
+
+
+def _upload(filename: str = "new_color.png", content: bytes = PNG) -> UploadFile:
+    """multipart アップロードの代用（Starlette の UploadFile をそのまま使う）."""
+    return UploadFile(file=io.BytesIO(content), filename=filename)
+
+
+def _md(
+    *,
+    status: str = MfgDataStatus.READY.value,
+    source_images: list | None = None,
+) -> ManufacturingData:
+    md = ManufacturingData(product_code="RKSYO-1", product_type="acrylic_keychain")
+    md.id = "md-1"
+    md.status = status
+    md.attempts = 1
+    md.size = "50x50mm"
+    md.variant = "clear"
+    md.source_images = (
+        source_images
+        if source_images is not None
+        else [
+            {"layer_type": "color", "url": "https://x/color.png"},
+            {"layer_type": "cutline", "url": "https://x/cutline.png"},
+        ]
+    )
+    md.created_at = datetime.now(UTC)
+    md.updated_at = datetime.now(UTC)
+    return md
+
+
+def _service(md: ManufacturingData | None, *, storage=None, order_repo=None, **kwargs):
+    md_repo = AsyncMock()
+    md_repo.find_by_id.return_value = md
+    md_repo.find_by_cache_key.return_value = md
+    if order_repo is None:
+        order_repo = AsyncMock()
+        order_repo.has_manufacturing_or_delivered_items.return_value = False
+    svc = ManufacturingDataService(
+        md_repo=md_repo,
+        order_repo=order_repo,
+        session=None,  # unit test: _commit は no-op
+        file_storage=storage or _storage(),
+        **kwargs,
+    )
+    return svc
+
+
+def _storage(save_path: str = "source_images/20260726_abcd1234.png"):
+    storage = MagicMock()
+    storage.save = AsyncMock(return_value=save_path)
+    storage.get = AsyncMock(return_value=PNG)
+    return storage
+
+
+class TestReplaceSourceImages:
+    @pytest.mark.asyncio
+    async def test_replaces_layer_and_restarts_generation(self):
+        md = _md()
+        storage = _storage()
+        svc = _service(md, storage=storage)
+        bg = MagicMock()
+
+        resp = await svc.replace_source_images(
+            "md-1",
+            {"color": _upload()},
+            replaced_by="admin@example.com",
+            background_tasks=bg,
+        )
+
+        # 指定レイヤーだけが file_path 形式に置き換わり、他は元の URL を保つ
+        assert md.source_images == [
+            {
+                "layer_type": "color",
+                "file_path": "source_images/20260726_abcd1234.png",
+                "filename": "new_color.png",
+            },
+            {"layer_type": "cutline", "url": "https://x/cutline.png"},
+        ]
+        assert storage.save.await_args.kwargs["prefix"] == "source_images"
+        # 差し替え履歴を記録
+        assert md.source_images_replaced_at is not None
+        assert md.source_images_replaced_by == "admin@example.com"
+        # 再生成の波及（pending へ戻す・発注済み明細を降格・バックグラウンド起動）
+        assert md.status == MfgDataStatus.PENDING.value
+        svc._order_repo.sync_item_status_for_manufacturing_data.assert_awaited_once_with(
+            "md-1", ready=False
+        )
+        bg.add_task.assert_called_once()
+        # レスポンスは由来つきのレイヤー一覧を返す
+        assert [(ly.layer_type, ly.origin) for ly in resp.source_images] == [
+            ("color", "uploaded"),
+            ("cutline", "external"),
+        ]
+        assert resp.source_images[0].filename == "new_color.png"
+        assert resp.source_images[1].url == "https://x/cutline.png"
+
+    @pytest.mark.asyncio
+    async def test_replaces_multiple_layers_with_single_generation(self):
+        md = _md()
+        svc = _service(md)
+        bg = MagicMock()
+
+        await svc.replace_source_images(
+            "md-1",
+            {"color": _upload("c.png"), "cutline": _upload("k.png")},
+            replaced_by="admin@example.com",
+            background_tasks=bg,
+        )
+
+        assert [img["filename"] for img in md.source_images] == ["c.png", "k.png"]
+        bg.add_task.assert_called_once()  # 再生成は1回だけ
+
+    @pytest.mark.asyncio
+    async def test_missing_row_raises_not_found(self):
+        with pytest.raises(NotFoundError):
+            await _service(None).replace_source_images(
+                "missing",
+                {"color": _upload()},
+                replaced_by=None,
+                background_tasks=MagicMock(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_while_generating(self):
+        md = _md(status=MfgDataStatus.GENERATING.value)
+        svc = _service(md)
+        bg = MagicMock()
+
+        with pytest.raises(ConflictError):
+            await svc.replace_source_images(
+                "md-1", {"color": _upload()}, replaced_by=None, background_tasks=bg
+            )
+
+        assert md.source_images_replaced_at is None
+        bg.add_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_shared_with_manufacturing_order(self):
+        md = _md()
+        order_repo = AsyncMock()
+        order_repo.has_manufacturing_or_delivered_items.return_value = True
+        svc = _service(md, order_repo=order_repo)
+        bg = MagicMock()
+
+        with pytest.raises(ConflictError):
+            await svc.replace_source_images(
+                "md-1", {"color": _upload()}, replaced_by=None, background_tasks=bg
+            )
+
+        assert md.status == MfgDataStatus.READY.value  # 状態は変えない
+        bg.add_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_row_without_source_images(self):
+        # マッピング不能で作られた failed 行など、元データを持たない行は差し替え対象外。
+        md = _md(status=MfgDataStatus.FAILED.value, source_images=[])
+        with pytest.raises(ConflictError):
+            await _service(md).replace_source_images(
+                "md-1",
+                {"color": _upload()},
+                replaced_by=None,
+                background_tasks=MagicMock(),
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "uploads",
+        [
+            pytest.param({}, id="no-layer-specified"),
+            # 行に存在しないレイヤー（レイヤー構成の変更は不可）
+            pytest.param({"white": _upload()}, id="layer-not-on-row"),
+        ],
+    )
+    async def test_rejects_invalid_layer_specification(self, uploads):
+        md = _md()
+        storage = _storage()
+        svc = _service(md, storage=storage)
+
+        with pytest.raises(ValidationError):
+            await svc.replace_source_images(
+                "md-1",
+                uploads,
+                replaced_by=None,
+                background_tasks=MagicMock(),
+            )
+
+        storage.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_png_upload(self):
+        md = _md()
+        storage = _storage()
+        svc = _service(md, storage=storage)
+
+        with pytest.raises(ValidationError, match="PNG"):
+            await svc.replace_source_images(
+                "md-1",
+                {"color": _upload("fake.png", b"GIF89a-not-a-png")},
+                replaced_by=None,
+                background_tasks=MagicMock(),
+            )
+
+        storage.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_upload_over_size_limit(self):
+        md = _md()
+        storage = _storage()
+        svc = _service(md, storage=storage, max_source_bytes=4)
+
+        with pytest.raises(ValidationError):
+            await svc.replace_source_images(
+                "md-1",
+                {"color": _upload()},
+                replaced_by=None,
+                background_tasks=MagicMock(),
+            )
+
+        storage.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_saves_nothing(self):
+        # 2件目が不正なら1件目も保存しない（中途半端な差し替えを作らない）。
+        md = _md()
+        storage = _storage()
+        svc = _service(md, storage=storage)
+
+        with pytest.raises(ValidationError):
+            await svc.replace_source_images(
+                "md-1",
+                {"color": _upload(), "cutline": _upload("bad.png", b"not-png")},
+                replaced_by=None,
+                background_tasks=MagicMock(),
+            )
+
+        storage.save.assert_not_called()
+        assert md.source_images[0] == {"layer_type": "color", "url": "https://x/color.png"}
+
+
+class TestSourceImageAccess:
+    @pytest.mark.asyncio
+    async def test_get_detail_reports_layer_origin(self):
+        md = _md(
+            source_images=[
+                {"layer_type": "color", "file_path": "source_images/a.png", "filename": "a.png"},
+                {"layer_type": "cutline", "url": "https://x/cutline.png"},
+            ]
+        )
+        detail = await _service(md).get_detail("md-1")
+        assert [(ly.layer_type, ly.origin) for ly in detail.source_images] == [
+            ("color", "uploaded"),
+            ("cutline", "external"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_source_image_returns_uploaded_file(self):
+        md = _md(
+            source_images=[
+                {"layer_type": "color", "file_path": "source_images/a.png", "filename": "a.png"}
+            ]
+        )
+        storage = _storage()
+        content = await _service(md, storage=storage).get_source_image("md-1", "color")
+        assert content == PNG
+        storage.get.assert_awaited_once_with("source_images/a.png")
+
+    @pytest.mark.asyncio
+    async def test_get_source_image_404_for_external_layer(self):
+        # 外部受注由来（URL のみ）は pod-admin 側に実体がないため 404。
+        md = _md()
+        with pytest.raises(NotFoundError):
+            await _service(md).get_source_image("md-1", "color")
+
+    @pytest.mark.asyncio
+    async def test_get_source_image_404_when_file_missing(self):
+        md = _md(
+            source_images=[{"layer_type": "color", "file_path": "source_images/gone.png"}]
+        )
+        storage = _storage()
+        storage.get = AsyncMock(return_value=None)
+        with pytest.raises(NotFoundError):
+            await _service(md, storage=storage).get_source_image("md-1", "color")
+
+
+class TestGenerationUsesReplacedSource:
+    @pytest.mark.asyncio
+    async def test_download_reads_stored_file_instead_of_url(self):
+        source_images = [
+            {"layer_type": "color", "file_path": "source_images/a.png", "filename": "a.png"},
+            {"layer_type": "cutline", "url": "https://x/cutline.png"},
+        ]
+        storage = _storage()
+        svc = _service(_md(), storage=storage, allowed_source_hosts=frozenset({"x"}))
+        svc._fetch_with_limit = AsyncMock(return_value=b"CUTLINE")
+
+        images = await svc._download_source_images(source_images, {"color", "cutline"})
+
+        assert images == {"color": PNG, "cutline": b"CUTLINE"}
+        # 差し替え済みレイヤーは HTTP 取得しない
+        assert svc._fetch_with_limit.await_count == 1
+        storage.get.assert_awaited_once_with("source_images/a.png")
+
+    @pytest.mark.asyncio
+    async def test_missing_stored_file_skips_layer_only(self):
+        # 保存済みファイルが失われても、他レイヤーの取得は継続する（必須不足は呼び出し側が判定）。
+        source_images = [
+            {"layer_type": "color", "file_path": "source_images/gone.png"},
+            {"layer_type": "cutline", "url": "https://x/cutline.png"},
+        ]
+        storage = _storage()
+        storage.get = AsyncMock(return_value=None)
+        svc = _service(_md(), storage=storage, allowed_source_hosts=frozenset({"x"}))
+        svc._fetch_with_limit = AsyncMock(return_value=b"CUTLINE")
+
+        images = await svc._download_source_images(source_images, {"color", "cutline"})
+
+        assert images == {"cutline": b"CUTLINE"}
+
+    @pytest.mark.asyncio
+    async def test_generate_sends_replaced_layer_to_vm(self):
+        md = _md(
+            status=MfgDataStatus.PENDING.value,
+            source_images=[
+                {"layer_type": "color", "file_path": "source_images/a.png", "filename": "a.png"},
+                {"layer_type": "cutline", "file_path": "source_images/b.png", "filename": "b.png"},
+            ],
+        )
+        storage = _storage()
+        storage.get = AsyncMock(side_effect=[b"COLOR", b"CUTLINE"])
+        storage.save = AsyncMock(return_value="manufacturing_data/out.ai")
+
+        vm_client = MagicMock()
+        vm_client.submit = AsyncMock(return_value="job-1")
+        vm_client.wait_until_complete = AsyncMock(
+            return_value=SimpleNamespace(output_filename="out.ai")
+        )
+        vm_client.download = AsyncMock(return_value=b"AI-BYTES")
+
+        svc = _service(md, storage=storage, vm_client=vm_client)
+        await svc.generate("md-1")
+
+        assert md.status == MfgDataStatus.READY.value
+        assert vm_client.submit.await_args.kwargs["images"] == {
+            "color": b"COLOR",
+            "cutline": b"CUTLINE",
+        }
+
+
+class TestIntakeKeepsReplacedSource:
+    """再受注で元データを更新するとき、差し替え済みレイヤーを維持することのテスト."""
+
+    def _intake_item(self, color_url: str = "https://x/new-color.png"):
+        return SimpleNamespace(
+            id="item-1",
+            product_code="RKSYO-1",
+            product_type="acrylic_keychain",
+            size="50x50mm",
+            source_images=[
+                {"layer_type": "color", "url": color_url},
+                {"layer_type": "cutline", "url": "https://x/cutline.png"},
+            ],
+            manufacturing_data_id=None,
+            manufacturing_data=None,
+            status=None,
+        )
+
+    async def _reintake(self, existing, item):
+        order_repo = AsyncMock()
+        order_repo.find_by_id.return_value = SimpleNamespace(
+            order_source_id="src-1", items=[item]
+        )
+        svc = _service(existing, order_repo=order_repo)
+        return await svc.prepare_for_order("order-1")
+
+    @pytest.mark.asyncio
+    async def test_replaced_layer_survives_and_others_are_refreshed(self):
+        # 差し替え後に生成が失敗した行を新規受注が拾っても、差し替えた色版は残す。
+        uploaded_color = {"layer_type": "color", "file_path": "source_images/a.png"}
+        existing = _md(
+            status=MfgDataStatus.FAILED.value,
+            source_images=[uploaded_color, {"layer_type": "cutline", "url": "https://x/old.png"}],
+        )
+        item = self._intake_item()
+
+        to_generate = await self._reintake(existing, item)
+
+        assert to_generate == ["md-1"]
+        assert existing.status == MfgDataStatus.PENDING.value
+        assert existing.source_images == [
+            uploaded_color,  # 差し替えは維持
+            {"layer_type": "cutline", "url": "https://x/cutline.png"},  # 受注値で更新
+        ]
+
+    @pytest.mark.asyncio
+    async def test_row_without_replacement_is_fully_refreshed_from_intake(self):
+        existing = _md(status=MfgDataStatus.FAILED.value, source_images=[])
+        item = self._intake_item()
+
+        await self._reintake(existing, item)
+
+        assert existing.source_images == item.source_images
+
+
+@pytest.mark.asyncio
+async def test_replace_then_generate_end_to_end_in_memory():
+    """差し替え → 生成 が同じ FileStorage 上で噛み合うことを確認する."""
+    md = _md()
+    saved: dict[str, bytes] = {}
+
+    async def fake_save(upload, prefix=""):
+        path = f"{prefix}/{upload.filename}"
+        saved[path] = upload.read()
+        return path
+
+    storage = MagicMock()
+    storage.save = AsyncMock(side_effect=fake_save)
+    storage.get = AsyncMock(side_effect=lambda path: saved.get(path))
+
+    vm_client = MagicMock()
+    vm_client.submit = AsyncMock(return_value="job-1")
+    vm_client.wait_until_complete = AsyncMock(
+        return_value=SimpleNamespace(output_filename="out.ai")
+    )
+    vm_client.download = AsyncMock(return_value=b"AI")
+
+    svc = _service(
+        md, storage=storage, vm_client=vm_client, allowed_source_hosts=frozenset({"x"})
+    )
+    svc._fetch_with_limit = AsyncMock(return_value=b"CUTLINE")
+
+    with patch.object(mds, "run_generation", AsyncMock()):
+        await svc.replace_source_images(
+            "md-1",
+            {"color": _upload()},
+            replaced_by="a@b.c",
+            background_tasks=MagicMock(),
+        )
+    await svc.generate("md-1")
+
+    # save が返したキーで生成側が読み出せている（差し替え→生成の受け渡しが噛み合う）
+    assert vm_client.submit.await_args.kwargs["images"]["color"] == PNG

--- a/docs/superpowers/specs/2026-07-26-manufacturing-source-image-replacement-design.md
+++ b/docs/superpowers/specs/2026-07-26-manufacturing-source-image-replacement-design.md
@@ -1,0 +1,91 @@
+# 製造データの元画像差し替え
+
+## 概要
+
+現状、製造データ（.ai/.pdf）の元画像（PNGレイヤー）は外部受注（v2 intake）から URL で受け取るだけで、
+pod-admin 側から差し替える手段がない。元画像に不備があると外部サイト側で修正・再送してもらうしかなく、
+製造データの生成失敗（`failed`）や意図しない仕上がりを管理画面から是正できない。
+
+本機能では、管理画面から元画像 PNG をアップロードして差し替え、その元画像で製造データを再生成できるようにする。
+
+## 現状の流れ
+
+```
+外部受注(v2) --source_images[{layer_type,url}]--> order_items
+                                              --> manufacturing_data.source_images
+                                                    --(URL を DL)--> illustrator-vm --> .ai/.pdf
+```
+
+`manufacturing_data` は「受注元 × 商品コード × サイズ × バリアント」単位のキャッシュで、
+同一商品の複数注文が 1 行を共有する。生成の入力は `manufacturing_data.source_images` が正。
+
+## 差し替え後の流れ
+
+```
+管理画面 --PNG アップロード--> FileStorage(source_images/)
+                          --> manufacturing_data.source_images[i] = {layer_type, file_path, filename}
+                                --(FileStorage から読む)--> illustrator-vm --> .ai/.pdf 再生成
+```
+
+- 差し替え対象は `manufacturing_data` 行（= 商品コード単位のデザイン）。同一商品コードの
+  他注文にも同じ元画像が適用されるのはキャッシュの意味論として正しい。
+- 差し替えは既存レイヤー種別の置き換えのみ許可する。レイヤー構成を変えると
+  `build_vm_mapping` の導出バリアント（= キャッシュキー）が変わってしまうため。
+
+## データモデル
+
+### `manufacturing_data.source_images`（JSONB, 形式を拡張）
+
+| 由来 | 形式 |
+|------|------|
+| 外部受注 | `{"layer_type": "color", "url": "https://..."}` |
+| 差し替え | `{"layer_type": "color", "file_path": "source_images/2026...png", "filename": "color_fix.png"}` |
+
+生成時は `file_path` があれば FileStorage から読み、無ければ従来どおり URL を SSRF ガード付きで取得する。
+
+### `manufacturing_data` 追加カラム
+
+| カラム | 型 | 説明 |
+|--------|------|------|
+| `source_images_replaced_at` | DateTime(tz), nullable | 最後に元画像を差し替えた時刻（未差し替えは NULL） |
+| `source_images_replaced_by` | String(255), nullable | 差し替えた管理ユーザーのメール |
+
+この2カラムは表示用の履歴（監査）のみ。差し替えの有無はレイヤー自身が `file_path` を持つかで
+判定する。外部受注が同じキャッシュキーの `failed` 行を拾って `source_images` を更新する既存経路
+では、レイヤー単位でマージする: 差し替え済み（`file_path`）レイヤーは維持し、それ以外は最新の
+受注値へ更新する。
+
+## API（管理者のみ）
+
+| メソッド | パス | 説明 |
+|----------|------|------|
+| `GET` | `/manufacturing-data/{id}` | 製造データ詳細（元画像レイヤー一覧を含む） |
+| `POST` | `/manufacturing-data/{id}/source-images` | 元画像を差し替えて再生成（multipart） |
+| `GET` | `/manufacturing-data/{id}/source-images/{layer_type}` | 差し替え済み元画像の取得（プレビュー用） |
+
+差し替えリクエストは「レイヤー種別と同名のファイル項目」（`color` / `cutline` / `white` / `design`）で
+受け取る。レイヤー種別の語彙・重複はエンドポイントのシグネチャが保証するため、サービス側の検証は
+行との突き合わせだけになる。1 リクエストで複数レイヤーを差し替えて再生成は 1 回だけ起動する。
+
+### 拒否条件
+
+| 条件 | 応答 |
+|------|------|
+| 行が存在しない | 404 |
+| `status = generating`（VM ジョブ進行中） | 409 |
+| 製造中/納入済みの注文と共有 | 409（完成データの保護。再作成と同じゲート） |
+| 元画像が未登録の行 | 409 |
+| 行に存在しないレイヤー（構成の変更） | 400 |
+| PNG 以外（マジックバイト検査） | 400 |
+| `SOURCE_IMAGE_MAX_BYTES` 超過 | 400 |
+
+差し替え成功時は `regenerate` と同じ波及を行う: 行を `pending` に戻し、参照する「発注済み」明細を
+「発注準備中」へ戻し（発注ゲートで保留）、バックグラウンド生成を起動する。生成完了で「発注済み」へ復帰する。
+
+## フロントエンド
+
+- `features/manufacturing-data/source-image-replace-dialog.tsx`（新規）
+  レイヤーごとに現在の元画像（外部 URL はリンク、差し替え済みはプレビュー）と差し替えファイル選択を表示。
+- `features/manufacturing-data/regenerate-controls.tsx`
+  既存の「再作成」の隣に「元画像差し替え」ボタンを追加。製造着手前かつ生成中でない行のみ表示。
+- 受注詳細（`orders/[id]`）とメーカー発注詳細（`purchase-orders/[id]`）の双方から操作できる。

--- a/web/src/features/manufacturing-data/regenerate-controls.tsx
+++ b/web/src/features/manufacturing-data/regenerate-controls.tsx
@@ -2,27 +2,54 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, ImageUp, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api/client";
+import { SourceImageReplaceDialog } from "./source-image-replace-dialog";
 import type { ManufacturingDataStatus, OrderItemStatus } from "@/types/api";
 
 /**
- * 製造データを製造着手前（発注準備中/発注済み）に再作成できるか。
- * v2（製造データ紐付けあり）かつ ready/failed の行のみ対象。生成中/生成待ちは不可。
+ * 是正操作（再作成・元画像差し替え）の対象になりうる明細か。
+ * v2（製造データ紐付けあり）かつ製造着手前（発注準備中/発注済み）のものだけを対象とする。
  * 受注詳細・メーカー発注詳細で共有する（型が異なるためプリミティブを受け取る）。
+ */
+function isCorrectableV2Item(
+  itemStatus: OrderItemStatus | undefined,
+  mfgStatus: ManufacturingDataStatus | null | undefined,
+  manufacturingDataId: string | null | undefined,
+): boolean {
+  if (!manufacturingDataId || !mfgStatus) return false;
+  return itemStatus === "preparing_order" || itemStatus === "ordered";
+}
+
+/**
+ * 製造データを同じ元データで再作成できるか。ready/failed の行のみ対象（生成中/生成待ちは不可）。
  */
 export function canRegenerateManufacturingData(
   itemStatus: OrderItemStatus | undefined,
   mfgStatus: ManufacturingDataStatus | null | undefined,
   manufacturingDataId: string | null | undefined,
 ): boolean {
-  if (!manufacturingDataId || !mfgStatus) return false;
-  const preManufacturing =
-    itemStatus === "preparing_order" || itemStatus === "ordered";
-  const regenerable = mfgStatus === "ready" || mfgStatus === "failed";
-  return preManufacturing && regenerable;
+  return (
+    isCorrectableV2Item(itemStatus, mfgStatus, manufacturingDataId) &&
+    (mfgStatus === "ready" || mfgStatus === "failed")
+  );
+}
+
+/**
+ * 元画像を差し替えられるか。生成中（進行中の VM ジョブと競合する）以外は差し替え可能で、
+ * 生成待ち・生成失敗の行も是正できる（API 側のゲートと一致）。
+ */
+export function canReplaceSourceImages(
+  itemStatus: OrderItemStatus | undefined,
+  mfgStatus: ManufacturingDataStatus | null | undefined,
+  manufacturingDataId: string | null | undefined,
+): boolean {
+  return (
+    isCorrectableV2Item(itemStatus, mfgStatus, manufacturingDataId) &&
+    mfgStatus !== "generating"
+  );
 }
 
 /**
@@ -56,12 +83,16 @@ interface ManufacturingRegenerateControlsProps {
   manufacturingDataId: string | null | undefined;
   /** 生成失敗時の詳細（要対応バッジの tooltip に表示）。 */
   errorMessage?: string | null;
+  /** 元画像を差し替え済みなら差し替え時刻（バッジ表示に使用）。 */
+  sourceImagesReplacedAt?: string | null;
   regeneratingId: string | null;
   onRegenerate: (mfgId: string) => void;
+  /** 元画像差し替え後に親のデータを再取得するためのコールバック。 */
+  onReplaced?: () => void;
 }
 
 /**
- * 統合ステータスに添える「⚠要対応（生成失敗）」表示と「再作成」ボタン。
+ * 統合ステータスに添える「⚠要対応（生成失敗）」表示と是正操作（再作成／元画像差し替え）。
  * 受注詳細・メーカー発注詳細のステータス列で共有する。
  */
 export function ManufacturingRegenerateControls({
@@ -69,14 +100,18 @@ export function ManufacturingRegenerateControls({
   mfgStatus,
   manufacturingDataId,
   errorMessage,
+  sourceImagesReplacedAt,
   regeneratingId,
   onRegenerate,
+  onReplaced,
 }: ManufacturingRegenerateControlsProps) {
+  const [replaceTargetOpen, setReplaceTargetOpen] = useState(false);
   const showRegenerate = canRegenerateManufacturingData(
     itemStatus,
     mfgStatus,
     manufacturingDataId,
   );
+  const showReplace = canReplaceSourceImages(itemStatus, mfgStatus, manufacturingDataId);
 
   return (
     <>
@@ -87,6 +122,14 @@ export function ManufacturingRegenerateControls({
         >
           <AlertTriangle className="h-3.5 w-3.5" />
           要対応
+        </span>
+      )}
+      {sourceImagesReplacedAt && (
+        <span
+          className="text-xs text-muted-foreground"
+          title={`元画像を差し替え済み（${new Date(sourceImagesReplacedAt).toLocaleString("ja-JP")}）`}
+        >
+          元画像差し替え済み
         </span>
       )}
       {showRegenerate && manufacturingDataId && (
@@ -106,6 +149,26 @@ export function ManufacturingRegenerateControls({
           />
           <span className="ml-1">再作成</span>
         </Button>
+      )}
+      {showReplace && manufacturingDataId && (
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-2"
+            onClick={() => setReplaceTargetOpen(true)}
+            title="製造データの元画像を差し替えて再生成する（製造着手前のみ）"
+          >
+            <ImageUp className="h-3.5 w-3.5" />
+            <span className="ml-1">元画像差し替え</span>
+          </Button>
+          <SourceImageReplaceDialog
+            manufacturingDataId={manufacturingDataId}
+            open={replaceTargetOpen}
+            onClose={() => setReplaceTargetOpen(false)}
+            onReplaced={onReplaced}
+          />
+        </>
       )}
     </>
   );

--- a/web/src/features/manufacturing-data/source-image-replace-dialog.tsx
+++ b/web/src/features/manufacturing-data/source-image-replace-dialog.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import useSWR from "swr";
+import { toast } from "sonner";
+import { ExternalLink, Loader2, Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ApiError, apiClient, fetchBlob } from "@/lib/api/client";
+import type {
+  ManufacturingDataDetail,
+  SourceImageLayer,
+  SourceImageLayerType,
+} from "@/types/api";
+
+const layerLabels: Record<SourceImageLayerType, string> = {
+  color: "カラー",
+  cutline: "カットライン",
+  white: "白版",
+  design: "デザイン",
+};
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString("ja-JP");
+}
+
+interface SourceImageReplaceDialogProps {
+  manufacturingDataId: string;
+  open: boolean;
+  onClose: () => void;
+  /** 差し替え完了後に一覧・詳細を再取得するためのコールバック */
+  onReplaced?: () => void;
+}
+
+/**
+ * 製造データの元画像（PNGレイヤー）を差し替えるダイアログ。
+ *
+ * 現在のレイヤー構成を取得して表示し、選択したレイヤーのみ PNG を差し替える。
+ * 送信は1リクエスト（レイヤー種別と同名のファイル項目）で、再生成はサーバ側で1回だけ起動される。
+ */
+export function SourceImageReplaceDialog({
+  manufacturingDataId,
+  open,
+  onClose,
+  onReplaced,
+}: SourceImageReplaceDialogProps) {
+  const { data: detail, isLoading } = useSWR<ManufacturingDataDetail>(
+    open ? `/manufacturing-data/${manufacturingDataId}` : null,
+    apiClient,
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // レイヤー種別 -> 差し替えるファイル
+  const [selected, setSelected] = useState<Record<string, File>>({});
+
+  useEffect(() => {
+    if (!open) return;
+    setSelected({});
+    setError(null);
+  }, [open]);
+
+  const handleSelect = (layerType: string, file: File | undefined) => {
+    if (file && file.type !== "image/png") {
+      setError("元画像は PNG 形式のみ対応しています");
+      return;
+    }
+    setError(null);
+    setSelected((prev) => {
+      const next = { ...prev };
+      if (file) {
+        next[layerType] = file;
+      } else {
+        delete next[layerType];
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    const entries = Object.entries(selected);
+    if (entries.length === 0) return;
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const formData = new FormData();
+      for (const [layerType, file] of entries) {
+        formData.append(layerType, file);
+      }
+      await apiClient(`/manufacturing-data/${manufacturingDataId}/source-images`, {
+        method: "POST",
+        body: formData,
+      });
+      toast.success("元画像を差し替えました（製造データの再生成が完了するまでお待ちください）");
+      onReplaced?.();
+      onClose();
+    } catch (err: unknown) {
+      setError(replaceErrorMessage(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const selectedCount = Object.keys(selected).length;
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>元画像の差し替え</DialogTitle>
+          <DialogDescription>
+            差し替えるレイヤーの PNG を選択してください。差し替え後、製造データは自動で再生成されます。
+            同じ商品コードの他の注文にも適用されます。
+          </DialogDescription>
+        </DialogHeader>
+
+        {detail?.source_images_replaced_at && (
+          <p className="text-xs text-muted-foreground">
+            最終差し替え: {formatDateTime(detail.source_images_replaced_at)}
+            {detail.source_images_replaced_by && `（${detail.source_images_replaced_by}）`}
+          </p>
+        )}
+
+        {error && (
+          <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {detail?.source_images.map((layer) => (
+              <LayerRow
+                key={layer.layer_type}
+                manufacturingDataId={manufacturingDataId}
+                layer={layer}
+                selectedFile={selected[layer.layer_type]}
+                onSelect={handleSelect}
+              />
+            ))}
+            {detail?.source_images.length === 0 && (
+              <p className="py-4 text-sm text-muted-foreground">
+                この製造データには元画像が登録されていません。
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting || selectedCount === 0}>
+            {isSubmitting
+              ? "差し替え中..."
+              : `差し替えて再生成${selectedCount > 0 ? `（${selectedCount}件）` : ""}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** 差し替え失敗時に表示するメッセージ（共有ブロックとバリデーションを区別する）。 */
+function replaceErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 409) {
+      return "この製造データは差し替えできません（生成中、または製造中/納品済みの注文と共有されています）";
+    }
+    if (err.status === 400) return err.message;
+  }
+  return "元画像の差し替えに失敗しました";
+}
+
+interface LayerRowProps {
+  manufacturingDataId: string;
+  layer: SourceImageLayer;
+  selectedFile: File | undefined;
+  onSelect: (layerType: string, file: File | undefined) => void;
+}
+
+/** 1レイヤー分の「現在の元画像」と差し替えファイル選択。 */
+function LayerRow({
+  manufacturingDataId,
+  layer,
+  selectedFile,
+  onSelect,
+}: LayerRowProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const label = layerLabels[layer.layer_type];
+  const [currentUrl, setCurrentUrl] = useState<string | null>(null);
+  const previewUrl = useMemo(
+    () => (selectedFile ? URL.createObjectURL(selectedFile) : null),
+    [selectedFile],
+  );
+
+  useEffect(() => {
+    if (!previewUrl) return;
+    return () => URL.revokeObjectURL(previewUrl);
+  }, [previewUrl]);
+
+  // 差し替え済みレイヤーは認証付き取得が必要なため、blob URL にして表示する。
+  useEffect(() => {
+    if (layer.origin !== "uploaded") return;
+    let objectUrl: string | null = null;
+    fetchBlob(`/manufacturing-data/${manufacturingDataId}/source-images/${layer.layer_type}`)
+      .then((blob) => {
+        objectUrl = URL.createObjectURL(blob);
+        setCurrentUrl(objectUrl);
+      })
+      .catch(() => undefined);
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [manufacturingDataId, layer.origin, layer.layer_type]);
+
+  return (
+    <div className="flex items-center gap-4 rounded-lg border p-3">
+      <div className="w-24 shrink-0">
+        <p className="text-sm font-medium">{label}</p>
+        {layer.origin === "uploaded" && (
+          <p className="text-xs text-muted-foreground">差し替え済み</p>
+        )}
+      </div>
+
+      <div className="min-w-0 flex-1 text-xs text-muted-foreground">
+        {layer.origin === "uploaded" ? (
+          <div className="flex items-center gap-2">
+            {currentUrl && (
+              <img
+                src={currentUrl}
+                alt={`${label}の現在の元画像`}
+                className="h-12 w-12 rounded border object-contain"
+              />
+            )}
+            <span className="truncate">{layer.filename}</span>
+          </div>
+        ) : layer.url ? (
+          <a
+            href={layer.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-primary hover:underline"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            受注時の元画像を開く
+          </a>
+        ) : (
+          <span>元画像なし</span>
+        )}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {previewUrl && (
+          <img
+            src={previewUrl}
+            alt={`${label}の差し替えプレビュー`}
+            className="h-12 w-12 rounded border object-contain"
+          />
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/png"
+          className="hidden"
+          aria-label={`${label}の元画像を選択`}
+          onChange={(event) => onSelect(layer.layer_type, event.target.files?.[0])}
+        />
+        <Button variant="outline" size="sm" onClick={() => inputRef.current?.click()}>
+          <Upload className="h-3.5 w-3.5" />
+          <span className="ml-1">{selectedFile ? "変更" : "PNGを選択"}</span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/orders/components/order-detail.tsx
+++ b/web/src/features/orders/components/order-detail.tsx
@@ -176,8 +176,12 @@ export function OrderDetail({ order, onRefresh }: OrderDetailProps) {
                           mfgStatus={item.manufacturing_data?.status}
                           manufacturingDataId={item.manufacturing_data?.id}
                           errorMessage={item.manufacturing_data?.error_message}
+                          sourceImagesReplacedAt={
+                            item.manufacturing_data?.source_images_replaced_at
+                          }
                           regeneratingId={regeneratingId}
                           onRegenerate={regenerate}
+                          onReplaced={onRefresh}
                         />
                       </div>
                     </TableCell>

--- a/web/src/features/purchase-orders/components/manufacturer-order-detail.tsx
+++ b/web/src/features/purchase-orders/components/manufacturer-order-detail.tsx
@@ -398,8 +398,10 @@ export function ManufacturerOrderDetail({
                             itemStatus={item.status}
                             mfgStatus={item.manufacturing_status}
                             manufacturingDataId={item.manufacturing_data_id}
+                            sourceImagesReplacedAt={item.source_images_replaced_at}
                             regeneratingId={regeneratingId}
                             onRegenerate={regenerate}
+                            onReplaced={onStatusUpdate}
                           />
                         </div>
                       </TableCell>

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -198,7 +198,14 @@ async function executeDownloadRequest(endpoint: string): Promise<Response> {
   return fetch(`${API_BASE_URL}${endpoint}`, { headers });
 }
 
-export async function downloadFile(endpoint: string, filename: string): Promise<void> {
+/**
+ * 認証付きでバイナリを取得する。
+ * `<img src>` では Authorization ヘッダを送れないため、画像プレビューにも使う。
+ */
+export async function fetchBlob(
+  endpoint: string,
+  errorMessage = "Failed to fetch file"
+): Promise<Blob> {
   let response = await executeDownloadRequest(endpoint);
 
   // 401エラーの場合、トークンリフレッシュを試みる
@@ -217,10 +224,14 @@ export async function downloadFile(endpoint: string, filename: string): Promise<
   }
 
   if (!response.ok) {
-    throw new Error("Download failed");
+    throw new Error(errorMessage);
   }
 
-  const blob = await response.blob();
+  return response.blob();
+}
+
+export async function downloadFile(endpoint: string, filename: string): Promise<void> {
+  const blob = await fetchBlob(endpoint, "Download failed");
   const url = window.URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;

--- a/web/src/types/api/index.ts
+++ b/web/src/types/api/index.ts
@@ -24,6 +24,29 @@ export interface MfgDataItemInfo {
   output_filename: string | null;
   file_size: number | null;
   error_message: string | null;
+  // 元画像を管理画面から差し替えた時刻（null = 外部受注のまま）
+  source_images_replaced_at?: string | null;
+}
+
+// 製造データの元画像レイヤー種別
+export type SourceImageLayerType = "color" | "cutline" | "white" | "design";
+
+// 製造データ1レイヤーの元画像（origin = 由来）
+export interface SourceImageLayer {
+  layer_type: SourceImageLayerType;
+  origin: "external" | "uploaded";
+  url: string | null;
+  filename: string | null;
+}
+
+// 製造データ詳細（元画像レイヤー一覧つき）
+export interface ManufacturingDataDetail extends MfgDataItemInfo {
+  product_code: string;
+  product_type: ProductType;
+  size: string | null;
+  variant: string | null;
+  source_images: SourceImageLayer[];
+  source_images_replaced_by: string | null;
 }
 
 export interface OrderItem {
@@ -139,8 +162,10 @@ export interface ManufacturerOrderItem {
   expected_delivery_date: string | null;  // 納品予定日（未設定の旧データは null）
   // 製造データ状態（v2）: null なら製造データ不要（v1）。ready 以外は発注不可。
   manufacturing_status?: ManufacturingDataStatus | null;
-  // 紐づく製造データ ID（v2）。GUI からの再作成に使用。
+  // 紐づく製造データ ID（v2）。GUI からの再作成・元画像差し替えに使用。
   manufacturing_data_id?: string | null;
+  // 元画像を管理画面から差し替えた時刻（null = 外部受注のまま）
+  source_images_replaced_at?: string | null;
 }
 
 export interface ManufacturerOrderItemListResponse {

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -53,6 +53,12 @@ if (typeof Element.prototype.scrollIntoView === 'undefined') {
   Element.prototype.scrollIntoView = vi.fn()
 }
 
+// jsdom does not implement object URLs (used for image previews)
+if (typeof URL.createObjectURL === 'undefined') {
+  URL.createObjectURL = vi.fn(() => 'blob:mock')
+  URL.revokeObjectURL = vi.fn()
+}
+
 // Mock Next.js router
 vi.mock('next/navigation', () => ({
   useRouter: () => ({

--- a/web/tests/unit/source-image-replace.test.tsx
+++ b/web/tests/unit/source-image-replace.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * 元画像差し替え UI のテスト
+ *
+ * 製造データの元画像（PNGレイヤー）を管理画面から差し替えられることを検証する。
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SourceImageReplaceDialog } from '@/features/manufacturing-data/source-image-replace-dialog'
+import {
+  canRegenerateManufacturingData,
+  canReplaceSourceImages,
+  ManufacturingRegenerateControls,
+} from '@/features/manufacturing-data/regenerate-controls'
+import { ApiError, apiClient, fetchBlob } from '@/lib/api/client'
+import type { ManufacturingDataDetail } from '@/types/api'
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+  fetchBlob: vi.fn(),
+  // apiClient が投げる例外クラス（ダイアログは instanceof で判定する）
+  ApiError: class ApiError extends Error {
+    constructor(
+      public status: number,
+      public code: string,
+      message: string
+    ) {
+      super(message)
+    }
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const mockedApiClient = vi.mocked(apiClient)
+const mockedFetchBlob = vi.mocked(fetchBlob)
+
+const detail: ManufacturingDataDetail = {
+  id: 'md-1',
+  product_code: 'RKSYO-1',
+  product_type: 'acrylic_keychain',
+  size: '50x50mm',
+  variant: 'clear',
+  status: 'failed',
+  output_filename: null,
+  file_size: null,
+  error_message: 'VM error',
+  source_images: [
+    { layer_type: 'color', origin: 'external', url: 'https://x/color.png', filename: null },
+    { layer_type: 'cutline', origin: 'uploaded', url: null, filename: 'cutline_fix.png' },
+  ],
+  source_images_replaced_at: '2026-07-26T10:00:00Z',
+  source_images_replaced_by: 'admin@example.com',
+}
+
+function pngFile(name = 'new_color.png'): File {
+  return new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], name, { type: 'image/png' })
+}
+
+describe('canReplaceSourceImages', () => {
+  it('製造着手前かつ生成中でない v2 明細は差し替え可能', () => {
+    expect(canReplaceSourceImages('preparing_order', 'failed', 'md-1')).toBe(true)
+    expect(canReplaceSourceImages('ordered', 'ready', 'md-1')).toBe(true)
+    // 生成待ちも是正できる（再作成は不可だが差し替えは可能）
+    expect(canReplaceSourceImages('preparing_order', 'pending', 'md-1')).toBe(true)
+    expect(canRegenerateManufacturingData('preparing_order', 'pending', 'md-1')).toBe(false)
+  })
+
+  it('生成中・製造着手後・v1 明細は差し替え不可', () => {
+    expect(canReplaceSourceImages('preparing_order', 'generating', 'md-1')).toBe(false)
+    expect(canReplaceSourceImages('manufacturing', 'ready', 'md-1')).toBe(false)
+    expect(canReplaceSourceImages('delivered', 'ready', 'md-1')).toBe(false)
+    expect(canReplaceSourceImages('ordered', null, null)).toBe(false)
+  })
+})
+
+describe('ManufacturingRegenerateControls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('差し替え可能な明細に「元画像差し替え」ボタンを表示する', () => {
+    render(
+      <ManufacturingRegenerateControls
+        itemStatus="preparing_order"
+        mfgStatus="failed"
+        manufacturingDataId="md-1"
+        regeneratingId={null}
+        onRegenerate={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('button', { name: /元画像差し替え/ })).toBeInTheDocument()
+  })
+
+  it('差し替え済みの明細にはバッジを表示する', () => {
+    render(
+      <ManufacturingRegenerateControls
+        itemStatus="ordered"
+        mfgStatus="ready"
+        manufacturingDataId="md-1"
+        sourceImagesReplacedAt="2026-07-26T10:00:00Z"
+        regeneratingId={null}
+        onRegenerate={vi.fn()}
+      />
+    )
+    expect(screen.getByText('元画像差し替え済み')).toBeInTheDocument()
+  })
+})
+
+describe('SourceImageReplaceDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedFetchBlob.mockResolvedValue(new Blob([new Uint8Array([0x89])], { type: 'image/png' }))
+  })
+
+  it('現在のレイヤー構成を由来つきで表示する', async () => {
+    mockedApiClient.mockResolvedValue(detail)
+
+    render(
+      <SourceImageReplaceDialog manufacturingDataId="md-1" open onClose={vi.fn()} />
+    )
+
+    await waitFor(() =>
+      expect(mockedApiClient).toHaveBeenCalledWith('/manufacturing-data/md-1')
+    )
+    expect(await screen.findByText('カラー')).toBeInTheDocument()
+    expect(screen.getByText('カットライン')).toBeInTheDocument()
+    // 外部受注由来は元画像へのリンク、差し替え済みはファイル名を表示
+    expect(screen.getByRole('link', { name: /受注時の元画像を開く/ })).toHaveAttribute(
+      'href',
+      'https://x/color.png'
+    )
+    expect(screen.getByText('cutline_fix.png')).toBeInTheDocument()
+    expect(screen.getByText('差し替え済み')).toBeInTheDocument()
+  })
+
+  it('選択したレイヤーだけを multipart で送信し、完了後にコールバックを呼ぶ', async () => {
+    mockedApiClient.mockResolvedValue(detail)
+    const onReplaced = vi.fn()
+    const onClose = vi.fn()
+
+    render(
+      <SourceImageReplaceDialog
+        manufacturingDataId="md-1"
+        open
+        onClose={onClose}
+        onReplaced={onReplaced}
+      />
+    )
+    await screen.findByText('カラー')
+
+    const input = screen.getByLabelText('カラーの元画像を選択') as HTMLInputElement
+    await userEvent.upload(input, pngFile())
+
+    await userEvent.click(screen.getByRole('button', { name: /差し替えて再生成/ }))
+
+    await waitFor(() => expect(onReplaced).toHaveBeenCalled())
+    const [endpoint, options] = mockedApiClient.mock.calls.at(-1) as [
+      string,
+      { method: string; body: FormData },
+    ]
+    expect(endpoint).toBe('/manufacturing-data/md-1/source-images')
+    expect(options.method).toBe('POST')
+    expect((options.body.get('color') as File).name).toBe('new_color.png')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('ファイル未選択のうちは送信ボタンを押せない', async () => {
+    mockedApiClient.mockResolvedValue(detail)
+
+    render(
+      <SourceImageReplaceDialog manufacturingDataId="md-1" open onClose={vi.fn()} />
+    )
+    await screen.findByText('カラー')
+
+    expect(screen.getByRole('button', { name: /差し替えて再生成/ })).toBeDisabled()
+  })
+
+  it.each([
+    [409, 'conflict', /製造中\/納品済みの注文と共有/],
+    [400, '元画像は PNG 形式のみ対応しています: color', '元画像は PNG 形式のみ対応しています: color'],
+  ])('%i の場合はエラー内容を表示する', async (status, message, expected) => {
+    mockedApiClient.mockResolvedValue(detail)
+
+    render(
+      <SourceImageReplaceDialog manufacturingDataId="md-1" open onClose={vi.fn()} />
+    )
+    await screen.findByText('カラー')
+    await userEvent.upload(
+      screen.getByLabelText('カラーの元画像を選択') as HTMLInputElement,
+      pngFile()
+    )
+
+    mockedApiClient.mockRejectedValueOnce(new ApiError(status, 'ERR', message))
+    await userEvent.click(screen.getByRole('button', { name: /差し替えて再生成/ }))
+
+    expect(await screen.findByText(expected)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 概要

**Intent Spec:** #<!-- Issue番号 -->

### なぜこの変更が必要か

製造データ（.ai/.pdf）の元画像（PNGレイヤー）は外部受注（v2 intake）から URL で受け取るだけで、pod-admin 側から差し替える手段がなかった。元画像に不備があると外部サイト側で修正・再送してもらうしかなく、生成失敗（`failed`）や意図しない仕上がりを管理画面から是正できない。

本 PR で、管理画面から元画像 PNG をアップロードして差し替え、その元画像で製造データを再生成できるようにする。

### 設計

設計メモ: `docs/superpowers/specs/2026-07-26-manufacturing-source-image-replacement-design.md`

- **差し替え対象は `manufacturing_data` 行**（= 受注元 × 商品コード × サイズ × バリアントのキャッシュ）。同一商品コードの他注文にも同じ元画像が適用されるのはキャッシュの意味論として正しい。
- **`source_images`（JSONB）の形式を拡張**: 外部受注由来は `{layer_type, url}`、差し替え済みは `{layer_type, file_path, filename}`。生成時は `file_path` があれば FileStorage から読み、無ければ従来どおり SSRF ガード付きで URL を取得する。
- **差し替えは既存レイヤー種別の置き換えのみ**。レイヤー構成を変えると `build_vm_mapping` の導出バリアント（= キャッシュキー）が変わってしまうため。
- **再受注時はレイヤー単位でマージ**: 外部受注が `failed` 行を拾って元データを更新する既存経路では、差し替え済み（`file_path`）レイヤーを維持し、それ以外を最新の受注値へ更新する。
- **ゲートは再作成（regenerate）と共通化**（`_assert_rebuildable` / `_restart_generation`）。生成中は VM ジョブと競合するため拒否、製造中/納入済みの注文と共有している行は完成データ保護のため拒否。

### API（管理者のみ）

| メソッド | パス | 説明 |
|---|---|---|
| `GET` | `/manufacturing-data/{id}` | 製造データ詳細（元画像レイヤーを由来つきで返す） |
| `POST` | `/manufacturing-data/{id}/source-images` | 元画像を差し替えて再生成（multipart。レイヤー種別と同名のファイル項目） |
| `GET` | `/manufacturing-data/{id}/source-images/{layer_type}` | 差し替え済み元画像の取得（プレビュー用） |

拒否条件: 404（行なし） / 409（生成中・製造着手済みと共有・元画像未登録） / 400（行に存在しないレイヤー・PNG 以外（マジックバイト検査）・`SOURCE_IMAGE_MAX_BYTES` 超過）。

### 画面

受注詳細・メーカー発注詳細のステータス列に「元画像差し替え」ボタンと「元画像差し替え済み」バッジを追加。ダイアログでは現在のレイヤー構成（外部 URL はリンク、差し替え済みはサムネイル＋ファイル名）と、選択した差し替えファイルのプレビューを表示する。

---

## 品質ゲート結果

| 検証 | 結果 | 詳細 |
|---|---|---|
| 型チェック | ✅ | mypy: 143 errors（main と同数・同一。本変更による増加なし） / `tsc --noEmit`: `src/` にエラーなし |
| リンター | ✅ | ruff: 変更ファイルは clean / eslint: エラー0（`<img>` の warning は既存コードと同様） |
| ユニットテスト | ✅ | api 追加 21 件パス / web 追加 9 件パス |
| 統合テスト | ✅ | 追加 6 件パス。全体はクリーンDBで main と完全に同一の失敗集合（45 件、すべて既存の失敗） |
| 仕様適合 | ✅ | 下表 AC: 8/8 カバー |
| AI意味レビュー | ✅ | `/simplify max`（reuse / simplification / efficiency / altitude の4観点）を実施し、採否を判断して反映 |

`npm run build`（Next.js 本番ビルド）も成功。

## 受け入れ基準との対応

| 受け入れ基準 | テスト | 結果 |
|---|---|---|
| AC-001: 管理者が元画像 PNG をアップロードして差し替えられる | `tests/integration/test_manufacturing_source_image_replacement.py::test_replace_stores_upload_and_restarts_generation` | ✅ |
| AC-002: 未指定レイヤーは受注時の元画像を保つ | 同上 / `tests/unit/test_source_image_replacement.py::test_replaces_layer_and_restarts_generation` | ✅ |
| AC-003: 差し替え後に製造データが再生成される（明細は発注準備中へ戻る） | `..._replacement.py::test_replace_demotes_referencing_items` | ✅ |
| AC-004: 生成は外部 URL ではなく差し替えたファイルを読む | `test_source_image_replacement.py::test_generate_sends_replaced_layer_to_vm` / `::test_download_reads_stored_file_instead_of_url` | ✅ |
| AC-005: 製造中/納入済みの注文と共有する製造データは差し替え不可（409） | `..._replacement.py::test_rejects_when_shared_order_is_in_manufacturing` / `test_source_image_replacement.py::test_rejects_when_shared_with_manufacturing_order` | ✅ |
| AC-006: PNG 以外・サイズ超過・行に無いレイヤーは 400 | `..._replacement.py::test_rejects_non_png_upload` / `test_source_image_replacement.py::test_rejects_upload_over_size_limit`, `::test_rejects_invalid_layer_specification` | ✅ |
| AC-007: 再受注で差し替えが失われない | `test_source_image_replacement.py::test_replaced_layer_survives_and_others_are_refreshed` | ✅ |
| AC-008: 差し替え可否がUIに反映される（生成中は非表示・差し替え済みはバッジ） | `web/tests/unit/source-image-replace.test.tsx` | ✅ |

## スクリーンショット

UI 変更はありますが、本セッションではブラウザ自動撮影を実施していないため未添付です。確認箇所: 受注詳細 `/orders/[id]` とメーカー発注詳細 `/purchase-orders/[id]` のステータス列（「元画像差し替え」ボタン → ダイアログ）。

## レビューのポイント

1. **差し替えの粒度**: 元画像を `manufacturing_data`（商品コード単位のキャッシュ）に対して差し替える設計でよいか。同じ商品コードの他注文にも適用される旨はダイアログ本文で明示しています。
2. **レイヤー構成の変更を許可しない判断**: 追加・削除を許すと導出バリアント（キャッシュキー）が変わるため 400 にしています。マッピング不能で元データを持たない行は 409（差し替え対象外）。
3. **再受注時のマージ規則**: 「差し替え済みレイヤーは維持、それ以外は最新の受注値」。受注値から消えた差し替え済みレイヤーも保持します。
4. **`ManufacturerOrderItemResponse` への `source_images_replaced_at` 追加**: 同スキーマはメーカーポータルにも返る（既に `manufacturing_status` / `manufacturing_data_id` を返している）ため、時刻のみを追加し、差し替え者のメールは管理者向けの詳細 API に限定しています。
5. **差し替え済み元画像のプレビュー**: `<img>` では Authorization を送れないため、`fetchBlob`（`downloadFile` から抽出した認証付きバイナリ取得）で blob URL にしています。

## レビュー指摘のうち見送ったもの

- `retry` を共有ゲート経由にする（既存の意図的な挙動: `failed` 行のみ再実行し明細降格はしない）
- 生成時の httpx クライアント遅延生成（全レイヤー差し替え済みなら約 52ms 無駄だが、分単位の VM ジョブに対して影響が小さく、取得ループの構造を崩す）
- プレビューを署名付き URL / サムネイル化する、テーブル単位にダイアログを1つへ集約する（いずれも本 PR の範囲外の最適化）
- 統合テストのフィクスチャを `conftest.py` へ共通化（このリポジトリの統合テストはファイル毎にフィクスチャを定義する慣習）

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFPKHZmcKDrJUkkLePf6s8)_