### PR TITLE
ci: 品質ゲートを導入（段階4/4）

### DIFF
--- a/.claude/hooks/guard-push.sh
+++ b/.claude/hooks/guard-push.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# guard-push.sh — PreToolUse フック。
+# `git push` の実行前に品質検証が完了しているかを確認し、未完なら拒否する。
+#
+# stdin から Claude Code のフック入力（JSON）を受け取り、
+# 拒否する場合は permissionDecision: deny を返す。
+#
+set -uo pipefail
+
+input="$(cat)"
+
+command="$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    print(data.get("tool_input", {}).get("command", ""))
+except Exception:
+    print("")
+' 2>/dev/null)"
+
+# git push 以外は素通し
+case "$command" in
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+# テンプレート本体（および contribute 目的のフォーク）は開発プロジェクトではないため、
+# 品質ゲートの対象外にする。origin に repo 名が残っているかで判定する。
+# 「Use this template」で作った案件は別名になるので、ここを素通りせず品質ゲートが効く。
+origin="$(git remote get-url origin 2>/dev/null || echo "")"
+case "$origin" in
+  *ai-native-project-template*) exit 0 ;;
+esac
+
+# ドキュメントのみのブランチは品質ゲート対象外
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+case "$branch" in
+  docs/*) exit 0 ;;
+esac
+
+deny() {
+  python3 -c '
+import json, sys
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": sys.argv[1]
+  }
+}, ensure_ascii=False))
+' "$1"
+  exit 0
+}
+
+if [ ! -x scripts/quality-gate.sh ]; then
+  exit 0
+fi
+
+result="$(bash scripts/quality-gate.sh --verify 2>&1)" || deny \
+  "push がブロックされました。$result / 先に /quality-gate を実行してください（静的チェック → /simplify max → 静的チェック再実行 → --seal の順）。"
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: ci
+
+# プロジェクトの静的解析（ビルド・テストゲート）。
+# 現状のコードベースでは大量に失敗するため（ruff / eslint / mypy / tsc）、各チェックは
+# continue-on-error による「情報提供のみ・非ブロッキング」で導入している。
+# REQ-0041 で是正して緑化したら continue-on-error を外し、ブランチ保護の必須チェックに
+# 昇格させる。テスト（pytest / vitest / Playwright）は DB・インフラ準備後に追加する。
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: 依存インストール
+        working-directory: api
+        run: uv sync --extra dev
+      - name: ruff（導入予定・非ブロッキング）
+        working-directory: api
+        continue-on-error: true
+        run: uv run ruff check .
+      - name: mypy（導入予定・非ブロッキング）
+        working-directory: api
+        continue-on-error: true
+        run: uv run mypy .
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: 依存インストール
+        working-directory: web
+        run: npm ci
+      - name: eslint（導入予定・非ブロッキング）
+        working-directory: web
+        continue-on-error: true
+        run: npm run lint
+      - name: tsc（導入予定・非ブロッキング）
+        working-directory: web
+        continue-on-error: true
+        run: npx tsc --noEmit

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,35 @@
+name: docs-check
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "scripts/docs-lint.py"
+      - "scripts/_docmodel.py"   # docs-lint.py が import する
+      - "_templates/**"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: ドキュメント整合性チェック
+        run: python3 scripts/docs-lint.py
+
+      - name: 未決事項をジョブサマリーに出す
+        if: always()
+        run: |
+          echo "## 未決事項 [NEEDS-DECISION]" >> $GITHUB_STEP_SUMMARY
+          if grep -rn "NEEDS-DECISION" docs/ >> $GITHUB_STEP_SUMMARY 2>/dev/null; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "次回アジェンダに載せてください。" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "なし" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -1,0 +1,120 @@
+name: pr-quality-check
+
+# 実装 PR に品質検証の記録があることを確認する。
+# フックはローカルの防御なので、CI 側でも同じことを確認して二重化する。
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+
+jobs:
+  verify-quality-section:
+    runs-on: ubuntu-latest
+    # 日本語リテラルに対する grep がバイト単位に落ちないよう固定する。
+    # このテンプレートは案件ごとに複製されるので、規律ではなく環境で防ぐ。
+    env:
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # テンプレート本体（および contribute 目的のフォーク）は開発プロジェクトではないため、
+      # 品質検証セクション・トレーサビリティの強制を外す。base repo 名で判定する。
+      # 「Use this template」で作った案件は別名になるので、通常どおり強制される。
+      - name: テンプレート本体か判定
+        id: template
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          case "$REPO" in
+            */ai-native-project-template) echo "is_template=true" >> $GITHUB_OUTPUT ;;
+            *) echo "is_template=false" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: ドキュメントのみの PR か判定
+        if: steps.template.outputs.is_template == 'false'
+        id: scope
+        run: |
+          base="origin/${{ github.event.pull_request.base.ref }}"
+          changed="$(git diff --name-only "$base"...HEAD)"
+          echo "$changed"
+          if echo "$changed" | grep -qv '^\(docs/\|_templates/\)'; then
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+          else
+            echo "docs_only=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: 品質検証セクションを確認
+        if: steps.template.outputs.is_template == 'false' && steps.scope.outputs.docs_only == 'false'
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          fail=0
+          echo "$BODY" | grep -q '\- \[x\] 静的チェック: `scripts/quality-gate.sh` 通過' || {
+            echo "::error::PR 本文に静的チェック通過の記載がありません"; fail=1; }
+          echo "$BODY" | grep -q '\- \[x\] `/simplify max` 実行済み' || {
+            echo "::error::PR 本文に /simplify max 実行済みの記載がありません"; fail=1; }
+          echo "$BODY" | grep -q '\- \[x\] 静的チェック再実行: 通過' || {
+            echo "::error::PR 本文に静的チェック再実行の記載がありません"; fail=1; }
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::/quality-gate を実行し、PR 本文の品質検証セクションを埋めてください"
+            exit 1
+          fi
+          echo "品質検証の記載を確認しました"
+
+      # 作業 ID は REQ-XXXX。Issue は使わないので Refs: が唯一の追跡経路になる。
+      # AGENTS.md「全工程を通さなくてよい変更」に当たるものだけ ID を持たない。
+      # 理由を書かせて、妥当性の判断はレビュアーに残す。
+      - name: トレーサビリティを確認
+        if: steps.template.outputs.is_template == 'false'
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+          DOCS_ONLY: ${{ steps.scope.outputs.docs_only }}
+        run: |
+          refs="$(printf '%s' "$BODY" | tr -d '\r' | grep -m1 -E '^[[:space:]]*Refs:' || true)"
+          if [ -z "$refs" ]; then
+            echo "::error::PR 本文に Refs: の行がありません"
+            exit 1
+          fi
+
+          # 抜け道を使えるのは ID を 1 つも持たない PR だけ。先に ID の有無で分岐しないと、
+          # 説明文にたまたま「なし（」を含む PR が下の BL 件数検査を素通りする。
+          # 判定は case のリテラル一致で行う。否定文字クラス [^）] は
+          # UTF-8 の「ー」「変」等が全角括弧とバイトを共有するため使えない。
+          if ! printf '%s' "$refs" | grep -qE '(REQ|ADR|MTG)-'; then
+            case "$refs" in
+              *'なし（）'*|*'なし（　）'*)
+                echo "::error::Refs: なし（理由） の理由が空です"
+                exit 1 ;;
+              *'なし（'*'）'*)
+                echo "ID なしを許可しました: $refs"
+                exit 0 ;;
+            esac
+            echo "::error::Refs: には REQ / ADR / MTG のいずれかの ID を書いてください"
+            echo "::error::全工程を通さない変更の場合は Refs: なし（理由） と書いてください"
+            echo "::error::AGENTS.md「全工程を通さなくてよい変更」を参照してください"
+            exit 1
+          fi
+
+          # 1 つの PR が実装してよい要件は 1 件まで。Issue 廃止で Closes # が担っていた
+          # 対応付けを、ここで機械的に保証する。
+          # 逆向き（1 要件を複数 PR に分ける）は許す。実装の都合による分割は正当であり、
+          # 同じ REQ-XXXX を参照する PR が複数あってよい（AGENTS.md「作業の単位」）。
+          if [ "$DOCS_ONLY" = "false" ]; then
+            # run: は bash -eo pipefail で動く。無マッチの grep が 1 を返すと
+            # pipefail + set -e でこの行ごとステップが落ち、下のエラー文が出ない。
+            count="$(printf '%s' "$refs" | grep -oE 'REQ-[0-9]{4}' | sort -u | wc -l | tr -d ' ')" || true
+            if [ "$count" -eq 0 ]; then
+              echo "::error::実装 PR には Refs: に REQ-XXXX を含めてください（作業 ID は要件です）"
+              exit 1
+            fi
+            if [ "$count" -gt 1 ]; then
+              echo "::error::この PR が $count 件の要件を実装しています。1 つの PR で実装してよい要件は 1 件までです"
+              echo "::error::実装が大きいだけなら PR を分けてください（要件は 1 つのままでよい）"
+              echo "::error::実体が複数の要件なら /requirements-refine で要件そのものを分けてください"
+              exit 1
+            fi
+          fi
+          echo "トレーサビリティの記載を確認しました"

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ Thumbs.db
 
 # Docker
 *.pid
