### PR TITLE
chore(scripts): client-export が呼ぶスクリプト一式を上流から取り込む

### DIFF
--- a/scripts/_exports.py
+++ b/scripts/_exports.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""_exports.py — 顧客向け成果物の列定義（要件・検討事項・決定事項・不具合）を集約する。
+
+export-csv.py（CSV）と export-xlsx.py（Excel 4 タブ）が同じ builder を使うことで、
+CSV と Excel で列や絞り込みがぶれないようにする。列を足すときはここだけ直せばよい。
+
+**要件と検討事項は同じ `docs/01-requirements/` から出る。** 違いは priority だけで、
+合意済み（must / future）が「要件」、未判断・見送り（undecided / wont）が「検討事項」になる。
+顧客に見せる単位が違うだけで、正本は 1 つである。
+
+**不具合は `docs/05-defects/` から出る。別の層なので絞り込みが要らない。**
+要件の一覧に混ざらないことがディレクトリの分離によって保証されている。
+
+4 種すべての先頭に「領域」列を置いている。顧客がこの列で絞り込めることが目的なので、
+列の位置は ID の直後から動かさない。
+
+各 builder は `(header, rows)` を返す。`client=True` なら顧客向け（日本語ラベル・
+内部項目を落とす）、`client=False` なら内部管理用（frontmatter をそのまま出す）。
+"""
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+
+from _docmodel import (
+    AGREED,
+    area_label,
+    as_list,
+    as_text,
+    load_areas,
+    load_docs,
+    section_body,
+    strip_comments,
+)
+from _labels import category_ja, priority_ja, status_ja
+
+
+def first_section(text: str, heading: str, limit: int = 200) -> str:
+    """本文から指定した見出しの直下を 1 行に畳んで返す。"""
+    body = strip_comments(section_body(text, heading))
+    body = re.sub(r"\s+", " ", body).strip()
+    return body[:limit] + ("…" if len(body) > limit else "")
+
+
+@lru_cache(maxsize=1)
+def load_requirements() -> tuple[dict, ...]:
+    """要件を 1 度だけ読む。要件タブと検討事項タブが同じディレクトリを見るため。"""
+    return tuple(load_docs("01-requirements"))
+
+
+@lru_cache(maxsize=1)
+def load_defects() -> tuple[dict, ...]:
+    """不具合を 1 度だけ読む。不具合タブと、要件タブの「未修正の不具合」列が使う。"""
+    return tuple(load_docs("05-defects"))
+
+
+@lru_cache(maxsize=1)
+def open_defect_counts() -> dict[str, int]:
+    """未修正の不具合を、それが指す文書 ID ごとに数える。
+
+    「未修正」は「直すと決めていて（must / future）まだ done でないもの」。
+    wont は「直さないと決めた」ので数えない。
+
+    要件は不具合が出ても done のまま戻さない（done はマージ時点の履歴であって、
+    今も満たしている保証ではない）。そのぶん **今この瞬間の健全性を要件の一覧に
+    出すのはこの列の役目になる。** 保存はせず、ここで毎回導出する。
+    """
+    counts: dict[str, int] = {}
+    for defect in load_defects():
+        if defect.get("priority") not in AGREED or defect.get("status") == "done":
+            continue
+        for target in as_list(defect.get("defect_of")):
+            counts[target] = counts.get(target, 0) + 1
+    return counts
+
+
+def build_requirements(client: bool) -> tuple[list[str], list[list[str]]]:
+    """合意済みの要件。顧客の「何を作るか」の一覧。"""
+    items = [i for i in load_requirements() if i.get("priority") in AGREED]
+    areas = load_areas()
+    open_defects = open_defect_counts()
+    if client:
+        header = ["ID", "領域", "要件", "種別", "対応区分", "実装状況", "未修正の不具合",
+                  "対象リリース", "根拠（打合せ）", "最終更新"]
+        rows = [[
+            i["id"], area_label(areas, i), as_text(i.get("title")),
+            category_ja(as_text(i.get("category"))),
+            priority_ja("REQ", as_text(i.get("priority"))),
+            status_ja("REQ", as_text(i.get("status"))),
+            str(open_defects.get(i["id"], "") or ""),
+            as_text(i.get("milestone")),
+            as_text(i.get("source")), as_text(i.get("updated")),
+        ] for i in items]
+    else:
+        header = ["ID", "area", "title", "priority", "status", "category", "milestone",
+                  "depends_on", "estimate", "requester", "source", "related", "updated"]
+        rows = [[
+            i["id"], as_text(i.get("area")), as_text(i.get("title")),
+            as_text(i.get("priority")), as_text(i.get("status")),
+            as_text(i.get("category")), as_text(i.get("milestone")),
+            as_text(i.get("depends_on")), as_text(i.get("estimate")),
+            as_text(i.get("requester")), as_text(i.get("source")),
+            as_text(i.get("related")), as_text(i.get("updated")),
+        ] for i in items]
+    return header, rows
+
+
+def build_pending(client: bool) -> tuple[list[str], list[list[str]]]:
+    """未判断（undecided）と見送り（wont）。顧客が判断する対象の一覧。
+
+    見送りを落とさないのは意図的である。受託開発では「言われたが、やらないと決めた」
+    記録そのものが資産になる。決めた理由と日付を列に出す。
+    """
+    items = [i for i in load_requirements() if i.get("priority") not in AGREED]
+    areas = load_areas()
+    if client:
+        header = ["ID", "領域", "内容", "ご要望元", "状況",
+                  "判断内容", "判断日", "最終更新"]
+        rows = [[
+            i["id"], area_label(areas, i), as_text(i.get("title")),
+            as_text(i.get("requester")),
+            priority_ja("REQ", as_text(i.get("priority"))),
+            as_text(i.get("decision")), as_text(i.get("decided_at")),
+            as_text(i.get("updated")),
+        ] for i in items]
+    else:
+        header = ["ID", "area", "title", "priority", "category", "requester",
+                  "source", "related", "decision", "decided_at", "背景", "updated"]
+        rows = [[
+            i["id"], as_text(i.get("area")), as_text(i.get("title")),
+            as_text(i.get("priority")), as_text(i.get("category")),
+            as_text(i.get("requester")), as_text(i.get("source")),
+            as_text(i.get("related")),
+            as_text(i.get("decision")), as_text(i.get("decided_at")),
+            first_section(i["_body"], "背景・理由"),
+            as_text(i.get("updated")),
+        ] for i in items]
+    return header, rows
+
+
+def build_decisions(client: bool) -> tuple[list[str], list[list[str]]]:
+    # 決定事項は検討中(proposed)・置き換え済み(superseded)も含めて全件出す。
+    # proposed は「まだ決まっていない論点」であり、顧客の判断対象そのものである。
+    items = load_docs("02-decisions")
+    areas = load_areas()
+    if client:
+        header = ["ID", "領域", "決定内容・論点", "状況", "決定日",
+                  "関連（要件）", "最終更新"]
+        rows = [[
+            i["id"], area_label(areas, i), as_text(i.get("title")),
+            status_ja("ADR", as_text(i.get("status"))),
+            as_text(i.get("date")), as_text(i.get("related")),
+            as_text(i.get("updated")),
+        ] for i in items]
+    else:
+        header = ["ID", "area", "title", "status", "date", "supersedes", "related",
+                  "決定", "updated"]
+        rows = [[
+            i["id"], as_text(i.get("area")), as_text(i.get("title")),
+            as_text(i.get("status")),
+            as_text(i.get("date")), as_text(i.get("supersedes")),
+            as_text(i.get("related")),
+            first_section(i["_body"], "決定"),
+            as_text(i.get("updated")),
+        ] for i in items]
+    return header, rows
+
+
+def build_defects(client: bool) -> tuple[list[str], list[list[str]]]:
+    """不具合。約束したものが満たされていない状態の一覧。
+
+    絞り込まずに全件出す。「直さないと決めた（wont）」も残すのは検討事項と同じ理由で、
+    受託開発では「不具合として報告を受けたが、仕様の範囲内と判断した」記録が資産になる。
+    """
+    items = load_defects()
+    areas = load_areas()
+    if client:
+        header = ["ID", "領域", "不具合", "対象要件", "対応区分", "修正状況",
+                  "対象リリース", "判断内容", "判断日", "最終更新"]
+        rows = [[
+            i["id"], area_label(areas, i), as_text(i.get("title")),
+            as_text(i.get("defect_of")),
+            priority_ja("BUG", as_text(i.get("priority"))),
+            status_ja("BUG", as_text(i.get("status"))),
+            as_text(i.get("milestone")),
+            as_text(i.get("decision")), as_text(i.get("decided_at")),
+            as_text(i.get("updated")),
+        ] for i in items]
+    else:
+        header = ["ID", "area", "title", "priority", "status", "defect_of", "milestone",
+                  "depends_on", "estimate", "requester", "source", "related",
+                  "decision", "decided_at", "現象", "updated"]
+        rows = [[
+            i["id"], as_text(i.get("area")), as_text(i.get("title")),
+            as_text(i.get("priority")), as_text(i.get("status")),
+            as_text(i.get("defect_of")), as_text(i.get("milestone")),
+            as_text(i.get("depends_on")), as_text(i.get("estimate")),
+            as_text(i.get("requester")), as_text(i.get("source")),
+            as_text(i.get("related")),
+            as_text(i.get("decision")), as_text(i.get("decided_at")),
+            first_section(i["_body"], "現象"),
+            as_text(i.get("updated")),
+        ] for i in items]
+    return header, rows
+
+
+# kind -> (CSV ファイル名で使うラベル, Excel のシート名, builder)
+# 並び順が Excel のタブ順（要件 → 検討事項 → 決定事項 → 不具合）になる。
+BUILDERS = {
+    "requirements": ("要件一覧", "要件", build_requirements),
+    "pending": ("検討事項一覧", "検討事項", build_pending),
+    "decisions": ("決定事項", "決定事項", build_decisions),
+    "defects": ("不具合一覧", "不具合", build_defects),
+}

--- a/scripts/_labels.py
+++ b/scripts/_labels.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""_labels.py — 顧客向け成果物で使う日本語ラベルの一元管理。
+
+採否（priority）・実装状態（status）・分類（category）の日本語表記を定義する。
+CSV（export-csv）と要件定義書（export-requirements）が同じ状態に同じ語を使うようにし、
+成果物ごとに表記がぶれるのを防ぐ。
+
+status と priority を種別ごとにネストしているのは、種別によって語彙も訳語も違うため。
+status は要件と ADR でまったく違う値を取る。priority は値こそ共通だが、
+**要件と不具合で意味が違うので訳語も変える**（要件の must は「対応」、不具合の must は「修正対応」）。
+同じ「対応」という語を両方に使うと、顧客が不具合を新規要件と読み違える。
+category は要件だけが持つのでフラットな 1 枚の表でよい。
+"""
+from __future__ import annotations
+
+# 採否・約束の度合い。人間が PR のマージで決める軸。
+# 要件の priority は「やると約束するか」、不具合の priority は「すでにした約束をいつ果たすか」。
+PRIORITY_JA = {
+    "REQ": {
+        "must": "対応",
+        "future": "次期フェーズ",
+        "undecided": "検討中",
+        "wont": "対象外",
+    },
+    "BUG": {
+        "must": "修正対応",
+        "future": "次期修正",
+        "wont": "現状仕様",
+    },
+}
+
+# 実装の進み具合。エージェントが進める軸。
+STATUS_JA = {
+    "REQ": {
+        "not-started": "未着手",
+        "in-progress": "実装中",
+        "done": "完了",
+        "on-hold": "保留",
+    },
+    "ADR": {
+        "proposed": "検討中",
+        "accepted": "決定",
+        "superseded": "置き換え済み",
+    },
+    "BUG": {
+        "not-started": "未着手",
+        "in-progress": "修正中",
+        "done": "修正済み",
+        "on-hold": "保留",
+    },
+}
+
+CATEGORY_JA = {
+    "functional": "機能要件",
+    "non-functional": "非機能要件",
+    "constraint": "制約事項",
+}
+
+
+def priority_ja(kind: str, priority: str) -> str:
+    """種別 kind の採否 priority を日本語にする。未知ならそのまま返す。"""
+    return PRIORITY_JA.get(kind, {}).get(priority, priority)
+
+
+def status_ja(kind: str, status: str) -> str:
+    """種別 kind の実装状態 status を日本語にする。未知ならそのまま返す。"""
+    return STATUS_JA.get(kind, {}).get(status, status)
+
+
+def category_ja(category: str) -> str:
+    """要件の分類 category を日本語にする。未知ならそのまま返す。"""
+    return CATEGORY_JA.get(category, category)

--- a/scripts/export-csv.py
+++ b/scripts/export-csv.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""export-csv.py — 要件・検討事項・決定事項・不具合を顧客向けの表形式で出力する。
+
+使い方:
+    python3 scripts/export-csv.py                # dist/ に全部出す
+    python3 scripts/export-csv.py --kind pending # 検討事項のみ
+    python3 scripts/export-csv.py --internal     # 社内用（内部項目も含める）
+
+出力は UTF-8 BOM 付き。Excel でそのまま開いても日本語が化けない。
+Google スプレッドシートはファイル > インポート でそのまま読める。
+
+顧客向け（既定）ではステータスなどを日本語に訳し、内部管理用の項目を落とす。
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+from _exports import BUILDERS
+
+DOCS = Path("docs")
+OUT = Path("dist")
+
+
+def write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # utf-8-sig = BOM 付き。これがないと Excel で日本語が文字化けする
+    with path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kind", choices=list(BUILDERS) + ["all"], default="all")
+    parser.add_argument("--internal", action="store_true", help="内部項目も含めて出力する")
+    parser.add_argument("--out", default=str(OUT))
+    args = parser.parse_args()
+
+    if not DOCS.exists():
+        print("docs/ が見つかりません。リポジトリのルートで実行してください。", file=sys.stderr)
+        return 1
+
+    out_dir = Path(args.out)
+    kinds = list(BUILDERS) if args.kind == "all" else [args.kind]
+    suffix = "-internal" if args.internal else ""
+
+    for kind in kinds:
+        label, _sheet, builder = BUILDERS[kind]
+        header, rows = builder(client=not args.internal)
+        target = out_dir / f"{kind}{suffix}.csv"
+        write_csv(target, header, rows)
+        print(f"{label}: {len(rows)} 件 -> {target}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/export-requirements.py
+++ b/scripts/export-requirements.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""export-requirements.py — 分割された要件を 1 つの要件定義書に結合する。
+
+使い方:
+    python3 scripts/export-requirements.py                    # レビュー版（undecided 含む）
+    python3 scripts/export-requirements.py --agreed-only      # 合意版（must / future のみ）
+    python3 scripts/export-requirements.py --docx             # Word も出す（要 pandoc）
+
+出力:
+    dist/要件定義書.md    常に生成
+    dist/要件定義書.docx  --docx かつ pandoc がある場合
+
+合意版を作るときは、生成後に Git タグを打って版を確定させてください。
+    git tag -a v1.0-requirements -m "要件定義 合意版 v1.0"
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from datetime import date
+from functools import lru_cache
+from pathlib import Path
+
+from _docmodel import (
+    AGREED,
+    area_label,
+    as_text,
+    load_areas,
+    load_docs,
+    parse_frontmatter,
+    strip_comments,
+)
+from _labels import category_ja, priority_ja, status_ja
+
+DOCS = Path("docs")
+OUT = Path("dist")
+
+CATEGORY_ORDER = ["functional", "non-functional", "constraint"]
+PRIORITY_ORDER = {"must": 0, "future": 1, "undecided": 2, "wont": 3, "": 9}
+
+
+def demote(body: str, levels: int = 2) -> str:
+    """本文中の見出しを levels 段下げる。0 なら無変換。"""
+    if levels <= 0:
+        return body
+    out = []
+    in_code = False
+    for line in body.splitlines():
+        if line.lstrip().startswith("```"):
+            in_code = not in_code
+        if not in_code and re.match(r"^#{1,5} ", line):
+            line = "#" * levels + line
+        out.append(line)
+    return "\n".join(out)
+
+
+def load_charter() -> dict:
+    result = {}
+    for name in ("charter", "nfr", "constraints"):
+        path = DOCS / "00-charter" / f"{name}.md"
+        if path.exists():
+            _, body = parse_frontmatter(path)
+            result[name] = strip_comments(body).strip()
+    return result
+
+
+@lru_cache(maxsize=1)
+def all_requirements() -> tuple[dict, ...]:
+    """要件を 1 度だけ読む。本文・未決事項の章の両方が同じディレクトリを見るため。"""
+    return tuple(load_docs("01-requirements"))
+
+
+def load_requirements(agreed_only: bool, areas: dict) -> list[tuple[dict, str]]:
+    # 見送り（wont）は本文に載せない。判断の記録は管理表（検討事項タブ）が担う。
+    allowed = AGREED if agreed_only else AGREED | {"undecided"}
+    items = [
+        (fm, strip_comments(fm["_body"]))
+        for fm in all_requirements()
+        if fm.get("priority") in allowed
+    ]
+    # 領域は areas.md に書かれた順に並べる。章立ての順序を人間が決められるようにするため。
+    area_order = {key: index for index, key in enumerate(areas)}
+    items.sort(key=lambda x: (
+        CATEGORY_ORDER.index(x[0].get("category", "functional"))
+        if x[0].get("category") in CATEGORY_ORDER else 9,
+        area_order.get(x[0].get("area", ""), 999),
+        PRIORITY_ORDER.get(x[0].get("priority", ""), 9),
+        x[0]["id"],
+    ))
+    return items
+
+
+def load_undecided() -> list[dict]:
+    """まだ採否が決まっていない要件。"""
+    return [fm for fm in all_requirements() if fm.get("priority") == "undecided"]
+
+
+def load_open_decisions() -> list[dict]:
+    """まだ決まっていない論点（proposed の ADR）。"""
+    return [fm for fm in load_docs("02-decisions") if fm.get("status") == "proposed"]
+
+
+def load_glossary() -> str:
+    path = DOCS / "90-glossary.md"
+    if not path.exists():
+        return ""
+    _, body = parse_frontmatter(path)
+    return strip_comments(body).strip()
+
+
+def git_version() -> str:
+    try:
+        tag = subprocess.run(
+            ["git", "describe", "--tags", "--match", "v*-requirements", "--abbrev=0"],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip()
+        sha = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip()
+        return tag or f"draft ({sha})" if sha else "draft"
+    except Exception:
+        return "draft"
+
+
+def history() -> list[str]:
+    result = subprocess.run(
+        ["git", "log", "--date=short", "--format=%ad|%s", "--", "docs/01-requirements/"],
+        capture_output=True, text=True, check=False,
+    )
+    lines = [l for l in result.stdout.splitlines() if "|" in l][:30]
+    return lines
+
+
+def build(agreed_only: bool) -> str:
+    charter = load_charter()
+    areas = load_areas()
+    reqs = load_requirements(agreed_only, areas)
+    version = git_version()
+    today = date.today().isoformat()
+    label = "合意版" if agreed_only else "レビュー版"
+
+    parts: list[str] = []
+    parts.append("---")
+    parts.append(f'title: "要件定義書"')
+    parts.append(f'subtitle: "{label} / {version}"')
+    parts.append(f"date: {today}")
+    parts.append("---\n")
+
+    parts.append("# 要件定義書\n")
+    parts.append(f"| | |\n|---|---|\n| 版 | {version} |\n| 区分 | {label} |\n| 発行日 | {today} |\n")
+
+    if not agreed_only:
+        parts.append(
+            "> この文書はレビュー版です。**【検討中】** と記載された要件は採否が未確定のため、"
+            "やる / やらないのご判断をお願いします。\n"
+        )
+
+    parts.append("\\newpage\n")
+
+    if charter.get("charter"):
+        parts.append("# 1. プロジェクト概要\n")
+        parts.append(demote(charter["charter"], 0).strip() + "\n")
+        parts.append("\\newpage\n")
+
+    # 要件本体
+    parts.append("# 2. 要件一覧\n")
+    parts.append("| ID | 領域 | 要件 | 対応区分 | 実装状況 |\n|---|---|---|---|---|")
+    for fm, _ in reqs:
+        parts.append(
+            f"| {fm['id']} | {area_label(areas, fm)} | {fm.get('title','')} | "
+            f"{priority_ja('REQ', fm.get('priority',''))} | {status_ja('REQ', fm.get('status',''))} |"
+        )
+    parts.append("\n\\newpage\n")
+
+    # 分類（機能要件 / 非機能要件 / 制約事項）で章を、領域で節を切る。
+    # reqs はこの順に並んでいるので、値が変わった時点が区切りになる。
+    current_category = None
+    current_area = None
+    section = 2
+    subsection = 0
+    for fm, body in reqs:
+        category = fm.get("category", "functional")
+        if category != current_category:
+            section += 1
+            subsection = 0
+            current_area = None
+            parts.append(f"# {section}. {category_ja(category)}\n")
+            current_category = category
+        area = fm.get("area", "")
+        if area != current_area:
+            subsection += 1
+            parts.append(f"## {section}-{subsection}. {area_label(areas, fm)}\n")
+            current_area = area
+        marker = "" if fm.get("priority") in AGREED else "【検討中】"
+        parts.append(f"### {marker}{fm['id']} {fm.get('title','')}\n")
+        meta = [
+            f"対応区分: {priority_ja('REQ', fm.get('priority',''))}",
+            f"実装状況: {status_ja('REQ', fm.get('status',''))}",
+        ]
+        if fm.get("milestone"):
+            meta.append(f"対象リリース: {fm['milestone']}")
+        if fm.get("source"):
+            meta.append(f"根拠: {as_text(fm['source'])}")
+        parts.append("*" + " / ".join(meta) + "*\n")
+        parts.append(demote(body, 2).strip() + "\n")
+
+    parts.append("\\newpage\n")
+
+    if charter.get("nfr"):
+        section += 1
+        parts.append(f"# {section}. 非機能要件（全体）\n")
+        parts.append(demote(charter["nfr"], 0).strip() + "\n")
+
+    if charter.get("constraints"):
+        section += 1
+        parts.append(f"# {section}. 技術制約・前提\n")
+        parts.append(demote(charter["constraints"], 0).strip() + "\n")
+
+    glossary = load_glossary()
+    if glossary:
+        section += 1
+        parts.append(f"# {section}. 用語集\n")
+        parts.append(demote(glossary, 0).strip() + "\n")
+
+    # 未決事項（採否が未確定の要件と、決まっていない論点）
+    undecided = load_undecided()
+    open_decisions = load_open_decisions()
+    section += 1
+    parts.append(f"# {section}. 未決事項\n")
+    if undecided or open_decisions:
+        parts.append(
+            "本書の発行時点で未決の事項です。詳細は検討事項一覧をご参照ください。\n"
+        )
+        parts.append("| ID | 領域 | 内容 | 区分 |\n|---|---|---|---|")
+        for fm in undecided:
+            parts.append(
+                f"| {fm['id']} | {area_label(areas, fm)} | "
+                f"{fm.get('title','')} | 採否のご判断待ち |"
+            )
+        for fm in open_decisions:
+            parts.append(
+                f"| {fm['id']} | {area_label(areas, fm)} | "
+                f"{fm.get('title','')} | 論点（選択肢のご判断待ち） |"
+            )
+        parts.append("")
+    else:
+        parts.append("現時点で未決の事項はありません。\n")
+
+    # 改訂履歴
+    section += 1
+    parts.append(f"# {section}. 改訂履歴\n")
+    lines = history()
+    if lines:
+        parts.append("| 日付 | 変更内容 |\n|---|---|")
+        for line in lines:
+            when, _, subject = line.partition("|")
+            parts.append(f"| {when} | {subject} |")
+    else:
+        parts.append("（履歴なし）")
+    parts.append("")
+
+    return "\n".join(parts)
+
+
+def to_docx(md_path: Path, docx_path: Path) -> bool:
+    if not shutil.which("pandoc"):
+        print("pandoc が見つからないため .docx はスキップしました。", file=sys.stderr)
+        print("  macOS: brew install pandoc / Ubuntu: apt install pandoc", file=sys.stderr)
+        return False
+    cmd = [
+        "pandoc", str(md_path), "-o", str(docx_path),
+        "--from", "markdown+raw_tex", "--to", "docx",
+        # 章（分類）・節（領域）・要件の 3 階層を目次に出す
+        "--standalone", "--toc", "--toc-depth=3",
+    ]
+    reference = Path("_templates/reference.docx")
+    if reference.exists():
+        cmd += ["--reference-doc", str(reference)]
+    lua = Path("_templates/pagebreak.lua")
+    if lua.exists():
+        cmd += ["--lua-filter", str(lua)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--agreed-only", action="store_true",
+        help="採否が確定した要件（must / future）のみ収録する",
+    )
+    parser.add_argument("--docx", action="store_true", help="Word 形式も生成する")
+    parser.add_argument("--out", default=str(OUT))
+    args = parser.parse_args()
+
+    if not DOCS.exists():
+        print("docs/ が見つかりません。リポジトリのルートで実行してください。", file=sys.stderr)
+        return 1
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    md_path = out_dir / "要件定義書.md"
+    md_path.write_text(build(args.agreed_only), encoding="utf-8")
+    print(f"生成: {md_path}")
+
+    if args.docx:
+        docx_path = out_dir / "要件定義書.docx"
+        if to_docx(md_path, docx_path):
+            print(f"生成: {docx_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/export-xlsx.py
+++ b/scripts/export-xlsx.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""export-xlsx.py — 要件・検討事項・決定事項・不具合を 1 つの Excel（4 タブ）で出力する。
+
+使い方:
+    python3 scripts/export-xlsx.py              # dist/プロジェクト管理表.xlsx を出す
+    python3 scripts/export-xlsx.py --internal   # 社内用（内部項目も含める）
+    python3 scripts/export-xlsx.py --out dist   # 出力先ディレクトリを指定
+
+列の定義は _exports.py に集約している（CSV 版の export-csv.py と共通）。
+顧客向け（既定）ではステータスを日本語に訳し、内部管理用の項目を落とす。
+
+依存: pip install openpyxl
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from _exports import BUILDERS
+
+DOCS = Path("docs")
+OUT = Path("dist")
+FILENAME = "プロジェクト管理表.xlsx"
+
+# 列幅の自動調整の上限。長い本文セルでシートが横に間延びするのを防ぐ。
+MAX_COL_WIDTH = 60
+
+
+def build_workbook(client: bool):
+    from openpyxl import Workbook
+    from openpyxl.styles import Alignment, Font, PatternFill
+    from openpyxl.utils import get_column_letter
+
+    wb = Workbook()
+    wb.remove(wb.active)  # 既定の空シートを消す
+
+    header_font = Font(bold=True, color="FFFFFF")
+    header_fill = PatternFill("solid", fgColor="4472C4")
+    wrap = Alignment(vertical="top", wrap_text=True)
+
+    counts: dict[str, int] = {}
+    for _label, sheet_name, builder in BUILDERS.values():
+        header, rows = builder(client=client)
+        ws = wb.create_sheet(title=sheet_name)
+        ws.append(header)
+        for row in rows:
+            ws.append(row)
+
+        for cell in ws[1]:
+            cell.font = header_font
+            cell.fill = header_fill
+        # 見出し行を固定して、スクロールしても列名が見えるようにする
+        ws.freeze_panes = "A2"
+        # 顧客が領域・状況で絞り込めるようにする
+        ws.auto_filter.ref = ws.dimensions
+
+        for idx, _name in enumerate(header, start=1):
+            column = [str(ws.cell(row=r, column=idx).value or "")
+                      for r in range(1, ws.max_row + 1)]
+            width = min(max((len(v) for v in column), default=8) + 2, MAX_COL_WIDTH)
+            ws.column_dimensions[get_column_letter(idx)].width = width
+        for row_cells in ws.iter_rows(min_row=2):
+            for cell in row_cells:
+                cell.alignment = wrap
+
+        counts[sheet_name] = len(rows)
+    return wb, counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--internal", action="store_true", help="内部項目も含めて出力する")
+    parser.add_argument("--out", default=str(OUT))
+    args = parser.parse_args()
+
+    if not DOCS.exists():
+        print("docs/ が見つかりません。リポジトリのルートで実行してください。", file=sys.stderr)
+        return 1
+
+    try:
+        import openpyxl  # noqa: F401
+    except ModuleNotFoundError:
+        print("openpyxl が必要です。`pip install openpyxl` を実行してください。", file=sys.stderr)
+        return 1
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem, suffix = FILENAME.rsplit(".", 1)
+    name = f"{stem}{'-internal' if args.internal else ''}.{suffix}"
+    target = out_dir / name
+
+    wb, counts = build_workbook(client=not args.internal)
+    wb.save(target)
+
+    summary = " / ".join(f"{sheet} {n} 件" for sheet, n in counts.items())
+    print(f"{target} を出力しました（{summary}）")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/push-sheets.py
+++ b/scripts/push-sheets.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""push-sheets.py — 生成した CSV を Google スプレッドシートへ反映する。
+
+顧客に「常に最新のシート」を見てもらうための片方向反映です。
+**双方向同期はしません。** 競合と巻き戻しの原因になるためです。
+
+顧客のコメントは、管理列より右のシートに書いてもらい、--pull で読み出します。
+このスクリプトは管理列（A 列から出力幅まで）しか書き換えないため、
+顧客が右側に追記した列は保持されます。
+
+準備:
+  1. Google Cloud で Sheets API を有効化し、サービスアカウントを作る
+  2. 発行された JSON キーの client_email に、対象スプレッドシートを「編集者」で共有
+  3. JSON キーを環境変数 GOOGLE_SERVICE_ACCOUNT_JSON に入れる（中身をそのまま）
+  4. スプレッドシート ID を SHEET_ID に入れる
+
+使い方:
+  python3 scripts/push-sheets.py --push dist/requirements.csv:要件 dist/pending.csv:検討事項
+  python3 scripts/push-sheets.py --pull 検討事項
+
+依存: pip install google-api-python-client google-auth
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from pathlib import Path
+
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
+
+
+def get_service():
+    try:
+        from google.oauth2 import service_account
+        from googleapiclient.discovery import build
+    except ImportError:
+        print("依存が不足しています: pip install google-api-python-client google-auth",
+              file=sys.stderr)
+        raise SystemExit(1)
+
+    raw = os.environ.get("GOOGLE_SERVICE_ACCOUNT_JSON")
+    if not raw:
+        print("環境変数 GOOGLE_SERVICE_ACCOUNT_JSON が未設定です", file=sys.stderr)
+        raise SystemExit(1)
+    info = json.loads(raw)
+    creds = service_account.Credentials.from_service_account_info(info, scopes=SCOPES)
+    return build("sheets", "v4", credentials=creds, cache_discovery=False)
+
+
+def ensure_tab(service, sheet_id: str, title: str) -> None:
+    meta = service.spreadsheets().get(spreadsheetId=sheet_id).execute()
+    existing = {s["properties"]["title"] for s in meta.get("sheets", [])}
+    if title in existing:
+        return
+    service.spreadsheets().batchUpdate(
+        spreadsheetId=sheet_id,
+        body={"requests": [{"addSheet": {"properties": {"title": title}}}]},
+    ).execute()
+    print(f"シート '{title}' を作成しました")
+
+
+def col_letter(n: int) -> str:
+    name = ""
+    while n > 0:
+        n, rem = divmod(n - 1, 26)
+        name = chr(65 + rem) + name
+    return name
+
+
+def push(service, sheet_id: str, csv_path: Path, tab: str) -> None:
+    with csv_path.open(encoding="utf-8-sig", newline="") as handle:
+        rows = list(csv.reader(handle))
+    if not rows:
+        print(f"{csv_path} が空のためスキップします")
+        return
+
+    ensure_tab(service, sheet_id, tab)
+    width = max(len(r) for r in rows)
+    last_col = col_letter(width)
+
+    # 管理列だけを消す。顧客が右側に足した列は残す
+    service.spreadsheets().values().clear(
+        spreadsheetId=sheet_id, range=f"'{tab}'!A:{last_col}",
+    ).execute()
+    service.spreadsheets().values().update(
+        spreadsheetId=sheet_id,
+        range=f"'{tab}'!A1",
+        valueInputOption="RAW",
+        body={"values": rows},
+    ).execute()
+    print(f"{csv_path} -> '{tab}' に {len(rows) - 1} 行を反映しました（管理列 A:{last_col}）")
+
+
+def pull(service, sheet_id: str, tab: str) -> None:
+    result = service.spreadsheets().values().get(
+        spreadsheetId=sheet_id, range=f"'{tab}'",
+    ).execute()
+    rows = result.get("values", [])
+    if not rows:
+        print("（データなし）")
+        return
+    writer = csv.writer(sys.stdout)
+    for row in rows:
+        writer.writerow(row)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--push", nargs="*", default=[], metavar="CSV:タブ名")
+    parser.add_argument("--pull", metavar="タブ名")
+    parser.add_argument("--sheet-id", default=os.environ.get("SHEET_ID", ""))
+    args = parser.parse_args()
+
+    if not args.sheet_id:
+        print("スプレッドシート ID を --sheet-id か環境変数 SHEET_ID で指定してください",
+              file=sys.stderr)
+        return 1
+
+    service = get_service()
+
+    for spec in args.push:
+        path_str, _, tab = spec.partition(":")
+        if not tab:
+            print(f"形式が不正です: {spec}（CSV:タブ名 の形で指定）", file=sys.stderr)
+            return 1
+        push(service, args.sheet_id, Path(path_str), tab)
+
+    if args.pull:
+        pull(service, args.sheet_id, args.pull)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要

`/client-export` スキルが呼ぶスクリプト一式が、ドキュメント体制の導入時に複製されておらず、**スキルが動作しない状態**でした（#104 の「発見事項」で報告したもの）。上流テンプレート [ironiwa/ai-native-project-template](https://github.com/ironiwa/ai-native-project-template)@`fd139e7` から 6 ファイルを取り込みます。

> [!NOTE]
> **この PR は #104 に積んでいます**（base = `claude/sync-project-template-changes-ce1de3`）。
> 取り込む `_exports.py` / `_labels.py` は上流 PR #6 の不具合タブ対応を含んでおり、
> #104 が入れる `_docmodel.py` の `KINDS["05-defects"]` と `PRIORITIES_BY_KIND` に依存します。
> #104 がマージされれば base は自動で `main` に切り替わります。

`AGENTS.md`「PR を分けてよいとき」の **「大量の機械的置換を、レビュー対象から切り離したい」** に当たるため、#104 とは別 PR にしました。#104 単体でも中間状態は壊れません（`/client-export` は以前から動かないままで、悪化しない）。

Refs: なし（運用基盤の変更）

## 変更内容

| ファイル | 役割 |
|---|---|
| `scripts/_exports.py` | 4 タブ（要件 / 検討事項 / 決定事項 / 不具合）の行データを組み立てる共有ロジック |
| `scripts/_labels.py` | `priority` / `status` / `category` の顧客向け日本語表記。不具合は種別ごとにネストした語彙を使う |
| `scripts/export-csv.py` | 上記 4 種を CSV で出力 |
| `scripts/export-xlsx.py` | 同じ 4 種を 1 つの Excel（プロジェクト管理表）に出力 |
| `scripts/export-requirements.py` | 要件定義書を 1 つの Markdown / Word 文書として出力 |
| `scripts/push-sheets.py` | CSV を Google スプレッドシートに反映・逆取り込み |

**6 ファイルとも上流 `fd139e7` と内容・ファイルモードまで一致させています。** 独自の変更は入れていません。次回のテンプレート同期で差分が出ないようにするためです（`git ls-tree` のモードまで突き合わせて確認済み）。

`scripts/migrate-to-unified.py` は移行完了済みのため、意図的に取り込んでいません。これで `scripts/` は上流と同じ構成になります（同スクリプトを除く）。

## 品質検証

- [x] 静的チェック: `scripts/quality-gate.sh` 通過
- [x] `/simplify max` 実行済み
  - 指摘: 4件 / 修正: 1件
  - 主な修正: コピー時に付けてしまった実行ビット（`export-csv.py` / `export-xlsx.py` / `export-requirements.py` / `push-sheets.py` が `100755`）を上流と同じ `100644` に戻した。残る 3 件は上流ファイルの逐語コピーに対する指摘のため見送り（下記）
- [x] 静的チェック再実行: 通過

### 実際に動かして確認したこと

| 検証 | 結果 |
|---|---|
| `export-csv.py` | 要件 38 件 / 検討事項 7 件 / 決定事項 21 件 / 不具合 0 件 |
| `export-xlsx.py` のタブ構成 | `['要件', '検討事項', '決定事項', '不具合']` の **4 タブ** |
| 要件タブの列 | `未修正の不具合` 列が出る（`defect_of` の逆引き） |
| `export-requirements.py` | `dist/要件定義書.md` を生成。`--agreed-only` も動作 |
| 要件定義書に不具合が混入していないか | **0 件**（`^#+ .*BUG-[0-9]{4}` が無マッチ） |
| 生成物に `未分類`（unassigned）の漏れ | なし |
| `dist/` が Git 管理外か | `.gitignore:14` の `/dist/` で除外済み |
| `docs-lint` | エラー 0 件（警告 4 件はいずれも既存で本 PR と無関係） |
| CI への影響 | なし。これらのスクリプトは `.github/workflows/` から呼ばれていない |

### 依存関係と、無いときの挙動

いずれも**遅延 import で、無ければ日本語のメッセージを出して止まります**（raw traceback は出ません）。上流の設計どおりで、マニフェストは追加していません。

| 依存 | 用途 | 無いとき |
|---|---|---|
| `openpyxl` | `export-xlsx.py` | `openpyxl が必要です。'pip install openpyxl' を実行してください。` / exit 1 |
| `google-api-python-client` + `google-auth` | `push-sheets.py` | `依存が不足しています: pip install ...` / exit 1 |
| `pandoc`（外部バイナリ） | `export-requirements.py --docx` | インストール手順を出して **.docx だけスキップ**。`.md` は生成され exit 0 |

**この環境には pandoc が入っていません。** `.docx` が要るときは `brew install pandoc` が必要です。`openpyxl` と Google の 2 つはシステムの `python3` に入っており、動作を確認済みです。

### 見送った指摘（3 件）

いずれも**上流ファイルの逐語コピーに対する指摘**です。ここで直すと上流と乖離し、次回の同期が壊れるため見送りました。上流へ提案するのが筋と判断しています。

1. `export-requirements.py:134` — ruff `E741`（曖昧な変数名 `l`）
2. `export-requirements.py:148` — ruff `F541`（プレースホルダの無い f-string）
3. `.claude/skills/client-export/SKILL.md` の `allowed-tools` に `push-sheets.py` と `git push` が無く、手順 4〜5 で権限確認が挟まる（**本 PR は同ファイルを触っていません**。#104 でコピーした上流の内容そのままです）

なお 1・2 はこのリポジトリの品質ゲートの対象外です。`PROJECT_CHECKS` の ruff / mypy は `cd api` で動くため、リポジトリ直下の `scripts/` は元から検査対象に入っていません（既存の `docs-lint.py` / `_docmodel.py` / `export-wbs.py` と同じ扱い）。**本 PR で新たに生じた穴ではないため、ゲートの拡張は提案しません。**

## ドキュメントの更新

- [x] 該当なし

<!-- `/client-export` の SKILL.md は #104 で上流の最新版に更新済み。本 PR は
     そこに書かれているコマンドが実際に動くようにしただけで、手順は変えていない -->

## 発見事項

- `.claude/skills/client-export/SKILL.md` の `allowed-tools` の不足（上記 3）は上流由来です。Google スプレッドシート連携（手順 4）とタグ付け（手順 5）を実際に使うようになったら、上流に修正を提案するのが筋です
- `_templates/reference.docx`（Word 出力のスタイル雛形）は上流にも無く、`export-requirements.py` 側で存在チェックされているため、無くても `.docx` は生成されます。体裁を作り込むなら後から置けます