+
+# Quality gate（scripts/quality-gate.sh がローカルに生成する。コミットしない）
+.quality-gate/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,7 +344,7 @@ cd api && uv run ruff check .        # backend（line-length 100, py312）
 cd web && npm run lint               # frontend（eslint 9）
 ```
 
-`scripts/quality-gate.sh` の `PROJECT_CHECKS` にも同じコマンドを登録すること（段階4で導入する）。
+`scripts/quality-gate.sh` の `PROJECT_CHECKS` は現状 docs-lint のみ有効。上記のコード用チェック（ruff / mypy / eslint / tsc）は 2026-08-06 時点で大量に失敗するため導入予定（REQ-0041）。緑化したものから順に有効化する。
 
 ### このプロジェクト特有の注意点
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@
 
 - 規約の正本は `AGENTS.md`（上の `@AGENTS.md` で読み込む）。ワークフローも同ファイルを参照。
 - 実装作業は `/implement-requirement <REQ-ID>` から開始する。例外は AGENTS.md「全工程を通さなくてよい変更」だけ。
-- コードを変更したら、コミット前に `/quality-gate` を実行する。
-  （push を機械的に止めるフックと PR の品質検証 CI は**段階4**で導入予定。それまでは運用で担保する。）
+- コードを変更したら、コミット前・push 前に `/quality-gate` を実行する。
+  push を機械的に止める push フック（`.claude/hooks/guard-push.sh`）を配置済み。**有効化には `.claude/settings.json` の登録が必要**（`docs/*` ブランチは対象外）。
+  `quality-gate.sh` の `PROJECT_CHECKS` は現状 docs-lint のみ有効。ruff / eslint / mypy / tsc は大量失敗のため導入予定（REQ-0041）。`ci.yml` はコードチェックを非ブロッキングで可視化する。
 - `/effort` の使い分け: 要件整理・設計判断は `high` 以上、定型のドキュメント更新は `medium` で足りる。
 
 

--- a/docs/01-requirements/REQ-0041.md
+++ b/docs/01-requirements/REQ-0041.md
@@ -1,0 +1,60 @@
+---
+id: REQ-0041
+title: 静的解析（ruff・eslint・mypy・tsc）を是正し品質ゲート・CI の必須チェックに組み込む
+priority: undecided
+status: not-started
+area: common
+category: non-functional
+source: []
+requester: ""
+related: []
+depends_on: []
+milestone: ""
+estimate: TBD
+decision: ""
+decided_at: ""
+updated: 2026-08-06
+---
+
+## 内容
+
+現状のコードベースで大量に失敗している静的解析（ruff / eslint / mypy / tsc）を是正し、品質ゲート（`scripts/quality-gate.sh` の `PROJECT_CHECKS`）と CI（`ci.yml`）の必須チェックとして有効化できる状態にしたい。緑化するまでは「導入予定」として非ブロッキングで可視化するに留める。
+
+## 背景・理由
+
+段階4（品質ゲート導入）の事前確認で、2026-08-06 時点の main で次の失敗が判明した。
+
+- api（uv）: ruff 260 errors（174 自動修正可）／ mypy 1758 errors（116 files）
+- web（npm）: eslint 5 errors・35 warnings ／ tsc 26 errors
+
+このままフックや必須チェックで有効化すると push・マージが常に失敗し、体制そのものが放棄される。そのため docs-lint 以外のコードチェックはゲートから外している（`quality-gate.sh` の `PROJECT_CHECKS` はコメントアウト、`ci.yml` は continue-on-error）。是正して緑化すれば、これらを必須に昇格できる。
+
+## 判断が出ないと止まるもの
+
+- どこまで是正するか（全件緑化か、まず ruff/eslint の自動修正可能分か、領域を絞って段階的にか）。
+- 是正の優先度（機能開発と並行か、専用フェーズを設けるか）。
+- mypy の厳格度（現行設定のままか、段階的に緩めて導入するか）。
+
+## 受入基準
+
+<!-- priority が undecided のため空でよい。must/future に上げるときに埋める -->
+
+## スコープ外
+
+テスト（pytest / vitest / Playwright）の CI 実行（DB・インフラ準備を含む）は本要件の対象外とし、別途扱う。
+
+## 未決事項
+
+是正の範囲・進め方が未確定。緑化した領域から順に、`quality-gate.sh` の `PROJECT_CHECKS` と `ci.yml` の必須化に組み込む。
+
+## 実装メモ
+
+- ゲート: `scripts/quality-gate.sh` の `PROJECT_CHECKS` に緑のチェックを 1 つずつ追加していく（現状は docs-lint のみ有効）。
+- CI: `.github/workflows/ci.yml` の該当ステップから `continue-on-error` を外す。緑化後にブランチ保護の必須チェックへ昇格。
+- 着手の足がかり: `uv run ruff check --fix`（174 件自動修正可）、eslint も `--fix` あり。mypy / tsc は手修正が中心。
+
+## 経緯
+
+| 日付 | 出典 | できごと |
+|---|---|---|
+| 2026-08-06 | 既存実装（コード精査） | 段階4の事前チェックで静的解析の大量失敗が判明し、是正要件として起票（/adopt-repo 段階4） |

--- a/docs/01-requirements/index.md
+++ b/docs/01-requirements/index.md
@@ -53,6 +53,7 @@ Slack で流れた話も、合意した要件も、見送ったものも、す�
 | [REQ-0038](REQ-0038.md) | order | 受注・発注のステータス変更履歴を記録し追跡できる | undecided | not-started | |
 | [REQ-0039](REQ-0039.md) | chat | チャットの未読/既読管理と新着通知ができる | undecided | not-started | |
 | [REQ-0040](REQ-0040.md) | auth | 本番のデバッグ資産（debug-token・トークンログ）を除去する | undecided | not-started | |
+| [REQ-0041](REQ-0041.md) | common | 静的解析（ruff/eslint/mypy/tsc）を是正し品質ゲート・CIの必須チェックに組み込む | undecided | not-started | |
 
 ## priority — 採否・約束の度合い
 

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# quality-gate.sh — 実装 PR を出す前の静的チェックを一括実行し、
+# 検証済みのツリー内容を .quality-gate/result.json に記録する。
+#
+# 使い方:
+#   scripts/quality-gate.sh              静的チェックを実行して結果を記録
+#   scripts/quality-gate.sh --seal       /simplify max 実行済みフラグを立てる
+#   scripts/quality-gate.sh --verify     記録が現在のツリーと一致するか検証（フックが使う）
+#
+# 記録されるフィンガープリントは「追跡対象ファイルの内容」から計算するため、
+# commit の前後で値が変わらない。つまり
+#   実装 → 静的チェック → /simplify max → 静的チェック再実行 → --seal → commit → push
+# の順で流しても、push 時点で検証が通る。
+#
+set -uo pipefail
+
+GATE_DIR=".quality-gate"
+RESULT="$GATE_DIR/result.json"
+
+# ---------------------------------------------------------------------------
+# プロジェクト固有の静的チェック
+# ここを各プロジェクトで書き換える。存在しないコマンドは自動でスキップされる。
+# ---------------------------------------------------------------------------
+PROJECT_CHECKS=(
+  # 導入予定（2026-08-06 時点の main では下記が大量に失敗するため未有効化。
+  # REQ-0041 で是正し、緑化したものから順にコメントを外して有効化する）。
+  # 有効化時は cwd が漏れないよう bash -c で囲む（monorepo の api/ web/ 対策）。
+  #   api（uv）: ruff 260 errors / mypy 1758 errors（116 files）
+  #   web（npm）: eslint 5 errors・35 warnings / tsc 26 errors
+  # "bash -c 'cd api && uv run ruff check .'"
+  # "bash -c 'cd api && uv run mypy .'"
+  # "bash -c 'cd web && npm run lint'"
+  # "bash -c 'cd web && npx tsc --noEmit'"
+  # テスト（要 DB/インフラ。ci.yml 側で導入予定）:
+  # "bash -c 'cd api && uv run pytest -q'"
+  # "bash -c 'cd web && npm run test:run'"
+)
+
+# ドキュメント整合性チェックは常に実行する
+DOCS_CHECK="python3 scripts/docs-lint.py"
+
+# ---------------------------------------------------------------------------
+
+sha() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum | awk '{print $1}'
+  else shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+fingerprint() {
+  # 追跡対象 + 未追跡（gitignore 対象外）のファイル内容からハッシュを作る。
+  # .quality-gate/ 自身は除外する。
+  git ls-files -z --cached --others --exclude-standard \
+    | tr '\0' '\n' \
+    | grep -v '^\.quality-gate/' \
+    | sort \
+    | while IFS= read -r f; do
+        [ -f "$f" ] || continue
+        printf '%s ' "$f"
+        sha < "$f"
+      done \
+    | sha
+}
+
+json_get() {
+  # $1: key
+  [ -f "$RESULT" ] || { echo ""; return; }
+  python3 - "$RESULT" "$1" <<'PY' 2>/dev/null || echo ""
+import json, sys
+try:
+    print(json.load(open(sys.argv[1])).get(sys.argv[2], ""))
+except Exception:
+    print("")
+PY
+}
+
+write_result() {
+  # $1: checks_passed(true/false)  $2: simplified(true/false)
+  mkdir -p "$GATE_DIR"
+  python3 - "$RESULT" "$(fingerprint)" "$1" "$2" <<'PY'
+import json, sys, datetime
+path, fp, checks, simplified = sys.argv[1:5]
+json.dump({
+    "fingerprint": fp,
+    "checks_passed": checks == "true",
+    "simplified": simplified == "true",
+    "recorded_at": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+}, open(path, "w"), indent=2)
+PY
+}
+
+# --- --verify -------------------------------------------------------------
+if [ "${1:-}" = "--verify" ]; then
+  [ -f "$RESULT" ] || { echo "GATE: 未実行（$RESULT がありません）"; exit 1; }
+  want="$(json_get fingerprint)"
+  have="$(fingerprint)"
+  [ "$want" = "$have" ] || { echo "GATE: 検証後にコードが変更されています"; exit 1; }
+  [ "$(json_get checks_passed)" = "True" ] || { echo "GATE: 静的チェックが未通過です"; exit 1; }
+  [ "$(json_get simplified)" = "True" ] || { echo "GATE: /simplify max が未実行です"; exit 1; }
+  echo "GATE: OK"
+  exit 0
+fi
+
+# --- --seal ---------------------------------------------------------------
+if [ "${1:-}" = "--seal" ]; then
+  [ -f "$RESULT" ] || { echo "先に scripts/quality-gate.sh を実行してください" >&2; exit 1; }
+  if [ "$(json_get checks_passed)" != "True" ]; then
+    echo "静的チェックが通っていません。修正してから再実行してください" >&2; exit 1
+  fi
+  write_result true true
+  echo "GATE: /simplify max 実行済みとして記録しました"
+  exit 0
+fi
+
+# --- 通常実行 --------------------------------------------------------------
+echo "=== quality gate ==="
+failed=0
+
+run_check() {
+  local cmd="$1"
+  local bin
+  bin="$(echo "$cmd" | awk '{print $1}')"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "-- skip: $cmd （$bin が見つかりません）"
+    return 0
+  fi
+  echo "-- run : $cmd"
+  if eval "$cmd"; then
+    echo "   ok"
+  else
+    echo "   FAILED: $cmd" >&2
+    failed=1
+  fi
+}
+
+run_check "$DOCS_CHECK"
+# 空配列 + set -u で bash 3.2（macOS 既定）が unbound variable を出すのを避ける
+for c in ${PROJECT_CHECKS[@]+"${PROJECT_CHECKS[@]}"}; do
+  run_check "$c"
+done
+
+if [ "$failed" -ne 0 ]; then
+  write_result false false
+  echo ""
+  echo "静的チェックに失敗しました。修正してから再実行してください。" >&2
+  exit 1
+fi
+
+# 静的チェック通過。simplified はこの時点では false のまま。
+write_result true "$( [ "$(json_get simplified)" = "True" ] && echo true || echo false )"
+echo ""
+echo "静的チェック通過。次に /simplify max を実行し、scripts/quality-gate.sh --seal を実行してください。"


### PR DESCRIPTION
## 概要

`/adopt-repo` **段階4/4**。既存コードベースを壊さない形で品質ゲートの基盤を導入します。

事前チェックで **ruff 260 / eslint 5 / mypy 1758 / tsc 26 errors** と判明したため、skill の警告（大量失敗するチェックをフックで有効化すると push 不能になり体制が放棄される）に従い、**docs-lint 以外のコードチェックはゲートから外し「導入予定」として非ブロッキングで可視化**します。是正は REQ-0041 として起票済み。ブランチ保護は本段階では入れません（ユーザー判断）。

Refs: なし（品質ゲートの導入・運用基盤）

## 変更内容

**有効化（緑）**
- `scripts/quality-gate.sh`: `PROJECT_CHECKS` は docs-lint のみ有効。コード用チェックは失敗数を明記してコメントアウト
- `.github/workflows/docs-check.yml`: docs-lint を PR で実行（緑）
- `.github/workflows/pr-quality-check.yml`: 実装 PR の品質検証セクション＋トレーサビリティ（Refs）を確認（緑）
- `.gitignore` に `.quality-gate/` を追加

**非ブロッキング（情報提供）**
- `.github/workflows/ci.yml`: api（ruff/mypy）・web（eslint/tsc）を `continue-on-error` で可視化。緑化したら `continue-on-error` を外して必須化

**追跡**
- `REQ-0041`（undecided）: 静的解析の是正とゲート・CI 必須化への組み込み。着手の足がかり（ruff `--fix` 174件 ほか）を記載

## ⚠ 要ご対応: `.claude/settings.json`（push フックの有効化）

push を機械的に止めるフック本体（`.claude/hooks/guard-push.sh`）は配置しましたが、**有効化に必要な `.claude/settings.json` は、自動モードの安全分類器にブロックされたため本PRに含めていません**（起動フックと権限ルールの追加はユーザーが明示承認すべき変更、という判断）。下記を `.claude/settings.json` として追加すると、フックが有効化されます（`docs/*` ブランチは対象外）。あわせて `gh pr merge` / force push / 議事録rawの編集を deny します。

<details><summary>.claude/settings.json（コピーして追加してください）</summary>

```json
{
  "$schema": "https://json.schemastore.org/claude-code-settings.json",
  "hooks": {
    "PreToolUse": [
      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-push.sh\"" } ] }
    ]
  },
  "permissions": {
    "allow": [
      "Bash(git status:*)", "Bash(git diff:*)", "Bash(git log:*)", "Bash(git add:*)",
      "Bash(git checkout:*)", "Bash(git switch:*)", "Bash(gh pr list:*)", "Bash(gh pr view:*)",
      "Bash(bash scripts/quality-gate.sh:*)", "Bash(python3 scripts/docs-lint.py:*)", "Bash(git tag:*)"
    ],
    "deny": [
      "Bash(gh pr merge:*)", "Bash(git push --force:*)", "Bash(git push -f:*)",
      "Edit(docs/03-meetings/raw/**)", "Write(docs/03-meetings/raw/**)"
    ]
  }
}
```
</details>

フックを入れない選択も可能です（その場合 `guard-push.sh` は未使用のまま残ります）。

## 品質検証

- [x] 静的チェック: `scripts/quality-gate.sh` 通過
- [x] `/simplify max` 実行済み
  - 指摘: 0件 / 修正: 0件
  - 主な修正: 指摘なし（変更は運用基盤・CI 設定・ドキュメントのみでプロダクトコード未変更。テンプレ由来ファイルは上流でレビュー済み、authored な `ci.yml` も確認済み）
- [x] 静的チェック再実行: 通過

## 完了後

段階4完了後、`/docs-audit` で整合性を確認し、残っている `[NEEDS-DECISION]` を報告します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)